### PR TITLE
Statically initialize benchmark_mutex and extend its lifetime.

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -184,7 +184,7 @@ inline std::string HumanReadableNumber(double n) {
 // For non-dense Range, intermediate values are powers of kRangeMultiplier.
 static const int kRangeMultiplier = 8;
 
-static pthread_mutex_t benchmark_mutex;
+static pthread_mutex_t benchmark_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t starting_mutex;
 pthread_cond_t starting_cv;
 
@@ -1222,11 +1222,9 @@ void RunSpecifiedBenchmarks(const BenchmarkReporter* reporter /*= nullptr*/) {
       spec, reporter == nullptr ? &default_reporter : reporter);
   pthread_cond_destroy(&starting_cv);
   pthread_mutex_destroy(&starting_mutex);
-  pthread_mutex_destroy(&benchmark_mutex);
 }
 
 void Initialize(int* argc, const char** argv) {
-  pthread_mutex_init(&benchmark_mutex, nullptr);
   pthread_mutex_init(&starting_mutex, nullptr);
   pthread_cond_init(&starting_cv, nullptr);
   walltime::Initialize();


### PR DESCRIPTION
RunSpecifiedBenchmarks destroys benchmark_mutex before its last usage, typically in RemoveBenchmark during cleanup of the BenchmarkFamilies singleton.

When compiled with `-fsanitize=thread` with Clang, `benchmark_test` emits an error during shutdown:

```
ThreadSanitizer WARNING: unlock of unlocked mutex                                  
    #0 pthread_mutex_unlock ??:0 (exe+0x00000003c44c)                              
    #1 ~mutex_lock /home/ckennelly/projects/benchmark/src/mutex_lock.h:13 (exe+0x000000096793)
    #2 ~mutex_lock /home/ckennelly/projects/benchmark/src/mutex_lock.h:13 (exe+0x00000007f4f0)
    #3 benchmark::internal::BenchmarkFamilies::RemoveBenchmark(int) /home/ckennelly/projects/benchmark/src/benchmark.cc:343 (exe+0x000000073ddd)
    #4 ~Benchmark /home/ckennelly/projects/benchmark/src/benchmark.cc:695 (exe+0x000000077fbe)
    #5 ~BenchmarkFamilies /home/ckennelly/projects/benchmark/src/benchmark.cc:324 (exe+0x000000073ac5)
    #6 __libc_secure_getenv ??:0 (libc.so.6+0x000000037c88)
```
