### PR TITLE
Remove CHECK_* from public API.

### DIFF
--- a/include/benchmark/macros.h
+++ b/include/benchmark/macros.h
@@ -35,17 +35,6 @@ char (&ArraySizeHelper(const T (&array)[N]))[N];
 
 #define arraysize(array) (sizeof(ArraySizeHelper(array)))
 
-#define CHECK(b)             \
-  do {                       \
-    if (!(b)) assert(false); \
-  } while (0)
-#define CHECK_EQ(a, b) CHECK((a) == (b))
-#define CHECK_NE(a, b) CHECK((a) != (b))
-#define CHECK_GE(a, b) CHECK((a) >= (b))
-#define CHECK_LE(a, b) CHECK((a) <= (b))
-#define CHECK_GT(a, b) CHECK((a) > (b))
-#define CHECK_LT(a, b) CHECK((a) < (b))
-
 //
 // Prevent the compiler from complaining about or optimizing away variables
 // that appear unused.

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "benchmark/benchmark.h"
-#include "benchmark/macros.h"
+#include "check.h"
 #include "colorprint.h"
 #include "commandlineflags.h"
 #include "re.h"

--- a/src/check.h
+++ b/src/check.h
@@ -1,0 +1,17 @@
+#ifndef CHECK_H_
+#define CHECK_H_
+
+#include <cassert>
+
+#define CHECK(b)             \
+  do {                       \
+    if (!(b)) assert(false); \
+  } while (0)
+#define CHECK_EQ(a, b) CHECK((a) == (b))
+#define CHECK_NE(a, b) CHECK((a) != (b))
+#define CHECK_GE(a, b) CHECK((a) >= (b))
+#define CHECK_LE(a, b) CHECK((a) <= (b))
+#define CHECK_GT(a, b) CHECK((a) > (b))
+#define CHECK_LT(a, b) CHECK((a) < (b))
+
+#endif  // CHECK_H_

--- a/src/re_posix.cc
+++ b/src/re_posix.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <benchmark/macros.h>
+#include "check.h"
 #include "re.h"
 
 namespace benchmark {

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -29,7 +29,7 @@
 #include <limits>
 #include <mutex>
 
-#include "benchmark/macros.h"
+#include "check.h"
 #include "cycleclock.h"
 #include "sleep.h"
 

--- a/src/walltime.cc
+++ b/src/walltime.cc
@@ -22,7 +22,7 @@
 #include <atomic>
 #include <limits>
 
-#include "benchmark/macros.h"
+#include "check.h"
 #include "cycleclock.h"
 #include "sysinfo.h"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,6 @@ find_package(Threads REQUIRED)
 # Demonstration executable
 add_executable(benchmark_test benchmark_test.cc)
 target_link_libraries(benchmark_test benchmark ${CMAKE_THREAD_LIBS_INIT})
-add_dependencies(benchmark_test googletest)
 add_test(benchmark benchmark_test 50)
 add_test(benchmark_filter_simple benchmark_test --benchmark_filter=Calculate 16)
 add_test(benchmark_filter_prefix benchmark_test --benchmark_filter=*Calculate 0)

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -1,5 +1,6 @@
 #include "benchmark/benchmark.h"
 
+#include <assert.h>
 #include <math.h>
 #include <stdint.h>
 
@@ -109,7 +110,7 @@ static void BM_StringCompare(benchmark::State& state) {
   while (state.KeepRunning())
     r |= s1.compare(s2);
   // Prevent compiler optimizations
-  CHECK(r != std::numeric_limits<int>::max());
+  assert(r != std::numeric_limits<int>::max());
 }
 BENCHMARK(BM_StringCompare)->Range(1, 1<<20);
 
@@ -138,7 +139,7 @@ static void BM_LongTest(benchmark::State& state) {
   while (state.KeepRunning())
     for (int i = 0; i < state.range_x(); ++i)
       tracker += i;
-  CHECK(tracker != 0.0);
+  assert(tracker != 0.0);
 }
 BENCHMARK(BM_LongTest)->Range(1<<16,1<<28);
 
@@ -168,8 +169,8 @@ class TestReporter : public benchmark::internal::ConsoleReporter {
 int main(int argc, const char* argv[]) {
   benchmark::Initialize(&argc, argv);
 
-  CHECK(Factorial(8) == 40320);
-  CHECK(CalculatePi(1) == 0.0);
+  assert(Factorial(8) == 40320);
+  assert(CalculatePi(1) == 0.0);
 
   TestReporter test_reporter;
   benchmark::RunSpecifiedBenchmarks(&test_reporter);


### PR DESCRIPTION
CHECK_\* are now private and used internally in the library. The test
uses have been replaced with asserts.

Fixes #62.
