### PR TITLE
Remove URL_HASH and TLS_VERIFY from CMake configuration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ include(ExternalProject)
 set_directory_properties(properties EP_PREFIX "${CMAKE_BINARY_DIR}/third_party")
 ExternalProject_Add(googletest
     URL "https://googletest.googlecode.com/files/gtest-1.7.0.zip"
-    URL_HASH SHA1=f85f6d2481e2c6c4a18539e391aa4ea8ab0394af
-    TLS_VERIFY on
     SOURCE_DIR "${CMAKE_BINARY_DIR}/third_party/gtest"
     INSTALL_COMMAND "")
 ExternalProject_Get_Property(googletest source_dir)


### PR DESCRIPTION
Per the CMake 2.8.0 documentation, these options did not exist for ExternalProject_Add.  These options were added in CMake 2.8.10.
