### PR TITLE
Ensure families is not nullptr before using it

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Dominic Hamon <dma@stripysock.com>
 Eugene Zhuk <eugene.zhuk@gmail.com>
 Google Inc.
 Oleksandr Sochka <sasha.sochka@gmail.com>
+Yusuke Suzuki <utatane.tea@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -28,3 +28,4 @@ Dominic Hamon <dma@stripysock.com>
 Eugene Zhuk <eugene.zhuk@gmail.com>
 Oleksandr Sochka <sasha.sochka@gmail.com>
 Pierre Phaneuf <pphaneuf@google.com>
+Yusuke Suzuki <utatane.tea@gmail.com>

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -757,6 +757,7 @@ void Benchmark::FindBenchmarks(const std::string& spec,
   }
 
   mutex_lock l(&benchmark_mutex);
+  if (families == nullptr) return;  // There's no families.
   for (Benchmark* family : *families) {
     if (family == nullptr) continue;  // Family was deleted
 


### PR DESCRIPTION
When there's no benchmarks, families becomes nullptr. So before touching
it, we need to ensure families is not nullptr.

NOTE:
I've read contributing guidelines and signed CLA.
