### PR TITLE
Rework travis configuration

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-set -x
-set -e
-
 # Before install
 if [ "$STD" = "c++11" ]; then
     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
@@ -15,12 +12,13 @@ if [ "$STD" = "c++11" ]; then
 fi
 
 # Install
-if [ "$STD" = "c++11" && "$CXX" = "g++" ]; then
+if [ "$STD" = "c++11" ] && [ "$CXX" = "g++" ]; then
     sudo apt-get install -qq gcc-4.8 g++-4.8
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
     sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
-fi
 elif [ "$CXX" = "clang++" ]; then
     sudo apt-get install clang-3.6
+    sudo update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-3.6 90
     sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 90
 fi
 # Install cmake

--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 
 # Before install
+
+sudo add-apt-repository -y ppa:kalakris/cmake
 if [ "$STD" = "c++11" ]; then
     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     if [ "$CXX" = "clang++" ]; then
         wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository -y "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main"
     fi
-    sudo apt-get update -qq
 fi
+sudo apt-get update -qq
 
 # Install
+sudo apt-get install -qq cmake
 if [ "$STD" = "c++11" ] && [ "$CXX" = "g++" ]; then
     sudo apt-get install -qq gcc-4.8 g++-4.8
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
@@ -21,8 +24,3 @@ elif [ "$CXX" = "clang++" ]; then
     sudo update-alternatives --install /usr/local/bin/clang++ clang++ /usr/bin/clang++-3.6 90
     export PATH=/usr/local/bin:$PATH
 fi
-# Install cmake
-wget http://www.cmake.org/files/v3.2/cmake-3.2.1-Linux-x86_64.tar.gz
-sudo tar -C /opt -xzf cmake-3.2.1-Linux-x86_64.tar.gz
-rm cmake-3.2.1-Linux-x86_64.tar.gz
-export PATH=/opt/cmake-3.2.1-Linux-x86_64/bin:$PATH

--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -17,7 +17,7 @@ if [ "$STD" = "c++11" ] && [ "$CXX" = "g++" ]; then
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
     sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
 elif [ "$CXX" = "clang++" ]; then
-    sudo apt-get install clang-3.6
+    sudo apt-get install -qq gcc-4.8 g++-4.8 clang-3.6
     sudo update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-3.6 90
     sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 90
 fi

--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -6,7 +6,6 @@ if [ "$STD" = "c++11" ]; then
     if [ "$CXX" = "clang++" ]; then
         wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository -y "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main"
-        sudo add-apt-repository -y "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main"
     fi
     sudo apt-get update -qq
 fi
@@ -17,12 +16,13 @@ if [ "$STD" = "c++11" ] && [ "$CXX" = "g++" ]; then
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
     sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
 elif [ "$CXX" = "clang++" ]; then
-    sudo apt-get install -qq gcc-4.8 g++-4.8 clang-3.6
-    sudo update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-3.6 90
-    sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 90
+    sudo apt-get install -qq clang-3.6
+    sudo update-alternatives --install /usr/local/bin/clang   clang   /usr/bin/clang-3.6 90
+    sudo update-alternatives --install /usr/local/bin/clang++ clang++ /usr/bin/clang++-3.6 90
+    export PATH=/usr/local/bin:$PATH
 fi
 # Install cmake
 wget http://www.cmake.org/files/v3.2/cmake-3.2.1-Linux-x86_64.tar.gz
-sudo tar -C /opt -xzvf cmake-3.2.1-Linux-x86_64.tar.gz
+sudo tar -C /opt -xzf cmake-3.2.1-Linux-x86_64.tar.gz
 rm cmake-3.2.1-Linux-x86_64.tar.gz
 export PATH=/opt/cmake-3.2.1-Linux-x86_64/bin:$PATH

--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -4,9 +4,9 @@
 if [ "$STD" = "c++11" ]; then
     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     if [ "$CXX" = "clang++" ]; then
-        deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main
-        deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main
         wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository -y "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main"
+        sudo add-apt-repository -y "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main"
     fi
     sudo apt-get update -qq
 fi

