### PR TITLE
Enable UseRealTime and fix documentation for SetLabel.

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -158,10 +158,6 @@ void RunSpecifiedBenchmarks(const BenchmarkReporter* reporter = nullptr);
 // ------------------------------------------------------
 // Routines that can be called from within a benchmark
 
-//
-// REQUIRES: a benchmark is currently executing
-void SetLabel(const std::string& label);
-
 // If this routine is called, peak memory allocation past this point in the
 // benchmark is reported at the end of the benchmark report line. (It is
 // computed by running the benchmark once with a single iteration and a memory
@@ -212,10 +208,10 @@ class State {
   // If this routine is called, the specified label is printed at the
   // end of the benchmark report line for the currently executing
   // benchmark.  Example:
-  //  static void BM_Compress(int iters) {
+  //  static void BM_Compress(benchmark::State& state) {
   //    ...
   //    double compress = input_size / output_size;
-  //    benchmark::SetLabel(StringPrintf("compress:%.1f%%", 100.0*compression));
+  //    state.SetLabel(StringPrintf("compress:%.1f%%", 100.0*compression));
   //  }
   // Produces output that looks like:
   //  BM_Compress   50         50   14115038  compress:27.3%

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -416,8 +416,6 @@ void MemoryUsage() {
 }
 */
 
-void UseRealTime() { use_real_time = true; }
-
 void PrintUsageAndExit() {
   fprintf(stdout,
           "benchmark [--benchmark_filter=<regex>]\n"
@@ -1175,6 +1173,8 @@ void RunSpecifiedBenchmarks(const BenchmarkReporter* reporter /*= nullptr*/) {
   internal::RunMatchingBenchmarks(
       spec, reporter == nullptr ? &default_reporter : reporter);
 }
+
+void UseRealTime() { use_real_time = true; }
 
 void Initialize(int* argc, const char** argv) {
   internal::ParseCommandLineFlags(argc, argv);

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -57,6 +57,17 @@ static void BM_Factorial(benchmark::State& state) {
 }
 BENCHMARK(BM_Factorial);
 
+static void BM_FactorialRealTime(benchmark::State& state) {
+  benchmark::UseRealTime();
+
+  int fac_42 = 0;
+  while (state.KeepRunning())
+    fac_42 = Factorial(8);
+  // Prevent compiler optimizations
+  std::cout << fac_42;
+}
+BENCHMARK(BM_FactorialRealTime);
+
 static void BM_CalculatePiRange(benchmark::State& state) {
   double pi = 0.0;
   while (state.KeepRunning())


### PR DESCRIPTION
Fixes #89

UseRealTime was defined in the internal namespace by mistake.
Similarly, documentation suggested that benchmark::SetLabel should be
used to set a label, and a function was declared but not defined, while
actually the call should be 'state.SetLabel'.