### PR TITLE
Add Value-Parameterized Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,25 @@ BENCHMARK_REGISTER_F(MyFixture, BarTest)->Threads(2);
 /* BarTest is now registered */
 ```
 
+Value Benchmarks
+-------------------
+Value benchmarks let you pass an arbitrary number of extra arguments to a
+benchmark test. The value of these extra arguments is specified when the
+benchmark is created. Use the `BENCHMARK_V(...)` macro to create value
+benchmarks.
+NOTE: Value benchmarks are only enabled in C++11 and beyond.
+
+```c++
+std::vector<int> test_vector1 = {1, 2, 3};
+
+void BM_find_in(benchmark::State&, std::vector<int>& cont, int value) {
+    while (st.KeepRunning()) {
+         DoNotOptimize(std::find(cont.begin(), cont.end(), value));
+    }
+}
+BENCHMARK_V(BM_find_in, test_vector1, 42);
+```
+
 Output Formats
 --------------
 The library supports multiple output formats. Use the

--- a/README.md
+++ b/README.md
@@ -216,13 +216,16 @@ NOTE: Value benchmarks are only enabled in C++11 and beyond.
 
 ```c++
 std::vector<int> test_vector1 = {1, 2, 3};
+std::vector<int> test_vector2 = {3, 4, 5};
 
