### PR TITLE
Compiler Flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,8 @@ include_directories(${source_dir}/include)
 ExternalProject_Get_Property(googletest binary_dir)
 link_directories(${binary_dir})
 
-# Set up the compiler flags
-include(CheckCXXCompilerFlag)
-
 # Enable the latest C++ standard possible
+include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(--std=c++14 HAVE_FLAG_CXX_14)
 check_cxx_compiler_flag(--std=c++11 HAVE_FLAG_CXX_11)
 check_cxx_compiler_flag(--std=c++0x HAVE_FLAG_CXX_0X)
@@ -36,31 +34,17 @@ elseif (HAVE_FLAG_CXX_0X)
 endif()
 
 # Turn compiler warnings up to 11
-check_cxx_compiler_flag(-Wall HAVE_FLAG_WALL)
-if (HAVE_FLAG_WALL)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-endif()
-check_cxx_compiler_flag(-Wshadow HAVE_FLAG_WSHADOW)
-if (HAVE_FLAG_WSHADOW)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
-endif()
-check_cxx_compiler_flag(-Werror HAVE_FLAG_WERROR)
-if (HAVE_FLAG_WERROR)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-endif()
-check_cxx_compiler_flag(-pedantic-errors HAVE_FLAG_PEDANTIC_ERRORS)
-if (HAVE_FLAG_PEDANTIC_ERRORS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors")
-endif()
+include(AddCXXCompilerFlag)
+add_cxx_compiler_flag(-Wall)
+add_cxx_compiler_flag(-Wshadow)
+add_cxx_compiler_flag(-Werror)
+add_cxx_compiler_flag(-pedantic-errors)
+
+# Release flags
+add_cxx_compiler_flag(-fno-strict-aliasing RELEASE)
 
 # Add a debug definition so we can make decisions in the compilation
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
-
-# We relax the aliasing in release
-check_cxx_compiler_flag(-fno-strict-aliasing HAVE_FLAG_NO_STRICT_ALIASING)
-if (HAVE_FLAG_NO_STRICT_ALIASING)
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-strict-aliasing")
-endif()
 
 # Set OS
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/cmake/AddCXXCompilerFlag.cmake
+++ b/cmake/AddCXXCompilerFlag.cmake
@@ -1,0 +1,39 @@
+# - Adds a compiler FLAG if it is supported by the compiler
+#
+# This function checks that the supplied compiler FLAG is supported and then
+# adds it to the corresponding compiler FLAGs
+#
+#  add_cxx_compiler_FLAG(<FLAG> [<VARIANT>])
+#
+# - Example
+#
+# include(AddCXXCompilerFlag)
+# add_cxx_compiler_FLAG(-Wall)
+# add_cxx_compiler_FLAG(-no-strict-aliasing RELEASE)
+# Requires CMake 2.6+
+
+if(__add_cxx_compiler_FLAG)
+  return()
+endif()
+set(__add_cxx_compiler_FLAG INCLUDED)
+
+include(CheckCXXCompilerFlag)
+
+function(add_cxx_compiler_flag FLAG)
+  if(ARGV1)
+    set(VARIANT ${ARGV1})
+    string(TOLOWER ${VARIANT} VARIANT)
+    set(VARIANT " ${VARIANT}")
+  endif()
+  message("-- Check compiler${VARIANT} flag ${FLAG}")
+  string(TOUPPER ${FLAG} SANITIZED_FLAG)
+  string(REGEX REPLACE "[^A-Za-z_0-9]" "_" ${SANITIZED_FLAG} SANITIZED_FLAG)
+  check_cxx_compiler_flag(${FLAG} ${SANITIZED_FLAG})
+  if(${SANITIZED_FLAG})
+    message("-- Check compiler${VARIANT} flag ${FLAG} -- works")
+    string(REGEX REPLACE "[^A-Za-z_0-9]" "_" "${VARIANT}" VARIANT)
+    string(TOUPPER "${VARIANT}" VARIANT)
+    set(CMAKE_CXX_FLAGS${VARIANT} "${CMAKE_CXX_FLAGS}${VARIANT} ${FLAG}" PARENT_SCOPE)
+  endif()
+endfunction()
+


### PR DESCRIPTION
The compiler flags are currently set assuming `gcc` or `clang`. We should detect if compiler flags are supported so that when compilers are added in the future (looking at you `cl.exe`) we can add specific compiler flags for those compilers as well.

CMake has a default set of compiler flags for each compiler it detects, we should play nicely with this so that we leverage the good work done by CMake. This branch appends flags to the detected flags.

**Net result**:
- The compiler flags for `gcc` and `clang` are the same as before the patches but leverage the built in flags and also detect that the flags are actually available
- I've added detection for `-Wshadow` and added that as it's a good warning to look for. However, I would happily drop this if anyone has any objections. The code currently cleanly passes this warning on `gcc-4.9`. I know that `-Wshadow has had a sketchy history with false positives on older versions of`gcc`.

In the future we are going to need MSVC flags that force that compiler into the closest to standards mode it goes. Again using flag detection is the way to go.
