### PR TITLE
Libraries are treated as runtime objects on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,7 @@ install(
   TARGETS benchmark
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
   COMPONENT library)
 
 install(


### PR DESCRIPTION
When the library is created as a *.dll on Windows it is treated like a
runtime object so we must proivde the destination for the runtime
objects in our install command