### PR TITLE
Improve cmake dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8.12)
 project (benchmark)
 
 option(BENCHMARK_ENABLE_TESTING "Enable testing of the benchmark library." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 2.8.11)
 project (benchmark)
 
 option(BENCHMARK_ENABLE_TESTING "Enable testing of the benchmark library." ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 add_library(benchmark ${SOURCE_FILES} ${RE_FILES})
 
 find_package(Threads REQUIRED)
-target_link_libraries(benchmark INTERFACE ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(benchmark ${CMAKE_THREAD_LIBS_INIT})
 
 set_target_properties(benchmark PROPERTIES
   OUTPUT_NAME "benchmark"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,10 +18,12 @@ else()
 endif()
 
 add_library(benchmark ${SOURCE_FILES} ${RE_FILES})
+find_package(Threads REQUIRED)
 
-# Link threading if building a shared library.
+# Link threading if building a shared library, otherwise let client do it.
 if (BUILD_SHARED_LIBS)
-  find_package(Threads REQUIRED)
+  target_link_libraries(benchmark PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+else()
   target_link_libraries(benchmark ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
@@ -35,6 +37,8 @@ set_target_properties(benchmark PROPERTIES
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   target_link_libraries(benchmark Shlwapi)
 endif()
+
+target_include_directories(benchmark PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 # Install target (will install the library to specified CMAKE_INSTALL_PREFIX variable)
 install(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 add_library(benchmark ${SOURCE_FILES} ${RE_FILES})
 
 find_package(Threads REQUIRED)
-target_link_libraries(benchmark ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(benchmark INTERFACE ${CMAKE_THREAD_LIBS_INIT})
 
 set_target_properties(benchmark PROPERTIES
   OUTPUT_NAME "benchmark"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,14 +18,9 @@ else()
 endif()
 
 add_library(benchmark ${SOURCE_FILES} ${RE_FILES})
-find_package(Threads REQUIRED)
 
-# Link threading if building a shared library, otherwise let client do it.
-if (BUILD_SHARED_LIBS)
-  target_link_libraries(benchmark PRIVATE ${CMAKE_THREAD_LIBS_INIT})
-else()
-  target_link_libraries(benchmark ${CMAKE_THREAD_LIBS_INIT})
-endif()
+find_package(Threads REQUIRED)
+target_link_libraries(benchmark ${CMAKE_THREAD_LIBS_INIT})
 
 set_target_properties(benchmark PROPERTIES
   OUTPUT_NAME "benchmark"


### PR DESCRIPTION
Configure 'benchmark' cmake target so that when other targets depend on it, they get the appropriate include directories and link libraries automatically.