### PR TITLE
Implemented git versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.so.?*
 *.dylib
 *.cmake
+!/cmake/*.cmake
 *~
 /test/benchmark_test
 /test/re_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required (VERSION 2.8)
 project (benchmark)
 
+# Make sure we can import out CMake functions
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# We need threads in this project
 find_package(Threads REQUIRED)
 
 # Import and build Google Test
@@ -39,31 +43,10 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86")
 endif()
 
 # Read the git tags to determine the project version
-execute_process(COMMAND git describe --match "v[0-9]*.[0-9]*.[0-9]*" --abbrev=8
-    RESULT_VARIABLE status
-    OUTPUT_VARIABLE GIT_VERSION
-    ERROR_QUIET)
-if(${status})
-    set(GIT_VERSION "v0.0.0")
-else()
-    string(STRIP ${GIT_VERSION} GIT_VERSION)
-    string(REGEX REPLACE "-[0-9]+-g" "-" GIT_VERSION ${GIT_VERSION})
-endif()
-
-# Work out if the repository is dirty
-execute_process(COMMAND git update-index -q --refresh
-    OUTPUT_QUIET
-    ERROR_QUIET)
-execute_process(COMMAND git diff-index --name-only HEAD --
-    OUTPUT_VARIABLE GIT_DIFF_INDEX
-    ERROR_QUIET)
-string(COMPARE NOTEQUAL "${GIT_DIFF_INDEX}" "" GIT_DIRTY)
-if (${GIT_DIRTY})
-    string(CONCAT GIT_VERSION ${GIT_VERSION} "-dirty")
-endif()
+include(GetGitVersion)
+get_git_version(GIT_VERSION)
 
 # Tell the user what versions we are using
-message("-- git Version: ${GIT_VERSION}")
 string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" VERSION ${GIT_VERSION})
 message("-- Version: ${VERSION}")
 

--- a/cmake/GetGitVersion.cmake
+++ b/cmake/GetGitVersion.cmake
@@ -1,0 +1,45 @@
+# - Returns a version string from Git tags
+#
+# This function inspects the annotated git tags for the project and returns a string
+# into a CMake variable
+#
+#  get_git_version(<var>)
+#
+# - Example
+#
+# include(GetGitVersion)
+# get_git_version(GIT_VERSION)
+#
+# Requires CMake 2.6+
+
+if(__get_git_version)
+  return()
+endif()
+set(__get_git_version INCLUDED)
+
+function(get_git_version var)
+  execute_process(COMMAND git describe --match "v[0-9]*.[0-9]*.[0-9]*" --abbrev=8
+      RESULT_VARIABLE status
+      OUTPUT_VARIABLE GIT_VERSION
+      ERROR_QUIET)
+  if(${status})
+      set(GIT_VERSION "v0.0.0")
+  else()
+      string(STRIP ${GIT_VERSION} GIT_VERSION)
+      string(REGEX REPLACE "-[0-9]+-g" "-" GIT_VERSION ${GIT_VERSION})
+  endif()
+
+  # Work out if the repository is dirty
+  execute_process(COMMAND git update-index -q --refresh
+      OUTPUT_QUIET
+      ERROR_QUIET)
+  execute_process(COMMAND git diff-index --name-only HEAD --
+      OUTPUT_VARIABLE GIT_DIFF_INDEX
+      ERROR_QUIET)
+  string(COMPARE NOTEQUAL "${GIT_DIFF_INDEX}" "" GIT_DIRTY)
+  if (${GIT_DIRTY})
+      string(CONCAT GIT_VERSION ${GIT_VERSION} "-dirty")
+  endif()
+  message("-- git Version: ${GIT_VERSION}")
+  set(${var} ${GIT_VERSION} PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
So this implements #40. It automatically versions the shared libraries from any annotated `git` tags:

```
git tag -a v1.0.0
```

It expects semver version tags such as `v1.0.0`. It would be trivial to support `1.0.0` but looking around it seems that most C/C++ projects follow `vX.X.X` rather that `X.X.X` like a lot of `Node.js` stuff.

This determines that the if the project has had a certain amount of commits since the last tag and also if the project is _dirty_ (has modified files), but does **nothing** with that information. In the future a more robust release could be implemented in the script.

This is pretty brittle and has little in the way of configuration. Ideally we should use `find_program` to work out where `git` is so that users can configure it. This implementation assumes that `git` will be available in `PATH`

Outputs the following on the command line:

```
-- git Version: v[MAJOR].[MINOR].[PATCH]-[COMMITS_SINCE_TAG]-[SHA1][-dirty]
-- Version: [MAJOR].[MINOR].[PATCH]
```

For example, dirty and ahead of a tag by one commit:

```
-- git Version: v1.4.0-1-gf492b08-dirty
-- Version: 1.4.0
```

On a tag and not dirty (this is what a release should be built from)

```
-- git Version: v0.0.1
-- Version: 0.0.1
```