-void BM_find_in(benchmark::State&, std::vector<int>& cont, int value) {
+void BM_find_in(benchmark::State&, std::vector<int>& cont, std::vector<int> const& values) {
     while (st.KeepRunning()) {
-         DoNotOptimize(std::find(cont.begin(), cont.end(), value));
+         for (auto value : values) {
+            DoNotOptimize(std::find(cont.begin(), cont.end(), value));
+        }
     }
 }
-BENCHMARK_V(BM_find_in, test_vector1, 42);
+BENCHMARK_V(BM_find_in, test_vector1, test_vector2);
 ```
 
 Output Formats

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -17,5 +17,8 @@
 #include "macros.h"
 #include "benchmark_api.h"
 #include "reporter.h"
+#if __cplusplus >= 201103L
+#include "value_benchmark.h"
+#endif
 
 #endif // BENCHMARK_BENCHMARK_H_

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -192,6 +192,12 @@ Benchmark* RegisterBenchmarkInternal(Benchmark*);
 } // end namespace internal
 
 
+template <class Tp>
+internal::Benchmark* RegisterBenchmark(Tp const& bench) {
+    Tp* new_bench = new Tp(bench);
+    return internal::RegisterBenchmarkInternal(new_bench);
+}
+
 // The DoNotOptimize(...) function can be used to prevent a value or
 // expression from being optimized away by the compiler. This function is
 // intented to add little to no overhead.

--- a/include/benchmark/value_benchmark.h
+++ b/include/benchmark/value_benchmark.h
@@ -1,0 +1,139 @@
+#ifndef BENCHMARK_VALUE_BENCHMARK_H
+#define BENCHMARK_VALUE_BENCHMARK_H
+
+#if __cplusplus < 201103L
+#error Variable benchmarks can only be used in C++ >= 11
+#endif
+
+#include "macros.h"
+#include "benchmark_api.h"
+
+#include <functional>
+#include <tuple>
+#include <utility>
+
+
+namespace benchmark {
+namespace internal {
+
+template <class T, T ...Indexes>
+struct IntegerSequence {
+    typedef IntegerSequence type;
+};
+
+template <std::size_t ...Indexes>
+using IndexSequence = IntegerSequence<std::size_t, Indexes...>;
+
+////////////////////////////////////////////////////////////////////////
+template <class LHS, class RHS>
+struct integer_seq_join;
+
+template <class T, T ...Vs0, T ...Vs1>
+struct integer_seq_join<
+      IntegerSequence<T, Vs0...>
+    , IntegerSequence<T, Vs1...>
+    >
+{
+    using type = IntegerSequence<T, Vs0..., (Vs1 + sizeof...(Vs0))...>;
+};
+
+////////////////////////////////////////////////////////////////////////
+template <class T, std::size_t N>
+struct integer_seq_impl
+    : integer_seq_join<
+        typename integer_seq_impl<T, (N / 2)>::type
+      , typename integer_seq_impl<T, (N - (N/2))>::type
+      >
+{};
+
+template <class T>
+struct integer_seq_impl<T, 0>
+{
+    using type = IntegerSequence<T>;
+};
+
+template <class T>
+struct integer_seq_impl<T, 1>
+{
+    using type = IntegerSequence<T, 0>;
+};
+
+template <std::size_t N>
+using MakeIndexSequence = typename integer_seq_impl<std::size_t, N>::type;
+
+#define BENCHMARK_AUTO_RETURN(...) \
+  -> decltype(__VA_ARGS__) { return __VA_ARGS__; }
+
+template <class Fn, class Tuple, std::size_t ...Id>
+inline
+auto ApplyTupleImp(Fn && f, Tuple && t, IndexSequence<Id...>)
+BENCHMARK_AUTO_RETURN(
+    std::forward<Fn>(f)(std::get<Id>(std::forward<Tuple>(t))...)
+)
+
+template <class Fn, class Tuple>
+inline
+auto ApplyTuple(Fn && f, Tuple && t)
+BENCHMARK_AUTO_RETURN(
+    ::benchmark::internal::ApplyTupleImp(
+        std::forward<Fn>(f), std::forward<Tuple>(t),
+        MakeIndexSequence<
+            std::tuple_size<typename std::decay<Tuple>::type>::value
+        >())
+)
+
+#undef BENCHMARK_AUTO_RETURN
+
+} // end namespace internal
+
+
+template <class Fn>
+class ValueFunctionBenchmark;
+
+template <class ...Args>
+class ValueFunctionBenchmark<void(State&, Args...)>
+    : public internal::Benchmark
+{
+public:
+    template <class Fn, class ...Args2>
+    ValueFunctionBenchmark(const char* name, Fn fn, Args2&&... args2)
+        : internal::Benchmark(name), func_(fn),
+          args_(std::forward<Args2&&>(args2)...)
+    {}
+
+    virtual void Run(State& st) {
+        ::benchmark::internal::ApplyTuple(
+            func_, std::tuple_cat(std::forward_as_tuple(st), args_)
+        );
+    }
+
+private:
+    using Func = void(State&, Args...);
+    using TupleT = std::tuple<typename std::decay<Args>::type...>;
+    std::function<Func> func_;
+    TupleT args_;
+};
+
+template <class Fn, class ...Args>
+inline
+internal::Benchmark* CreateValueBenchmark(const char* name,
+    Fn && func, Args&&... args)
+{
+    using Func = typename std::remove_pointer<
+                    typename std::remove_reference<Fn>::type
+                >::type;
+    auto bench = new ValueFunctionBenchmark<Func>(
+                        name, std::forward<Func>(func),
+                        std::forward<Args>(args)...);
+    return internal::RegisterBenchmarkInternal(bench);
+}
+
+} // namespace benchmark
+
+#define BENCHMARK_V(fn, ...)                   \
+    BENCHMARK_PRIVATE_DECLARE(fn) =            \
+        (::benchmark::CreateValueBenchmark( \
+            #fn "<" #__VA_ARGS__ ">", fn, __VA_ARGS__))
+
+
+#endif // BENCHMARK_VALUE_BENCHMARK_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,12 @@ add_test(basic_benchmark basic_test --benchmark_min_time=0.01)
 compile_benchmark_test(fixture_test)
 add_test(fixture_test fixture_test --benchmark_min_time=0.01)
 
+if (HAVE_FLAG_CXX_11)
+  compile_benchmark_test(value_test)
+  add_test(value_test value_test --benchmark_min_time=0.01)
+endif()
+
+
 compile_benchmark_test(cxx03_test)
 set_target_properties(cxx03_test
     PROPERTIES COMPILE_FLAGS "${CXX03_FLAGS}")

--- a/test/fixture_test.cc
+++ b/test/fixture_test.cc
@@ -39,7 +39,4 @@ BENCHMARK_DEFINE_F(MyFixture, Bar)(benchmark::State& st) {
 BENCHMARK_REGISTER_F(MyFixture, Bar)->Arg(42);
 
 
-
-
-
 BENCHMARK_MAIN()

--- a/test/fixture_test.cc
+++ b/test/fixture_test.cc
@@ -39,4 +39,7 @@ BENCHMARK_DEFINE_F(MyFixture, Bar)(benchmark::State& st) {
 BENCHMARK_REGISTER_F(MyFixture, Bar)->Arg(42);
 
 
+
+
+
 BENCHMARK_MAIN()

--- a/test/value_test.cc
+++ b/test/value_test.cc
@@ -1,0 +1,22 @@
+#include "benchmark/benchmark.h"
+
+#include <cassert>
+
+void BM_one(benchmark::State& st, int x) {
+    assert(x == 42);
+    ((void)x);
+    while (st.KeepRunning()) {}
+}
+BENCHMARK_V(BM_one, 42);
+
+
+void BM_two(benchmark::State& st, int x, int y) {
+    assert(x == 42);
+    ((void)x);
+    assert(x +1 == y);
+    ((void)y);
+    while (st.KeepRunning()) {}
+}
+BENCHMARK_V(BM_two, 42, 43);
+
+BENCHMARK_MAIN()

--- a/test/value_test.cc
+++ b/test/value_test.cc
@@ -1,6 +1,8 @@
 #include "benchmark/benchmark.h"
 
 #include <cassert>
+#include <algorithm>
+#include <vector>
 
 void BM_one(benchmark::State& st, int x) {
     assert(x == 42);
@@ -18,5 +20,12 @@ void BM_two(benchmark::State& st, int x, int y) {
     while (st.KeepRunning()) {}
 }
 BENCHMARK_V(BM_two, 42, 43);
+
+void BM_vector_find(benchmark::State& st, std::vector<int> const& v, int x) {
+    while (st.KeepRunning()) {
+        benchmark::DoNotOptimize(std::find(v.begin(), v.end(), x));
+    }
+}
+BENCHMARK_V(BM_vector_find, std::vector<int>({1, 2, 3, 4}), 5);
 
 BENCHMARK_MAIN()


### PR DESCRIPTION
This patch adds value-parameterized benchmarks. These benchmarks accept any number of arguments after the first State argument. The value for these arguments are set when the benchmark is created.

