### PR TITLE
Use #ifdef to protect calling Factorial in benchmark_test.cc

### DIFF
--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -171,7 +171,9 @@ class TestReporter : public benchmark::internal::ConsoleReporter {
 int main(int argc, const char* argv[]) {
   benchmark::Initialize(&argc, argv);
 
+#ifdef DEBUG
   assert(Factorial(8) == 40320);
+#endif
   assert(CalculatePi(1) == 0.0);
 
   TestReporter test_reporter;


### PR DESCRIPTION
`Factorial()` is defined in "#ifdef DEBUG" but is called outside "DEBUG". It makes the default building process failed.
