### PR TITLE
Add more context information and print estimated runtime

### DIFF
--- a/include/benchmark/reporter.h
+++ b/include/benchmark/reporter.h
@@ -34,6 +34,9 @@ class BenchmarkReporter {
     double mhz_per_cpu;
     bool cpu_scaling_enabled;
 
+    double benchmark_min_time;
+    size_t benchmark_count;
+    size_t benchmark_repetitions;
     // The number of chars in the longest benchmark name.
     size_t name_field_width;
   };

--- a/include/benchmark/reporter.h
+++ b/include/benchmark/reporter.h
@@ -32,12 +32,6 @@ class BenchmarkReporter {
   struct Context {
     Context();
 
-    // Information relating to the value of the command line flags.
-    std::string benchmark_filter;
-    int benchmark_iterations;
-    double benchmark_min_time;
-    int benchmark_repetitions;
-
     // The total number of benchmarks that will be run
     std::size_t benchmark_count;
 
@@ -92,8 +86,15 @@ class BenchmarkReporter {
   virtual void Finalize();
 
   virtual ~BenchmarkReporter();
+
 protected:
     static void ComputeStats(std::vector<Run> const& reports, Run* mean, Run* stddev);
+    // Information relating to the value of the command line flags.
+    static std::string const& BenchmarkFilterFlag();
+    static int BenchmarkIterationsFlag();
+    static double BenchmarkMinTimeFlag();
+    static int BenchmarkRepetitionsFlag();
+    static bool ColorPrintFlag();
 };
 
 // Simple reporter that outputs benchmark data to the console. This is the

--- a/include/benchmark/reporter.h
+++ b/include/benchmark/reporter.h
@@ -30,13 +30,22 @@ namespace benchmark {
 class BenchmarkReporter {
  public:
   struct Context {
+    Context();
+
+    // Information relating to the value of the command line flags.
+    std::string benchmark_filter;
+    int benchmark_iterations;
+    double benchmark_min_time;
+    int benchmark_repetitions;
+
+    // The total number of benchmarks that will be run
+    std::size_t benchmark_count;
+
+    // Information relating to the CPU.
     int num_cpus;
     double mhz_per_cpu;
     bool cpu_scaling_enabled;
 
-    double benchmark_min_time;
-    size_t benchmark_count;
-    size_t benchmark_repetitions;
     // The number of chars in the longest benchmark name.
     size_t name_field_width;
   };

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -803,11 +803,7 @@ void RunMatchingBenchmarks(const std::string& spec,
 
   context.cpu_scaling_enabled = CpuScalingEnabled();
   context.benchmark_count = benchmarks.size();
-  context.benchmark_min_time = FLAGS_benchmark_iterations ? 0.0
-                                : FLAGS_benchmark_min_time;
-  context.benchmark_repetitions = FLAGS_benchmark_repetitions;
   context.name_field_width = name_field_width;
-
 
   if (reporter->ReportContext(context)) {
     for (const auto& benchmark : benchmarks) {

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -802,7 +802,12 @@ void RunMatchingBenchmarks(const std::string& spec,
   context.mhz_per_cpu = CyclesPerSecond() / 1000000.0f;
 
   context.cpu_scaling_enabled = CpuScalingEnabled();
+  context.benchmark_count = benchmarks.size();
+  context.benchmark_min_time = FLAGS_benchmark_iterations ? 0.0
+                                : FLAGS_benchmark_min_time;
+  context.benchmark_repetitions = FLAGS_benchmark_repetitions;
   context.name_field_width = name_field_width;
+
 
   if (reporter->ReportContext(context)) {
     for (const auto& benchmark : benchmarks) {

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -14,21 +14,37 @@
 
 #include "benchmark/reporter.h"
 
-#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
-#include <limits>
 #include <string>
 #include <vector>
 
 #include "check.h"
 #include "colorprint.h"
+#include "commandlineflags.h"
 #include "stat.h"
 #include "string_util.h"
 #include "walltime.h"
 
+DECLARE_string(benchmark_filter);
+DECLARE_int32(benchmark_iterations);
+DECLARE_double(benchmark_min_time);
+DECLARE_int32(benchmark_repetitions);
+
 namespace benchmark {
+
+BenchmarkReporter::Context::Context()
+    : benchmark_filter(FLAGS_benchmark_filter),
+      benchmark_iterations(FLAGS_benchmark_iterations),
+      benchmark_min_time(FLAGS_benchmark_min_time),
+      benchmark_repetitions(FLAGS_benchmark_repetitions),
+      benchmark_count(0),
+      num_cpus(0),
+      mhz_per_cpu(0.0),
+      cpu_scaling_enabled(false),
+      name_field_width(0)
+{}
 
 void BenchmarkReporter::ComputeStats(
     const std::vector<Run>& reports,
@@ -115,8 +131,7 @@ bool ConsoleReporter::ReportContext(const Context& context) {
 #ifndef NDEBUG
   fprintf(stdout, "Build Type: DEBUG\n");
 #endif
-  if (std::abs(context.benchmark_min_time)
-        > std::numeric_limits<double>::epsilon()) {
+  if (context.benchmark_iterations == 0) {
     double estimated_time = context.benchmark_count
                           * context.benchmark_repetitions
                           * context.benchmark_min_time

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -14,9 +14,11 @@
 
 #include "benchmark/reporter.h"
 
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -113,6 +115,14 @@ bool ConsoleReporter::ReportContext(const Context& context) {
 #ifndef NDEBUG
   fprintf(stdout, "Build Type: DEBUG\n");
 #endif
+  if (std::abs(context.benchmark_min_time)
+        > std::numeric_limits<double>::epsilon()) {
+    double estimated_time = context.benchmark_count
+                          * context.benchmark_repetitions
+                          * context.benchmark_min_time
+                          * 1.4;
+    fprintf(stdout, "Estimated run time: %.0fs\n", estimated_time);
+  }
 
   int output_width =
       fprintf(stdout,

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -31,15 +31,12 @@ DECLARE_string(benchmark_filter);
 DECLARE_int32(benchmark_iterations);
 DECLARE_double(benchmark_min_time);
 DECLARE_int32(benchmark_repetitions);
+DECLARE_bool(color_print);
 
 namespace benchmark {
 
 BenchmarkReporter::Context::Context()
-    : benchmark_filter(FLAGS_benchmark_filter),
-      benchmark_iterations(FLAGS_benchmark_iterations),
-      benchmark_min_time(FLAGS_benchmark_min_time),
-      benchmark_repetitions(FLAGS_benchmark_repetitions),
-      benchmark_count(0),
+    : benchmark_count(0),
       num_cpus(0),
       mhz_per_cpu(0.0),
       cpu_scaling_enabled(false),
@@ -101,6 +98,26 @@ void BenchmarkReporter::ComputeStats(
   stddev_data->items_per_second = items_per_second_stat.StdDev();
 }
 
+std::string const& BenchmarkReporter::BenchmarkFilterFlag() {
+    return FLAGS_benchmark_filter;
+}
+
+int BenchmarkReporter::BenchmarkIterationsFlag() {
+    return FLAGS_benchmark_iterations;
+}
+
+double BenchmarkReporter::BenchmarkMinTimeFlag() {
+    return FLAGS_benchmark_min_time;
+}
+
+int BenchmarkReporter::BenchmarkRepetitionsFlag() {
+    return FLAGS_benchmark_repetitions;
+}
+
+bool BenchmarkReporter::ColorPrintFlag() {
+    return FLAGS_color_print;
+}
+
 void BenchmarkReporter::Finalize() {
 }
 
@@ -131,10 +148,10 @@ bool ConsoleReporter::ReportContext(const Context& context) {
 #ifndef NDEBUG
   fprintf(stdout, "Build Type: DEBUG\n");
 #endif
-  if (context.benchmark_iterations == 0) {
+  if (BenchmarkIterationsFlag() == 0) {
     double estimated_time = context.benchmark_count
-                          * context.benchmark_repetitions
-                          * context.benchmark_min_time
+                          * BenchmarkRepetitionsFlag()
+                          * BenchmarkMinTimeFlag()
                           * 1.4;
     fprintf(stdout, "Estimated run time: %.0fs\n", estimated_time);
   }


### PR DESCRIPTION
It's useful to have an idea of how long it will take to run all of the benchmark. This patch adds enough information to the Context type to do that in some cases. ConsoleReporter now prints the estimated time.

NOTE: when --benchmark_iterations is given there is no way to estimate how long the tests will take to run.