### PR TITLE
Verify gtest with URL_MD5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,7 @@ include(ExternalProject)
 set_directory_properties(properties EP_PREFIX "${CMAKE_BINARY_DIR}/third_party")
 ExternalProject_Add(googletest
     URL "https://googletest.googlecode.com/files/gtest-1.7.0.zip"
-    # TODO: add this when we have cmake 2.9
-    # URL_HASH MD5=2d6ec8ccdf5c46b05ba54a9fd1d130d7
+    URL_MD5 2d6ec8ccdf5c46b05ba54a9fd1d130d7
     SOURCE_DIR "${CMAKE_BINARY_DIR}/third_party/gtest"
     CMAKE_ARGS "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
     INSTALL_COMMAND "")


### PR DESCRIPTION
`URL_HASH` is not supported in older CMake versions but `URL_MD5` is.
