### PR TITLE
Verify the download of gtest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include(ExternalProject)
 set_directory_properties(properties EP_PREFIX "${CMAKE_BINARY_DIR}/third_party")
 ExternalProject_Add(googletest
     URL "https://googletest.googlecode.com/files/gtest-1.7.0.zip"
+    URL_HASH MD5=2d6ec8ccdf5c46b05ba54a9fd1d130d7
     SOURCE_DIR "${CMAKE_BINARY_DIR}/third_party/gtest"
     CMAKE_ARGS "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
     INSTALL_COMMAND "")


### PR DESCRIPTION
Fixes up the verifying step when downloading `gtest`:

```
-- downloading... done
-- verifying file...
     file='/home/matt/git/benchmark/third_party/src/gtest-1.7.0.zip'
-- verifying file... warning: did not verify file - no URL_HASH specified?
```