--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+# Before install
+if [ "$STD" = "c++11" ]; then
+    sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    if [ "$CXX" = "clang++" ]; then
+        deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main
+        deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main
+        wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+    fi
+    sudo apt-get update -qq
+fi
+
+# Install
+if [ "$STD" = "c++11" && "$CXX" = "g++" ]; then
+    sudo apt-get install -qq gcc-4.8 g++-4.8
+    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+fi
+elif [ "$CXX" = "clang++" ]; then
+    sudo apt-get install clang-3.6
+    sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 90
+fi
+# Install cmake
+wget http://www.cmake.org/files/v3.2/cmake-3.2.1-Linux-x86_64.tar.gz
+sudo tar -C /opt -xzvf cmake-3.2.1-Linux-x86_64.tar.gz
+rm cmake-3.2.1-Linux-x86_64.tar.gz
+export PATH=/opt/cmake-3.2.1-Linux-x86_64/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
 language: cpp
+
+# NOTE: The COMPILER variable is unused. It simply makes the display on
+# travis-ci.org more readable.
 matrix:
     include:
         - compiler: gcc
-          env: BUILD_TYPE=Debug STD=c++0x
+          env: COMPILER=g++-4.6     STD=c++0x BUILD_TYPE=Debug
         - compiler: gcc
-          env: BUILD_TYPE=Release STD=c++0x
+          env: COMPILER=g++-4.6     STD=c++0x BUILD_TYPE=Release
         - compiler: gcc
-          env: BUILD_TYPE=Debug STD=c++11
+          env: COMPILER=g++-4.8     STD=c++11 BUILD_TYPE=Debug
         - compiler: gcc
-          env: BUILD_TYPE=Release STD=c++11
+          env: COMPILER=g++-4.8     STD=c++11 BUILD_TYPE=Release
         - compiler: clang
-          env: BUILD_TYPE=Debug STD=c++11
+          env: COMPILER=clang++-3.6 STD=c++11 BUILD_TYPE=Debug
         - compiler: clang
-          env: BUILD_TYPE=Release STD=c++11
+          env: COMPILER=clang++-3.6 STD=c++11 BUILD_TYPE=Release
 
 before_script:
     - source .travis-setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,21 @@
+language: cpp
 
-language:
-    - cpp
-os:
-    - linux
+compiler:
+    - gcc
+    - clang
 env:
     - BUILD_TYPE=Debug   STD=c++0x
     - BUILD_TYPE=Release STD=c++0x
     - BUILD_TYPE=Debug   STD=c++11
     - BUILD_TYPE=Release STD=c++11
 
