### PR TITLE
Add variadic macro for BENCHMARK_TEMPLATE in c++11 and beyond.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,9 @@ include(CXXFeatureCheck)
 check_cxx_compiler_flag(-std=c++11 HAVE_FLAG_CXX_11)
 check_cxx_compiler_flag(-std=c++0x HAVE_FLAG_CXX_0X)
 if (HAVE_FLAG_CXX_11)
-  list(APPEND CMAKE_CXX_FLAGS -std=c++11)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 elseif (HAVE_FLAG_CXX_0X)
-  list(APPEND CMAKE_CXX_FLAGS -std=c++0x)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 endif()
 
 # Turn compiler warnings up to 11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,9 @@ include(CXXFeatureCheck)
 check_cxx_compiler_flag(-std=c++11 HAVE_FLAG_CXX_11)
 check_cxx_compiler_flag(-std=c++0x HAVE_FLAG_CXX_0X)
 if (HAVE_FLAG_CXX_11)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  list(APPEND CMAKE_CXX_FLAGS -std=c++11)
 elseif (HAVE_FLAG_CXX_0X)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+  list(APPEND CMAKE_CXX_FLAGS -std=c++0x)
 endif()
 
 # Turn compiler warnings up to 11

--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ template <class Q> int BM_Sequential(benchmark::State& state) {
 BENCHMARK_TEMPLATE(BM_Sequential, WaitQueue<int>)->Range(1<<0, 1<<10);
 ```
 
+Three macros are provided for adding benchmark templates.
+
+```c++
+#if __cplusplus >= 201103L // C++11 and greater.
+#define BENCHMARK_TEMPLATE(func, ...) // Takes any number of parameters.
+#else // C++ < C++11
+#define BENCHMARK_TEMPLATE(func, arg1)
+#endif
+#define BENCHMARK_TEMPLATE1(func, arg1)
+#define BENCHMARK_TEMPLATE2(func, arg1, arg2)
+```
+
 In a multithreaded test, it is guaranteed that none of the threads will start
 until all have called KeepRunning, and all will have finished before KeepRunning
 returns false. As such, any global setup or teardown you want to do can be

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -445,7 +445,7 @@ class Benchmark {
 // BENCHMARK_TEMPLATE(BM_Foo, 1);
 //
 // will register BM_Foo<1> as a benchmark.
-#define BENCHMARK_TEMPLATE(n, a)                             \
+#define BENCHMARK_TEMPLATE1(n, a)                            \
   static ::benchmark::internal::Benchmark* BENCHMARK_CONCAT( \
       _benchmark_, n, __LINE__) BENCHMARK_UNUSED =           \
       (new ::benchmark::internal::Benchmark(#n "<" #a ">", n<a>))
@@ -454,6 +454,16 @@ class Benchmark {
   static ::benchmark::internal::Benchmark* BENCHMARK_CONCAT( \
       _benchmark_, n, __LINE__) BENCHMARK_UNUSED =           \
       (new ::benchmark::internal::Benchmark(#n "<" #a "," #b ">", n<a, b>))
+
+#if __cplusplus >= 201103L
+#define BENCHMARK_TEMPLATE(n, ...) \
+  static ::benchmark::internal::Benchmark* BENCHMARK_CONCAT( \
+      _benchmark_, n, __LINE__) BENCHMARK_UNUSED =           \
+      (new ::benchmark::internal::Benchmark(                 \
+        #n "<" #__VA_ARGS__ ">", n<__VA_ARGS__>))
+#else
+#define BENCHMARK_TEMPLATE(n, a) BENCHMARK_TEMPLATE1(n, a)
+#endif
 
 // Helper macro to create a main routine in a test that runs the benchmarks
 #define BENCHMARK_MAIN()                             \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@
 find_package(Threads REQUIRED)
 
 set(CXX03_FLAGS "${CMAKE_CXX_FLAGS}")
+separate_arguments(CXX03_FLAGS)
 list(REMOVE_ITEM CXX03_FLAGS -std=c++11 -std=c++0x)
 list(APPEND CXX03_FLAGS -std=c++03)
 string(REPLACE ";" " " CXX03_FLAGS "${CXX03_FLAGS}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,10 +3,8 @@
 find_package(Threads REQUIRED)
 
 set(CXX03_FLAGS "${CMAKE_CXX_FLAGS}")
-separate_arguments(CXX03_FLAGS)
-list(REMOVE_ITEM CXX03_FLAGS -std=c++11 -std=c++0x)
-list(APPEND CXX03_FLAGS -std=c++03)
-string(REPLACE ";" " " CXX03_FLAGS "${CXX03_FLAGS}")
+string(REPLACE "-std=c++11" "-std=c++03" CXX03_FLAGS "${CXX03_FLAGS}")
+string(REPLACE "-std=c++0x" "-std=c++03" CXX03_FLAGS "${CXX03_FLAGS}")
 
 macro(compile_benchmark_test name)
   add_executable(${name} "${name}.cc")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,11 @@
 
 find_package(Threads REQUIRED)
 
+set(CXX03_FLAGS "${CMAKE_CXX_FLAGS}")
+list(REMOVE_ITEM CXX03_FLAGS -std=c++11 -std=c++0x)
+list(APPEND CXX03_FLAGS -std=c++03)
+string(REPLACE ";" " " CXX03_FLAGS "${CXX03_FLAGS}")
+
 macro(compile_benchmark_test name)
   add_executable(${name} "${name}.cc")
   target_link_libraries(${name} benchmark ${CMAKE_THREAD_LIBS_INIT})
@@ -23,3 +28,8 @@ add_test(filter_regex_end filter_test --benchmark_filter=.*Pi$ 8)
 
 compile_benchmark_test(basic_test)
 add_test(basic basic_test)
+
+compile_benchmark_test(cxx03_test)
+set_target_properties(cxx03_test
+    PROPERTIES COMPILE_FLAGS "${CXX03_FLAGS}")
+add_test(cxx03 cxx03_test)

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -121,6 +121,10 @@ static void BM_Sequential(benchmark::State& state) {
 }
 BENCHMARK_TEMPLATE2(BM_Sequential, std::vector<int>, int)->Range(1 << 0, 1 << 10);
 BENCHMARK_TEMPLATE(BM_Sequential, std::list<int>)->Range(1 << 0, 1 << 10);
+// Test the variadic version of BENCHMARK_TEMPLATE in C++11 and beyond.
+#if __cplusplus >= 201103L
+BENCHMARK_TEMPLATE(BM_Sequential, std::vector<int>, int)->Arg(512);
+#endif
 
 static void BM_StringCompare(benchmark::State& state) {
   std::string s1(state.range_x(), '-');

--- a/test/cxx03_test.cc
+++ b/test/cxx03_test.cc
@@ -1,0 +1,31 @@
+
+#include <cstddef>
+
+#include "benchmark/benchmark.h"
+
+#if __cplusplus >= 201103L
+#error C++11 or greater detected. Should be C++03.
+#endif
+
+void BM_empty(benchmark::State& state) {
+    while (state.KeepRunning()) {
+        volatile std::size_t x = state.iterations();
+        ((void)x);
+    }
+}
+BENCHMARK(BM_empty);
+
+template <class T, class U>
+void BM_template2(benchmark::State& state) {
+    BM_empty(state);
+}
+BENCHMARK_TEMPLATE2(BM_template2, int, long);
+
+template <class T>
+void BM_template1(benchmark::State& state) {
+    BM_empty(state);
+}
+BENCHMARK_TEMPLATE(BM_template1, long);
+BENCHMARK_TEMPLATE1(BM_template1, int);
+
+BENCHMARK_MAIN()


### PR DESCRIPTION
This patch makes it easier to use the BENCHMARK_TEMPLATE macro when >= c++11 by using variadic macros to accept templates that have an arbitrary number of parameters (and not just 1).