### PR TITLE
Auto-detect whether Benchmark should produce colorized output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,6 +24,7 @@ Jussi Knuuttila <jussi.knuuttila@gmail.com>
 Kaito Udagawa <umireon@gmail.com>
 Lei Xu <eddyxu@gmail.com>
 Matt Clarkson <mattyclarkson@gmail.com>
+Nick Hutchinson <nshutchinson@gmail.com>
 Oleksandr Sochka <sasha.sochka@gmail.com>
 Paul Redmond <paul.redmond@gmail.com>
 Radoslav Yovchev <radoslav.tm@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -40,6 +40,7 @@ Kaito Udagawa <umireon@gmail.com>
 Kai Wolf <kai.wolf@gmail.com>
 Lei Xu <eddyxu@gmail.com>
 Matt Clarkson <mattyclarkson@gmail.com>
+Nick Hutchinson <nshutchinson@gmail.com>
 Oleksandr Sochka <sasha.sochka@gmail.com>
 Pascal Leroy <phl@google.com>
 Paul Redmond <paul.redmond@gmail.com>

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -34,6 +34,7 @@
 #include <thread>
 
 #include "check.h"
+#include "colorprint.h"
 #include "commandlineflags.h"
 #include "complexity.h"
 #include "log.h"
@@ -82,7 +83,12 @@ DEFINE_string(benchmark_out_format, "json",
 
 DEFINE_string(benchmark_out, "", "The file to write additonal output to");
 
-DEFINE_bool(color_print, true, "Enables colorized logging.");
+DEFINE_string(benchmark_color, "auto",
+              "Whether to use colors in the output.  Valid values: "
+              "'true'/'yes'/1, 'false'/'no'/0, and 'auto'. 'auto' means to use "
+              "colors if the output is being sent to a terminal and the TERM "
+              "environment variable is set to a terminal type that supports "
+              "colors.");
 
 DEFINE_int32(v, 0, "The level of verbose logging to output");
 
@@ -532,8 +538,14 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* console_reporter,
   std::unique_ptr<BenchmarkReporter> default_console_reporter;
   std::unique_ptr<BenchmarkReporter> default_file_reporter;
   if (!console_reporter) {
-    auto output_opts = FLAGS_color_print ? ConsoleReporter::OO_Color
-                                          : ConsoleReporter::OO_None;
+    auto output_opts = ConsoleReporter::OO_None;
+    if (FLAGS_benchmark_color == "auto")
+      output_opts = IsColorTerminal() ? ConsoleReporter::OO_Color
+                                      : ConsoleReporter::OO_None;
+    else
+      output_opts = IsTruthyFlagValue(FLAGS_benchmark_color)
+                        ? ConsoleReporter::OO_Color
+                        : ConsoleReporter::OO_None;
     default_console_reporter = internal::CreateReporter(
           FLAGS_benchmark_format, output_opts);
     console_reporter = default_console_reporter.get();
@@ -588,7 +600,7 @@ void PrintUsageAndExit() {
           "          [--benchmark_format=<console|json|csv>]\n"
           "          [--benchmark_out=<filename>]\n"
           "          [--benchmark_out_format=<json|console|csv>]\n"
-          "          [--color_print={true|false}]\n"
+          "          [--benchmark_color={auto|true|false}]\n"
           "          [--v=<verbosity>]\n");
   exit(0);
 }
@@ -613,8 +625,12 @@ void ParseCommandLineFlags(int* argc, char** argv) {
                         &FLAGS_benchmark_out) ||
         ParseStringFlag(argv[i], "benchmark_out_format",
                         &FLAGS_benchmark_out_format) ||
-        ParseBoolFlag(argv[i], "color_print",
-                       &FLAGS_color_print) ||
+        ParseStringFlag(argv[i], "benchmark_color",
+                        &FLAGS_benchmark_color) ||
+        // "color_print" is the deprecated name for "benchmark_color".
+        // TODO: Remove this.
+        ParseStringFlag(argv[i], "color_print",
+                        &FLAGS_benchmark_color) ||
         ParseInt32Flag(argv[i], "v", &FLAGS_v)) {
       for (int j = i; j != *argc; ++j) argv[j] = argv[j + 1];
 
@@ -627,6 +643,9 @@ void ParseCommandLineFlags(int* argc, char** argv) {
   for (auto const* flag : {&FLAGS_benchmark_format,
                            &FLAGS_benchmark_out_format})
   if (*flag != "console" && *flag != "json" && *flag != "csv") {
+    PrintUsageAndExit();
+  }
+  if (FLAGS_benchmark_color.empty()) {
     PrintUsageAndExit();
   }
 }

--- a/src/colorprint.h
+++ b/src/colorprint.h
@@ -23,6 +23,10 @@ std::string FormatString(const char* msg, ...);
 void ColorPrintf(std::ostream& out, LogColor color, const char* fmt, va_list args);
 void ColorPrintf(std::ostream& out, LogColor color, const char* fmt, ...);
 
+// Returns true if stdout appears to be a terminal that supports colored
+// output, false otherwise.
+bool IsColorTerminal();
+
 }  // end namespace benchmark
 
 #endif  // BENCHMARK_COLORPRINT_H_

