### PR TITLE
Fixed compiling on Mac 10.9.3 with g++-4.8, clang or system c++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set_directory_properties(properties EP_PREFIX "${CMAKE_BINARY_DIR}/third_party")
 ExternalProject_Add(googletest
     URL "https://googletest.googlecode.com/files/gtest-1.7.0.zip"
     SOURCE_DIR "${CMAKE_BINARY_DIR}/third_party/gtest"
+    CMAKE_ARGS "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
     INSTALL_COMMAND "")
 ExternalProject_Get_Property(googletest source_dir)
 include_directories(${source_dir}/include)

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -390,19 +390,20 @@ void BenchmarkFamilies::FindBenchmarks(
     if (family->rangeX_.empty() && family->rangeY_.empty()) {
       instances = family->CreateBenchmarkInstances(
         Benchmark::kNoRange, Benchmark::kNoRange);
-      benchmarks->insert(benchmarks->end(), instances.begin(), instances.end());
+      std::copy(instances.begin(), instances.end(),
+                std::back_inserter(*benchmarks));
     } else if (family->rangeY_.empty()) {
       for (size_t x = 0; x < family->rangeX_.size(); ++x) {
         instances = family->CreateBenchmarkInstances(x, Benchmark::kNoRange);
-        benchmarks->insert(benchmarks->end(), instances.begin(),
-                           instances.end());
+        std::copy(instances.begin(), instances.end(),
+                  std::back_inserter(*benchmarks));
       }
     } else {
       for (size_t x = 0; x < family->rangeX_.size(); ++x) {
         for (size_t y = 0; y < family->rangeY_.size(); ++y) {
           instances = family->CreateBenchmarkInstances(x, y);
-          benchmarks->insert(benchmarks->end(), instances.begin(),
-                             instances.end());
+          std::copy(instances.begin(), instances.end(),
+                    std::back_inserter(*benchmarks));
         }
       }
     }

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -36,13 +36,14 @@
 
 namespace benchmark {
 namespace {
-const int64_t estimate_time_ms = 1000;
 pthread_once_t cpuinfo_init = PTHREAD_ONCE_INIT;
 double cpuinfo_cycles_per_second = 1.0;
 int cpuinfo_num_cpus = 1;  // Conservative guess
 pthread_mutex_t cputimens_mutex;
 
 #if !defined OS_MACOSX
+const int64_t estimate_time_ms = 1000;
+
 // Helper function estimates cycles/sec by observing cycles elapsed during
 // sleep(). Using small sleep time decreases accuracy significantly.
 int64_t EstimateCyclesPerSecond() {


### PR DESCRIPTION
Fix compiling bug on Mac OSX 10.9.3 (#24)

Test against `clang`, `g++-4.8` (installed from homebrew) and system `/usr/bin/c++` to compile this package without warnings.
