### PR TITLE
Min max features

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,7 +19,7 @@ Google Inc.
 JianXiong Zhou <zhoujianxiong2@gmail.com>
 Lei Xu <eddyxu@gmail.com>
 Matt Clarkson <mattyclarkson@gmail.com>
-Michael Bacci <michael.bacci.software@gmail.com>
+Michael Bacci <michaelparis314@gmail.com>
 Oleksandr Sochka <sasha.sochka@gmail.com>
 Paul Redmond <paul.redmond@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -19,6 +19,7 @@ Google Inc.
 JianXiong Zhou <zhoujianxiong2@gmail.com>
 Lei Xu <eddyxu@gmail.com>
 Matt Clarkson <mattyclarkson@gmail.com>
+Michael Bacci <michael.bacci.software@gmail.com>
 Oleksandr Sochka <sasha.sochka@gmail.com>
 Paul Redmond <paul.redmond@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,6 +33,7 @@ Felix Homann <linuxaudio@showlabor.de>
 JianXiong Zhou <zhoujianxiong2@gmail.com>
 Lei Xu <eddyxu@gmail.com>
 Matt Clarkson <mattyclarkson@gmail.com>
+Michael Bacci <michaelparis314@gmail.com>dd
 Oleksandr Sochka <sasha.sochka@gmail.com>
 Pascal Leroy <phl@google.com>
 Paul Redmond <paul.redmond@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,7 +33,7 @@ Felix Homann <linuxaudio@showlabor.de>
 JianXiong Zhou <zhoujianxiong2@gmail.com>
 Lei Xu <eddyxu@gmail.com>
 Matt Clarkson <mattyclarkson@gmail.com>
