### PR TITLE
Unable to compile with -Werror flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project (benchmark)
 
 find_package(Threads REQUIRED)
 
-set(CMAKE_CXX_FLAGS "-Wall -Werror -pedantic-errors --std=c++0x")
+set(CMAKE_CXX_FLAGS "-Wall -pedantic-errors --std=c++0x")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -DDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE "-fno-strict-aliasing -O3 -DNDEBUG")
 


### PR DESCRIPTION
Framework is not compiling because auf unused parameter warning and -Werror compile flag.
benchmark.cc:866:8: error: unused parameter ‘b’ [-Werror=unused-parameter]
 double Benchmark::MeasurePeakHeapMemory(const Instance& b)
