### PR TITLE
Fix #77 build on freebsd 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,10 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   add_definitions(-DOS_WINDOWS)
 endif()
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  add_definitions(-DOS_FREEBSD)
+endif()
+
 # Set CPU
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86")
   add_definitions(-DARCH_X86)

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -21,9 +21,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/resource.h>
+#include <sys/types.h>
 #include <sys/sysctl.h>
 #include <sys/time.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 #include <iostream>

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/resource.h>
-#include <sys/types.h>
+#include <sys/types.h> // this header must be included before 'sys/sysctl.h' to avoid compilation error on FreeBSD
 #include <sys/sysctl.h>
 #include <sys/time.h>
 #include <unistd.h>


### PR DESCRIPTION
I added a macro to detect freebsd in code (OS_FREEBSD), and put sys/types.h header before sys/sysctl.h. In fact it built itself fine even without freebsd macro. All tests passed for me, also checked it on linux.