-Michael Bacci <michaelparis314@gmail.com>dd
+Michael Bacci <michaelparis314@gmail.com>
 Oleksandr Sochka <sasha.sochka@gmail.com>
 Pascal Leroy <phl@google.com>
 Paul Redmond <paul.redmond@gmail.com>

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -219,7 +219,7 @@ class State {
 public:
   State(size_t max_iters, bool has_x, int x, bool has_y, int y, int thread_i);
 
-  // Returns true if the benchmark should continue through another iteration.
+  // Returns true iff the benchmark should continue through another iteration.
   // NOTE: A benchmark may not return from the test until KeepRunning() has
   // returned false.
   bool KeepRunning();
@@ -294,9 +294,6 @@ public:
   double worse_performance() const {
     return worse_performance_;
   }
-
-  BENCHMARK_ALWAYS_INLINE
-  void log(const int level, const char* msg);
 
     // If this routine is called, the specified label is printed at the
   // end of the benchmark report line for the currently executing

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -359,7 +359,7 @@ private:
   double count_pause_resume_;
   double best_performance_;
   double worse_performance_;
-  decltype(std::chrono::high_resolution_clock::now())
+  std::chrono::time_point<std::chrono::steady_clock>
       single_iteration_timer_, single_iteration_pause_;
   bool pause_flag_;
 

--- a/include/benchmark/reporter.h
+++ b/include/benchmark/reporter.h
@@ -33,7 +33,7 @@ class BenchmarkReporter {
     int num_cpus;
     double mhz_per_cpu;
     bool cpu_scaling_enabled;
-    bool benchmark_best_worse_enabled;
+    bool benchmark_min_max_enabled;
 
     // The number of chars in the longest benchmark name.
     size_t name_field_width;
@@ -42,14 +42,14 @@ class BenchmarkReporter {
   struct PerformanceHit {
     PerformanceHit() :
       enabled(false),
-      benchmark_best_time(0),
-      benchmark_worse_time(0) {}
+      benchmark_min_time(0),
+      benchmark_max_time(0) {}
 
     bool enabled;
 
     //benchmark best and worse performance
-    double benchmark_best_time;
-    double benchmark_worse_time;
+    double benchmark_min_time;
+    double benchmark_max_time;
   };
 
   struct Run {

--- a/include/benchmark/reporter.h
+++ b/include/benchmark/reporter.h
@@ -33,9 +33,23 @@ class BenchmarkReporter {
     int num_cpus;
     double mhz_per_cpu;
     bool cpu_scaling_enabled;
+    bool benchmark_best_worse_enabled;
 
     // The number of chars in the longest benchmark name.
     size_t name_field_width;
+  };
+
+  struct PerformanceHit {
+    PerformanceHit() :
+      enabled(false),
+      benchmark_best_time(0),
+      benchmark_worse_time(0) {}
+
+    bool enabled;
+
+    //benchmark best and worse performance
+    double benchmark_best_time;
+    double benchmark_worse_time;
   };
 
   struct Run {
@@ -59,6 +73,9 @@ class BenchmarkReporter {
 
     // This is set to 0.0 if memory tracing is not enabled.
     double max_heapbytes_used;
+
+    //benchmark best and worse performance
+    struct PerformanceHit hit;
   };
 
   // Called once for every suite of benchmarks run.

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -49,7 +49,7 @@ bool ConsoleReporter::ReportContext(const Context& context) {
                              static_cast<int>(name_field_width_), "Benchmark",
                              "Time(ns)", "CPU(ns)", "Iterations");
 
-  if (context.benchmark_best_worse_enabled)
+  if (context.benchmark_min_max_enabled)
     output_width += fprintf(stdout, " %10s %10s", "Best(ns)" , "Worse(ns)");
 
   output_width += fprintf(stdout, "\n");
@@ -115,8 +115,8 @@ void ConsoleReporter::PrintRunData(const Run& result) {
 
   if(result.hit.enabled) {
     ColorPrintf(COLOR_CYAN, " %10.0f %10.0f",
-                result.hit.benchmark_best_time,
-                result.hit.benchmark_worse_time);
+                result.hit.benchmark_min_time,
+                result.hit.benchmark_max_time);
   }
 
   ColorPrintf(COLOR_DEFAULT, "%*s %*s %s\n",

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -114,9 +114,9 @@ void ConsoleReporter::PrintRunData(const Run& result) {
   ColorPrintf(COLOR_CYAN, "%10lld", result.iterations);
 
   if(result.hit.enabled) {
-    ColorPrintf(COLOR_CYAN, "%10.0f %10.0f",
-        result.hit.benchmark_best_time * multiplier,
-        result.hit.benchmark_worse_time * multiplier);
+    ColorPrintf(COLOR_CYAN, " %10.0f %10.0f",
+                result.hit.benchmark_best_time,
+                result.hit.benchmark_worse_time);
   }
 
   ColorPrintf(COLOR_DEFAULT, "%*s %*s %s\n",

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -45,9 +45,15 @@ bool ConsoleReporter::ReportContext(const Context& context) {
                "affected.\n";
 #endif
 
-  int output_width = fprintf(stdout, "%-*s %10s %10s %10s\n",
+  int output_width = fprintf(stdout, "%-*s %10s %10s %10s",
                              static_cast<int>(name_field_width_), "Benchmark",
                              "Time(ns)", "CPU(ns)", "Iterations");
+
+  if (context.benchmark_best_worse_enabled)
+    output_width += fprintf(stdout, " %10s %10s", "Best(ns)" , "Worse(ns)");
+
+  output_width += fprintf(stdout, "\n");
+
   std::cout << std::string(output_width - 1, '-') << "\n";
 
   return true;
@@ -106,6 +112,13 @@ void ConsoleReporter::PrintRunData(const Run& result) {
                     (static_cast<double>(result.iterations)));
   }
   ColorPrintf(COLOR_CYAN, "%10lld", result.iterations);
+
+  if(result.hit.enabled) {
+    ColorPrintf(COLOR_CYAN, "%10.0f %10.0f",
+        result.hit.benchmark_best_time * multiplier,
+        result.hit.benchmark_worse_time * multiplier);
+  }
+
   ColorPrintf(COLOR_DEFAULT, "%*s %*s %s\n",
               13, rate.c_str(),
               18, items.c_str(),

--- a/src/csv_reporter.cc
+++ b/src/csv_reporter.cc
@@ -42,8 +42,15 @@ bool CSVReporter::ReportContext(const Context& context) {
   std::cerr << "***WARNING*** Library was built as DEBUG. Timings may be "
                "affected.\n";
 #endif
+
   std::cout << "name,iterations,real_time,cpu_time,bytes_per_second,"
-               "items_per_second,label\n";
+            "items_per_second,label";
+
+  if (context.benchmark_best_worse_enabled)
+    std::cout << ",best,worse";
+
+  std::cout << "\n";
+
   return true;
 }
 
@@ -99,6 +106,12 @@ void CSVReporter::PrintRunData(Run const& run) {
     ReplaceAll(&label, "\"", "\"\"");
     std::cout << "\"" << label << "\"";
   }
+
+  if (run.hit.enabled) {
+    std::cout << "," << run.hit.benchmark_best_time;
+    std::cout << "," << run.hit.benchmark_worse_time;
+  }
+
   std::cout << '\n';
 }
 

--- a/src/csv_reporter.cc
+++ b/src/csv_reporter.cc
@@ -46,7 +46,7 @@ bool CSVReporter::ReportContext(const Context& context) {
   std::cout << "name,iterations,real_time,cpu_time,bytes_per_second,"
             "items_per_second,label";
 
-  if (context.benchmark_best_worse_enabled)
+  if (context.benchmark_min_max_enabled)
     std::cout << ",best,worse";
 
   std::cout << "\n";
@@ -108,8 +108,8 @@ void CSVReporter::PrintRunData(Run const& run) {
   }
 
   if (run.hit.enabled) {
-    std::cout << "," << run.hit.benchmark_best_time;
-    std::cout << "," << run.hit.benchmark_worse_time;
+    std::cout << "," << run.hit.benchmark_min_time;
+    std::cout << "," << run.hit.benchmark_max_time;
   }
 
   std::cout << '\n';

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -147,6 +147,14 @@ void JSONReporter::PrintRunData(Run const& run) {
         << ",\n";
     out << indent
         << FormatKV("cpu_time", RoundDouble(cpu_time));
+
+    if (run.hit.enabled) {
+      out << ",\n" << indent
+          << FormatKV("best", RoundDouble(run.hit.benchmark_best_time));
+      out << ",\n" << indent
+          << FormatKV("worse", RoundDouble(run.hit.benchmark_worse_time));
+    }
+
     if (run.bytes_per_second > 0.0) {
         out << ",\n" << indent
             << FormatKV("bytes_per_second", RoundDouble(run.bytes_per_second));

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -150,9 +150,9 @@ void JSONReporter::PrintRunData(Run const& run) {
 
     if (run.hit.enabled) {
       out << ",\n" << indent
-          << FormatKV("best", RoundDouble(run.hit.benchmark_best_time));
+          << FormatKV("best", RoundDouble(run.hit.benchmark_min_time));
       out << ",\n" << indent
-          << FormatKV("worse", RoundDouble(run.hit.benchmark_worse_time));
+          << FormatKV("worse", RoundDouble(run.hit.benchmark_max_time));
     }
 
     if (run.bytes_per_second > 0.0) {

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -64,7 +64,6 @@ void BenchmarkReporter::ComputeStats(
                                     run_iterations;
   mean_data->bytes_per_second = bytes_per_second_stat.Mean();
   mean_data->items_per_second = items_per_second_stat.Mean();
-
   mean_data->hit.benchmark_best_time = best_performance;
   mean_data->hit.benchmark_worse_time = worse_performance;
 

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -36,22 +36,24 @@ void BenchmarkReporter::ComputeStats(
   // can take this information from the first benchmark.
   std::size_t const run_iterations = reports.front().iterations;
 
-  double best_performance = std::numeric_limits<double>::max();
-  double worse_performance = 0;
+  double min_real_accumulated_time = std::numeric_limits<double>::max();
+  double max_real_accumulated_time = 0;
 
   // Populate the accumulators.
   for (Run const& run : reports) {
     CHECK_EQ(reports[0].benchmark_name, run.benchmark_name);
     CHECK_EQ(run_iterations, run.iterations);
+    auto real_accumulated_time = run.real_accumulated_time/run.iterations;
     real_accumulated_time_stat +=
-        Stat1_d(run.real_accumulated_time/run.iterations, run.iterations);
+        Stat1_d(real_accumulated_time, run.iterations);
     cpu_accumulated_time_stat +=
         Stat1_d(run.cpu_accumulated_time/run.iterations, run.iterations);
     items_per_second_stat += Stat1_d(run.items_per_second, run.iterations);
     bytes_per_second_stat += Stat1_d(run.bytes_per_second, run.iterations);
     if (run.hit.enabled) {
-      best_performance = std::min(best_performance, run.hit.benchmark_min_time);
-      worse_performance = std::max(worse_performance, run.hit.benchmark_max_time);
+      mean_data->hit.enabled = true;
+      min_real_accumulated_time = std::min(min_real_accumulated_time, real_accumulated_time);
+      max_real_accumulated_time = std::max(max_real_accumulated_time, real_accumulated_time);
     }
   }
 
@@ -64,8 +66,10 @@ void BenchmarkReporter::ComputeStats(
                                     run_iterations;
   mean_data->bytes_per_second = bytes_per_second_stat.Mean();
   mean_data->items_per_second = items_per_second_stat.Mean();
-  mean_data->hit.benchmark_min_time = best_performance;
-  mean_data->hit.benchmark_max_time = worse_performance;
+
+  double const multiplier = 1e9; // nano second multiplier
+  mean_data->hit.benchmark_min_time = min_real_accumulated_time * multiplier;
+  mean_data->hit.benchmark_max_time = max_real_accumulated_time * multiplier;
 
   // Only add label to mean/stddev if it is same for all runs
   mean_data->report_label = reports[0].report_label;
@@ -85,8 +89,6 @@ void BenchmarkReporter::ComputeStats(
       cpu_accumulated_time_stat.StdDev();
   stddev_data->bytes_per_second = bytes_per_second_stat.StdDev();
   stddev_data->items_per_second = items_per_second_stat.StdDev();
-  stddev_data->hit.benchmark_min_time = best_performance;
-  stddev_data->hit.benchmark_max_time = worse_performance;
 }
 
 void BenchmarkReporter::Finalize() {

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -67,9 +67,11 @@ void BenchmarkReporter::ComputeStats(
   mean_data->bytes_per_second = bytes_per_second_stat.Mean();
   mean_data->items_per_second = items_per_second_stat.Mean();
 
-  double const multiplier = 1e9; // nano second multiplier
-  mean_data->hit.benchmark_min_time = min_real_accumulated_time * multiplier;
-  mean_data->hit.benchmark_max_time = max_real_accumulated_time * multiplier;
+  if (mean_data->hit.enabled) {
+    double const multiplier = 1e9; // nano second multiplier
+    mean_data->hit.benchmark_min_time = min_real_accumulated_time * multiplier;
+    mean_data->hit.benchmark_max_time = max_real_accumulated_time * multiplier;
+  }
 
   // Only add label to mean/stddev if it is same for all runs
   mean_data->report_label = reports[0].report_label;

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -50,8 +50,8 @@ void BenchmarkReporter::ComputeStats(
     items_per_second_stat += Stat1_d(run.items_per_second, run.iterations);
     bytes_per_second_stat += Stat1_d(run.bytes_per_second, run.iterations);
     if (run.hit.enabled) {
-      best_performance = std::min(best_performance, run.hit.benchmark_best_time);
-      worse_performance = std::max(worse_performance, run.hit.benchmark_worse_time);
+      best_performance = std::min(best_performance, run.hit.benchmark_min_time);
+      worse_performance = std::max(worse_performance, run.hit.benchmark_max_time);
     }
   }
 
@@ -64,8 +64,8 @@ void BenchmarkReporter::ComputeStats(
                                     run_iterations;
   mean_data->bytes_per_second = bytes_per_second_stat.Mean();
   mean_data->items_per_second = items_per_second_stat.Mean();
-  mean_data->hit.benchmark_best_time = best_performance;
-  mean_data->hit.benchmark_worse_time = worse_performance;
+  mean_data->hit.benchmark_min_time = best_performance;
+  mean_data->hit.benchmark_max_time = worse_performance;
 
   // Only add label to mean/stddev if it is same for all runs
   mean_data->report_label = reports[0].report_label;
@@ -85,8 +85,8 @@ void BenchmarkReporter::ComputeStats(
       cpu_accumulated_time_stat.StdDev();
   stddev_data->bytes_per_second = bytes_per_second_stat.StdDev();
   stddev_data->items_per_second = items_per_second_stat.StdDev();
-  stddev_data->hit.benchmark_best_time = best_performance;
-  stddev_data->hit.benchmark_worse_time = worse_performance;
+  stddev_data->hit.benchmark_min_time = best_performance;
+  stddev_data->hit.benchmark_max_time = worse_performance;
 }
 
 void BenchmarkReporter::Finalize() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,4 +42,4 @@ set_target_properties(cxx03_test
 add_test(cxx03 cxx03_test --benchmark_min_time=0.01)
 
 compile_benchmark_test(sleep_test)
-add_test(sleep_benchmark sleep_test --benchmark_best_worse)
+add_test(sleep_benchmark sleep_test --benchmark_min_max)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,4 +42,4 @@ set_target_properties(cxx03_test
 add_test(cxx03 cxx03_test --benchmark_min_time=0.01)
 
 compile_benchmark_test(sleep_test)
-add_test(basic_benchmark sleep_test)
+add_test(sleep_benchmark sleep_test --benchmark_best_worse)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,3 +40,6 @@ compile_benchmark_test(cxx03_test)
 set_target_properties(cxx03_test
     PROPERTIES COMPILE_FLAGS "${CXX03_FLAGS}")
 add_test(cxx03 cxx03_test --benchmark_min_time=0.01)
+
+compile_benchmark_test(sleep_test)
+add_test(basic_benchmark sleep_test)

--- a/test/sleep_test.cc
+++ b/test/sleep_test.cc
@@ -1,0 +1,16 @@
+
+#include <cstddef>
+#include <chrono>
+#include <thread>
+
+#include "benchmark/benchmark_api.h"
+
+void BM_sleep(benchmark::State& state) {
+  std::chrono::nanoseconds ns(10000);
+  while (state.KeepRunning()) {
+    std::this_thread::sleep_for(ns);
+  }
+}
+BENCHMARK(BM_sleep);
+
+BENCHMARK_MAIN()

--- a/test/sleep_test.cc
+++ b/test/sleep_test.cc
@@ -2,15 +2,75 @@
 #include <cstddef>
 #include <chrono>
 #include <thread>
-
+#include <stdio.h>
 #include "benchmark/benchmark_api.h"
 
+#define BASIC_BENCHMARK_TEST(x) \
+    BENCHMARK(x)->Arg(10)->Arg(100)->Arg(10000)->Arg(500000)->\
+                  Arg(1000000)->Arg(5000000)->Arg(1000000000)
+
+#define CHECK_EXPECTED_BENCHMARK \
+  char f[100];\
+  sprintf(f, "Best(ns) score is: %6.0f%% of expected performance", state.best_performance()*100/state.range_x());\
+  state.SetLabel(f);\
+
 void BM_sleep(benchmark::State& state) {
-  std::chrono::nanoseconds ns(10000);
+  std::chrono::nanoseconds ns(state.range_x());
+
   while (state.KeepRunning()) {
     std::this_thread::sleep_for(ns);
   }
+
+  CHECK_EXPECTED_BENCHMARK
 }
-BENCHMARK(BM_sleep);
+
+BASIC_BENCHMARK_TEST(BM_sleep);
+BASIC_BENCHMARK_TEST(BM_sleep)->UseRealTime();
+BASIC_BENCHMARK_TEST(BM_sleep)->ThreadPerCpu();
+
+void BM_sleep_and_wait(benchmark::State& state) {
+  std::chrono::nanoseconds ns(state.range_x());
+
+  while (state.KeepRunning()) {
+    state.PauseTiming();
+    {
+      /* this loop will be not be counted */
+      for (int i = 0; i < state.range_y(); ++i) {
+        benchmark::DoNotOptimize(i);
+      }
+    }
+    state.ResumeTiming();
+
+    std::this_thread::sleep_for(ns);
+  }
+}
+
+BENCHMARK(BM_sleep_and_wait)->ArgPair(100000000, 1<<10);
+
+void BM_real_sleep_and_virtual_sleep(benchmark::State& state) {
+  std::chrono::nanoseconds ns_real(state.range_x());
+  std::chrono::nanoseconds ns_virtual(state.range_y());
+
+  while (state.KeepRunning()) {
+    state.PauseTiming();
+    {
+      /* this sleep will not be counted */
+      std::this_thread::sleep_for(ns_virtual);
+    }
+    state.ResumeTiming();
+
+    std::this_thread::sleep_for(ns_real);
+
+    state.PauseTiming();
+    {
+      /* this sleep will not be counted */
+      std::this_thread::sleep_for(ns_virtual);
+    }
+    state.ResumeTiming();
+
+  }
+}
+
+BENCHMARK(BM_real_sleep_and_virtual_sleep)->ArgPair(1000000000, 2000000000);
 
 BENCHMARK_MAIN()


### PR DESCRIPTION
I have add the flag "--benchmark_best_worse" that enable the framework to output (console,json,cvs) the best and worse performance for each benchmark.
It works for multi-thread: showing the best and worse result between the best/worse results of each threads.
There is a new simple benchmark test 'sleep_test.cc', that show the fact that for very short time the expected results does not overlap with real results.

Here the output of sleep_test.cc:

Run on (8 X 1000 MHz CPU s)
2015-04-04 20:57:06
***WARNING*** Library was built as DEBUG. Timings may be affected.
Benchmark                                           Time(ns)    CPU(ns) Iterations   Best(ns)  Worse(ns)
--------------------------------------------------------------------------------------------------------
BM_sleep/10                                            16150       4276      32135      14419    2827113                                 Best(ns) score is: 144190% of expected performance
BM_sleep/100                                            7798       4028      38028       4490    3022835                                 Best(ns) score is:   4490% of expected performance
BM_sleep/9.76562k                                      18011       3928      34124      14946    2402929                                 Best(ns) score is:    149% of expected performance
BM_sleep/488.281k                                     615686      10469       1000     511129    4006443                                 Best(ns) score is:    102% of expected performance
BM_sleep/976.562k                                    1251184      13035       1000    1010582    5338854                                 Best(ns) score is:    101% of expected performance
BM_sleep/4.76837M                                    5897284      22210        100    5024193    6612936                                 Best(ns) score is:    100% of expected performance
BM_sleep/953.674M                                 1003946304      21000          1 1003947346 1003947346                                 Best(ns) score is:    100% of expected performance
BM_sleep/10/real_time                                  15595       3934       9281      14423    2400661                                 Best(ns) score is: 144230% of expected performance
BM_sleep/100/real_time                                  6434       3654      20406       4198    1374015                                 Best(ns) score is:   5444% of expected performance
BM_sleep/9.76562k/real_time                            18323       4117       7687      15173    2304735                                 Best(ns) score is:    152% of expected performance
BM_sleep/488.281k/real_time                           618930      10010        197     515935    4283909                                 Best(ns) score is:    105% of expected performance
BM_sleep/976.562k/real_time                          1254678      12018        112    1024115    2820843                                 Best(ns) score is:    102% of expected performance
BM_sleep/4.76837M/real_time                          5860500      20840         25    5044375    6917322                                 Best(ns) score is:    101% of expected performance
BM_sleep/953.674M/real_time                       1000902891      19000          1 1000904478 1000904478                                 Best(ns) score is:    100% of expected performance
BM_sleep/10/threads:8                                  10101      19088       7112      20634     340630                                 Best(ns) score is: 211770% of expected performance
BM_sleep/100/threads:8                                  9907      19029       6688      18537     623515                                 Best(ns) score is:  19208% of expected performance
BM_sleep/9.76562k/threads:8                             9303      17219       6536      21623    1282573                                 Best(ns) score is:    263% of expected performance
BM_sleep/488.281k/threads:8                            81914      15874       9232     526604    3623895                                 Best(ns) score is:    105% of expected performance
BM_sleep/976.562k/threads:8                           160127      16929       8032    1022631    4253851                                 Best(ns) score is:    104% of expected performance
BM_sleep/4.76837M/threads:8                           743442      23290        800    5038206    7402964                                 Best(ns) score is:    101% of expected performance
BM_sleep/953.674M/threads:8                        125249207      38500          8 1001907675 1001962341                                 Best(ns) score is:    100% of expected performance
BM_sleep_and_wait/95.3674M/1024                    103413272      26000         10  100214096  107304085                                 
BM_real_sleep_and_virtual_sleep/953.674M/1.86265G 1004458666      42000          1 1004452826 1004452826         