-before_install:
-    - if [ "$STD" = "c++11" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
-    - if [ "$STD" = "c++11" ]; then sudo apt-get update -qq; fi
-
-install:
-    - if [ "$STD" = "c++11" ]; then sudo apt-get install -qq gcc-4.8 g++-4.8; fi
-    - if [ "$STD" = "c++11" ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
-    - wget http://www.cmake.org/files/v3.2/cmake-3.2.1-Linux-x86_64.tar.gz
-    - sudo tar -C /opt -xzvf cmake-3.2.1-Linux-x86_64.tar.gz
-    - rm cmake-3.2.1-Linux-x86_64.tar.gz
-    - export PATH=/opt/cmake-3.2.1-Linux-x86_64/bin:$PATH
-    - cmake --version
+matrix:
+    exclude:
+        - compiler: clang
+          env: STD=c++0x
 
 before_script:
+    - source .travis-setup.sh
     - mkdir build && cd build
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,10 @@ before_install:
 install:
     - if [ "$STD" = "c++11" ]; then sudo apt-get install -qq gcc-4.8 g++-4.8; fi
     - if [ "$STD" = "c++11" ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
-    - mkdir depends && cd depends
-    - wget http://www.cmake.org/files/v3.2/cmake-3.2.1-Linux-x86_64.sh
-    - sudo sh cmake-3.2.1-Linux-x86_64.sh --prefix=/opt/cmake
-    - cd .. && sudo rm -rf depends
-    - export PATH=/opt/cmake/bin:$PATH
+    - wget http://www.cmake.org/files/v3.2/cmake-3.2.1-Linux-x86_64.tar.gz
+    - sudo tar -C /opt -xzvf cmake-3.2.1-Linux-x86_64.tar.gz
+    - rm cmake-3.2.1-Linux-x86_64.tar.gz
+    - export PATH=/opt/cmake-3.2.1-Linux-x86_64/bin:$PATH
     - cmake --version
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,18 @@
 language: cpp
-
-compiler:
-    - gcc
-    - clang
-env:
-    - BUILD_TYPE=Debug   STD=c++0x
-    - BUILD_TYPE=Release STD=c++0x
-    - BUILD_TYPE=Debug   STD=c++11
-    - BUILD_TYPE=Release STD=c++11
-
 matrix:
-    exclude:
-        - compiler: clang
+    include:
+        - compiler: gcc
           env: BUILD_TYPE=Debug STD=c++0x
-        - compiler: clang
+        - compiler: gcc
           env: BUILD_TYPE=Release STD=c++0x
+        - compiler: gcc
+          env: BUILD_TYPE=Debug STD=c++11
+        - compiler: gcc
+          env: BUILD_TYPE=Release STD=c++11
+        - compiler: clang
+          env: BUILD_TYPE=Debug STD=c++11
+        - compiler: clang
+          env: BUILD_TYPE=Release STD=c++11
 
 before_script:
     - source .travis-setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ env:
 matrix:
     exclude:
         - compiler: clang
-          env: STD=c++0x
+          env: BUILD_TYPE=Debug STD=c++0x
+        - compiler: clang
+          env: BUILD_TYPE=Release STD=c++0x
 
 before_script:
     - source .travis-setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,27 @@
-matrix:
-  include:
-    - os: linux
-      env: BUILD_TYPE=Debug   STD=c++0x
-    - os: linux
-      env: BUILD_TYPE=Debug   STD=c++11
-    - os: linux
-      env: BUILD_TYPE=Release STD=c++0x
-    - os: linux
-      env: BUILD_TYPE=Release STD=c++11
-    - os: osx
-      env: BUILD_TYPE=Debug   STD=c++11
-    - os: osx
-      env: BUILD_TYPE=Release STD=c++11
 
 language:
     - cpp
+os:
+    - linux
+env:
+    - BUILD_TYPE=Debug   STD=c++0x
+    - BUILD_TYPE=Release STD=c++0x
+    - BUILD_TYPE=Debug   STD=c++11
+    - BUILD_TYPE=Release STD=c++11
 
 before_install:
-    - uname -a
-    - cmake --version
-    - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$STD" = "c++11" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
-    - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$STD" = "c++11" ]; then sudo apt-get update -qq; fi
+    - if [ "$STD" = "c++11" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
+    - if [ "$STD" = "c++11" ]; then sudo apt-get update -qq; fi
 
 install:
-    - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$STD" = "c++11" ]; then sudo apt-get install -qq gcc-4.8 g++-4.8; fi
-    - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$STD" = "c++11" ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
+    - if [ "$STD" = "c++11" ]; then sudo apt-get install -qq gcc-4.8 g++-4.8; fi
+    - if [ "$STD" = "c++11" ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
+    - mkdir depends && cd depends
+    - wget http://www.cmake.org/files/v3.2/cmake-3.2.1-Linux-x86_64.sh
+    - sudo sh cmake-3.2.1-Linux-x86_64.sh --prefix=/opt/cmake
+    - cd .. && sudo rm -rf depends
+    - export PATH=/opt/cmake/bin:$PATH
+    - cmake --version
 
 before_script:
     - mkdir build && cd build


### PR DESCRIPTION
This patch does the following:

1. Cleanup travis configuration.
2. Upgrade CMake to 3.2
3. Add Clang 3.6 testers.

I would prefer to use CMake 2.8.12 (the soon to be minimum version) when testing, but I couldn't find a repository that had it. Unfortunately cmake.org only provides x86_64 linux binaries for CMake 3. 