--- a/src/commandlineflags.cc
+++ b/src/commandlineflags.cc
@@ -14,6 +14,7 @@
 
 #include "commandlineflags.h"
 
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
@@ -74,17 +75,6 @@ bool ParseDouble(const std::string& src_text, const char* str, double* value) {
   return true;
 }
 
-inline const char* GetEnv(const char* name) {
-#if defined(__BORLANDC__) || defined(__SunOS_5_8) || defined(__SunOS_5_9)
-  // Environment variables which we programmatically clear will be set to the
-  // empty string rather than unset (nullptr).  Handle that case.
-  const char* const env = getenv(name);
-  return (env != nullptr && env[0] != '\0') ? env : nullptr;
-#else
-  return getenv(name);
-#endif
-}
-
 // Returns the name of the environment variable corresponding to the
 // given flag.  For example, FlagToEnvVar("foo") will return
 // "BENCHMARK_FOO" in the open-source version.
@@ -104,7 +94,7 @@ static std::string FlagToEnvVar(const char* flag) {
 // The value is considered true iff it's not "0".
 bool BoolFromEnv(const char* flag, bool default_value) {
   const std::string env_var = FlagToEnvVar(flag);
-  const char* const string_value = GetEnv(env_var.c_str());
+  const char* const string_value = getenv(env_var.c_str());
   return string_value == nullptr ? default_value : strcmp(string_value, "0") != 0;
 }
 
@@ -113,7 +103,7 @@ bool BoolFromEnv(const char* flag, bool default_value) {
 // doesn't represent a valid 32-bit integer, returns default_value.
 int32_t Int32FromEnv(const char* flag, int32_t default_value) {
   const std::string env_var = FlagToEnvVar(flag);
-  const char* const string_value = GetEnv(env_var.c_str());
+  const char* const string_value = getenv(env_var.c_str());
   if (string_value == nullptr) {
     // The environment variable is not set.
     return default_value;
@@ -133,7 +123,7 @@ int32_t Int32FromEnv(const char* flag, int32_t default_value) {
 // the given flag; if it's not set, returns default_value.
 const char* StringFromEnv(const char* flag, const char* default_value) {
   const std::string env_var = FlagToEnvVar(flag);
-  const char* const value = GetEnv(env_var.c_str());
+  const char* const value = getenv(env_var.c_str());
   return value == nullptr ? default_value : value;
 }
 
@@ -175,7 +165,7 @@ bool ParseBoolFlag(const char* str, const char* flag, bool* value) {
   if (value_str == nullptr) return false;
 
   // Converts the string value to a bool.
-  *value = !(*value_str == '0' || *value_str == 'f' || *value_str == 'F');
+  *value = IsTruthyFlagValue(value_str);
   return true;
 }
 
@@ -216,5 +206,13 @@ bool ParseStringFlag(const char* str, const char* flag, std::string* value) {
 
 bool IsFlag(const char* str, const char* flag) {
   return (ParseFlagValue(str, flag, true) != nullptr);
+}
+
+bool IsTruthyFlagValue(const std::string& str) {
+  if (str.empty())
+    return true;
+  char ch = str[0];
+  return isalnum(ch) &&
+         !(ch == '0' || ch == 'f' || ch == 'F' || ch == 'n' || ch == 'N');
 }
 }  // end namespace benchmark

--- a/src/commandlineflags.h
+++ b/src/commandlineflags.h
@@ -38,8 +38,7 @@ const char* StringFromEnv(const char* flag, const char* default_val);
 // Parses a string for a bool flag, in the form of either
 // "--flag=value" or "--flag".
 //
-// In the former case, the value is taken as true as long as it does
-// not start with '0', 'f', or 'F'.
+// In the former case, the value is taken as true if it passes IsTruthyValue().
 //
 // In the latter case, the value is taken as true.
 //
@@ -71,6 +70,10 @@ bool ParseStringFlag(const char* str, const char* flag, std::string* value);
 // Returns true if the string matches the flag.
 bool IsFlag(const char* str, const char* flag);
 
+// Returns true unless value starts with one of: '0', 'f', 'F', 'n' or 'N', or
+// some non-alphanumeric character. As a special case, also returns true if
+// value is the empty string.
+bool IsTruthyFlagValue(const std::string& value);
 }  // end namespace benchmark
 
 #endif  // BENCHMARK_COMMANDLINEFLAGS_H_


### PR DESCRIPTION
Attached is a patch that makes Benchmark only produce colorized output
if stdout is a TTY. (This can be overridden with --color-print=true.)

The logic for deciding whether to use colorized output was lifted from
GTest: <https://code.google.com/p/googletest/source/browse/trunk/src/gtest.cc#2872>.

I haven't got a Windows system to test my changes on, but I see from #7
that there's more work to be done here anyway, so hopefully that's okay!