### PR TITLE
Add ability to use benchmark fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,36 @@ static void BM_test(benchmark::State& state) {
 }
 ```
 
+Benchmark Fixtures
+------------------
+Fixture tests are created by
+first defining a type that derives from ::benchmark::Fixture and then
+creating/registering the tests using the following macros:
+
+* `BENCHMARK_F(ClassName, Method)`
+* `BENCHMARK_DEFINE_F(ClassName, Method)`
+* `BENCHMARK_REGISTER_F(ClassName, Method)`
+
+For Example:
+
+```c++
+class MyFixture : public benchmark::Fixture {};
+
+BENCHMARK_F(MyFixture, FooTest)(benchmark::State& st) {
+   while (st.KeepRunning()) {
+     ...
+  }
+}
+
+BENCHMARK_DEFINE_F(MyFixture, BarTest)(benchmark::State& st) {
+   while (st.KeepRunning()) {
+     ...
+  }
+}
+/* BarTest is NOT registered */
+BENCHMARK_REGISTER_F(MyFixture, BarTest)->Threads(2);
+/* BarTest is now registered */
+```
 
 Output Formats
 --------------

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -488,7 +488,7 @@ public:
 
     virtual void Run(State& st) {
       this->SetUp();
-      this->TestCase(st);
+      this->BenchmarkCase(st);
       this->TearDown();
     }
 
@@ -496,7 +496,7 @@ public:
     virtual void TearDown() {}
 
 protected:
-    virtual void TestCase(State&) = 0;
+    virtual void BenchmarkCase(State&) = 0;
 };
 
 }  // end namespace benchmark
@@ -525,8 +525,9 @@ protected:
   BENCHMARK_PRIVATE_NAME(n) BENCHMARK_UNUSED
 
 #define BENCHMARK(n) \
-    BENCHMARK_PRIVATE_DECLARE(n) = (::benchmark::internal::RegisterBenchmarkInternal( \
-        new ::benchmark::internal::FunctionBenchmark(#n, n)))
+    BENCHMARK_PRIVATE_DECLARE(n) =                               \
+        (::benchmark::internal::RegisterBenchmarkInternal(       \
+            new ::benchmark::internal::FunctionBenchmark(#n, n)))
 
 // Old-style macros
 #define BENCHMARK_WITH_ARG(n, a) BENCHMARK(n)->Arg((a))
@@ -548,10 +549,11 @@ protected:
       (::benchmark::internal::RegisterBenchmarkInternal( \
         new ::benchmark::internal::FunctionBenchmark(#n "<" #a ">", n<a>)))
 
-#define BENCHMARK_TEMPLATE2(n, a, b) \
-  BENCHMARK_PRIVATE_DECLARE(n) =     \
+#define BENCHMARK_TEMPLATE2(n, a, b)                     \
+  BENCHMARK_PRIVATE_DECLARE(n) =                         \
       (::benchmark::internal::RegisterBenchmarkInternal( \
-        new ::benchmark::internal::FunctionBenchmark(#n "<" #a "," #b ">", n<a, b>)))
+        new ::benchmark::internal::FunctionBenchmark(    \
+            #n "<" #a "," #b ">", n<a, b>)))
 
 #if __cplusplus >= 201103L
 #define BENCHMARK_TEMPLATE(n, ...)           \
@@ -564,17 +566,18 @@ protected:
 #endif
 
 
-#define BENCHMARK_PRIVATE_DECLARE_F(BaseClass, Method) \
+#define BENCHMARK_PRIVATE_DECLARE_F(BaseClass, Method)      \
 class BaseClass##_##Method##_Benchmark : public BaseClass { \
-public:\
-    BaseClass##_##Method##_Benchmark() : BaseClass() {this->SetName(#BaseClass "/" #Method);} \
-protected: \
-    virtual void TestCase(::benchmark::State&); \
+public:                                                     \
+    BaseClass##_##Method##_Benchmark() : BaseClass() {      \
+        this->SetName(#BaseClass "/" #Method);}             \
+protected:                                                  \
+    virtual void BenchmarkCase(::benchmark::State&);        \
 };
 
 #define BENCHMARK_DEFINE_F(BaseClass, Method) \
     BENCHMARK_PRIVATE_DECLARE_F(BaseClass, Method) \
-    void BaseClass##_##Method##_Benchmark::TestCase
+    void BaseClass##_##Method##_Benchmark::BenchmarkCase
 
 #define BENCHMARK_REGISTER_F(BaseClass, Method) \
     BENCHMARK_PRIVATE_REGISTER_F(BaseClass##_##Method##_Benchmark)
@@ -587,7 +590,7 @@ protected: \
 #define BENCHMARK_F(BaseClass, Method) \
     BENCHMARK_PRIVATE_DECLARE_F(BaseClass, Method) \
     BENCHMARK_REGISTER_F(BaseClass, Method); \
-    void BaseClass##_##Method##_Benchmark::TestCase
+    void BaseClass##_##Method##_Benchmark::BenchmarkCase
 
 
 // Helper macro to create a main routine in a test that runs the benchmarks

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -169,6 +169,7 @@ void RunSpecifiedBenchmarks(BenchmarkReporter* reporter);
 namespace internal {
 class Benchmark;
 class BenchmarkImp;
+class BenchmarkFamilies;
 
 template <class T> struct Voider {
     typedef void type;
@@ -184,7 +185,10 @@ struct EnableIfString<T, typename Voider<typename T::basic_string>::type> {
 
 void UseCharPointer(char const volatile*);
 
+Benchmark* RegisterBenchmarkInternal(Benchmark*);
+
 } // end namespace internal
+
 
 // The DoNotOptimize(...) function can be used to prevent a value or
 // expression from being optimized away by the compiler. This function is
@@ -372,9 +376,9 @@ typedef void(Function)(State&);
 // chained into one expression.
 class Benchmark {
  public:
-  Benchmark(const char* name, Function* f);
+  Benchmark(const char* name);
 
-  ~Benchmark();
+  virtual ~Benchmark();
 
   // Note: the following methods all return "this" so that multiple
   // method calls can be chained together in one expression.
@@ -445,15 +449,71 @@ class Benchmark {
   // Equivalent to ThreadRange(NumCPUs(), NumCPUs())
   Benchmark* ThreadPerCpu();
 
+  virtual void Run(State& state) = 0;
+
   // Used inside the benchmark implementation
   struct Instance;
 
- private:
-   BenchmarkImp* imp_;
-   BENCHMARK_DISALLOW_COPY_AND_ASSIGN(Benchmark);
+protected:
+   Benchmark(Benchmark const&);
+   void SetName(const char* name);
+
+private:
+  friend class BenchmarkFamilies;
+  BenchmarkImp* imp_;
+
+  Benchmark& operator=(Benchmark const&);
+};
+
+// The class used to hold all Benchmarks created from static function.
+// (ie those created using the BENCHMARK(...) macros.
+class FunctionBenchmark : public Benchmark {
+public:
+    FunctionBenchmark(const char* name, Function* func)
+        : Benchmark(name), func_(func)
+    {}
+
+    virtual void Run(State& st);
+private:
+    Function* func_;
 };
 
 }  // end namespace internal
+
+// The base class for all fixture tests. Fixture tests are created by
+// first defining a type that derives from ::benchmark::Fixture and then
+// creating/registering the tests using the following macros:
+//
+// * BENCHMARK_F(ClassName, Method)
+// * BENCHMARK_DEFINE_F(ClassName, Method)
+// * BENCHMARK_REGISTER_F(ClassName, Method)
+//
+// For Example:
+//
+// class MyFixture : public benchmark::Fixture {};
+//
+// BENCHMARK_F(MyFixture, FooTest)(benchmark::State& st) {
+//    while (st.KeepRunning()) {
+//      ...
+//    }
+// }
+class Fixture: public internal::Benchmark {
+public:
+    Fixture() : internal::Benchmark("") {}
+
+    virtual void Run(State& st) {
+      this->SetUp();
+      this->TestCase(st);
+      this->TearDown();
+    }
+
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+
+protected:
+    virtual void TestCase(State&) = 0;
+};
+
 }  // end namespace benchmark
 
 
@@ -480,7 +540,8 @@ class Benchmark {
   BENCHMARK_PRIVATE_NAME(n) BENCHMARK_UNUSED
 
 #define BENCHMARK(n) \
-    BENCHMARK_PRIVATE_DECLARE(n) = (new ::benchmark::internal::Benchmark(#n, n))
+    BENCHMARK_PRIVATE_DECLARE(n) = (::benchmark::internal::RegisterBenchmarkInternal( \
+        new ::benchmark::internal::FunctionBenchmark(#n, n)))
 
 // Old-style macros
 #define BENCHMARK_WITH_ARG(n, a) BENCHMARK(n)->Arg((a))
@@ -499,20 +560,65 @@ class Benchmark {
 // will register BM_Foo<1> as a benchmark.
 #define BENCHMARK_TEMPLATE1(n, a) \
   BENCHMARK_PRIVATE_DECLARE(n) =  \
-      (new ::benchmark::internal::Benchmark(#n "<" #a ">", n<a>))
+      (::benchmark::internal::RegisterBenchmarkInternal( \
+        new ::benchmark::internal::FunctionBenchmark(#n "<" #a ">", n<a>)))
 
 #define BENCHMARK_TEMPLATE2(n, a, b) \
   BENCHMARK_PRIVATE_DECLARE(n) =     \
-      (new ::benchmark::internal::Benchmark(#n "<" #a "," #b ">", n<a, b>))
+      (::benchmark::internal::RegisterBenchmarkInternal( \
+        new ::benchmark::internal::FunctionBenchmark(#n "<" #a "," #b ">", n<a, b>)))
 
 #if __cplusplus >= 201103L
 #define BENCHMARK_TEMPLATE(n, ...)           \
   BENCHMARK_PRIVATE_DECLARE(n) =             \
-      (new ::benchmark::internal::Benchmark( \
-        #n "<" #__VA_ARGS__ ">", n<__VA_ARGS__>))
+      (::benchmark::internal::RegisterBenchmarkInternal( \
+        new ::benchmark::internal::FunctionBenchmark( \
+        #n "<" #__VA_ARGS__ ">", n<__VA_ARGS__>)))
 #else
 #define BENCHMARK_TEMPLATE(n, a) BENCHMARK_TEMPLATE1(n, a)
 #endif
+
+
+#define BENCHMARK_PRIVATE_DECLARE_F(BaseClass, Method) \
+class BaseClass##_##Method##_Test : public BaseClass { \
+public:\
+    BaseClass##_##Method##_Test() : BaseClass() {this->SetName(#BaseClass "/" #Method);} \
+protected: \
+    virtual void TestCase(::benchmark::State&); \
+};
+
+// The BENCHMARK_DEFINE_F(...) and BENCHMARK_REGISTER_F(...) macros are used
+// to define and register new fixture benchmarks in two steps.
+// Example:
+//
+// class MyFixture : public ::benchmark::Fixture {};
+//
+// BENCHMARK_DEFINE_F(MyFixture, Method)(benchmark::State& st) {
+//    while(st.KeepRunning()) {
+//        ...
+//    }
+// }
+// /* the test is not registered. */
+// BENCHMARK_REGISTER_F(MyFixture, Method)->Arg(42);
+// /* the test is now registered */
+#define BENCHMARK_DEFINE_F(BaseClass, Method) \
+    BENCHMARK_PRIVATE_DECLARE_F(BaseClass, Method) \
+    void BaseClass##_##Method##_Test::TestCase
+
+#define BENCHMARK_REGISTER_F(BaseClass, Method) \
+    BENCHMARK_PRIVATE_REGISTER_F(BaseClass##_##Method##_Test)
+
+#define BENCHMARK_PRIVATE_REGISTER_F(TestName) \
+    BENCHMARK_PRIVATE_DECLARE(TestName) = \
+        (::benchmark::internal::RegisterBenchmarkInternal(new TestName()))
+
+// This function will define and register a benchmark within a fixture class.
+// See Fixture for more information.
+#define BENCHMARK_F(BaseClass, Method) \
+    BENCHMARK_PRIVATE_DECLARE_F(BaseClass, Method) \
+    BENCHMARK_REGISTER_F(BaseClass, Method); \
+    void BaseClass##_##Method##_Test::TestCase
+
 
 // Helper macro to create a main routine in a test that runs the benchmarks
 #define BENCHMARK_MAIN()                             \

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -289,7 +289,7 @@ class BenchmarkFamilies {
 
 class BenchmarkImp {
 public:
-  BenchmarkImp(const char* name);
+  explicit BenchmarkImp(const char* name);
   ~BenchmarkImp();
 
   void Arg(int x);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,9 @@ add_test(options_benchmarks options_test --benchmark_min_time=0.01)
 compile_benchmark_test(basic_test)
 add_test(basic_benchmark basic_test --benchmark_min_time=0.01)
 
+compile_benchmark_test(fixture_test)
+add_test(fixture_test fixture_test --benchmark_min_time=0.01)
+
 compile_benchmark_test(cxx03_test)
 set_target_properties(cxx03_test
     PROPERTIES COMPILE_FLAGS "${CXX03_FLAGS}")

--- a/test/fixture_test.cc
+++ b/test/fixture_test.cc
@@ -1,0 +1,22 @@
+
+#include "benchmark/benchmark.h"
+
+class MyFixture : public ::benchmark::Fixture
+{
+};
+
+
+BENCHMARK_F(MyFixture, Foo)(benchmark::State& st) {
+    while (st.KeepRunning()) {
+    }
+}
+
+BENCHMARK_DEFINE_F(MyFixture, Bar)(benchmark::State& st) {
+  while (st.KeepRunning()) {
+  }
+  st.SetItemsProcessed(st.range_x());
+}
+BENCHMARK_REGISTER_F(MyFixture, Bar)->Arg(42);
+
+
+BENCHMARK_MAIN()

--- a/test/fixture_test.cc
+++ b/test/fixture_test.cc
@@ -1,12 +1,32 @@
 
 #include "benchmark/benchmark.h"
 
+#include <cassert>
+
 class MyFixture : public ::benchmark::Fixture
 {
+public:
+    void SetUp() {
+        data = new int(42);
+    }
+
+    void TearDown() {
+        assert(data != nullptr);
+        delete data;
+        data = nullptr;
+    }
+
+    ~MyFixture() {
+      assert(data == nullptr);
+    }
+
+    int* data;
 };
 
 
 BENCHMARK_F(MyFixture, Foo)(benchmark::State& st) {
+    assert(data != nullptr);
+    assert(*data == 42);
     while (st.KeepRunning()) {
     }
 }


### PR DESCRIPTION
This patch implements #109. It adds the ability to create and use benchmarks that derive from test fixtures.