### PR TITLE
Fix the compilation error against G++ on Mac OS X.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ Evgeny Safronov <division494@gmail.com>
 Felix Homann <linuxaudio@showlabor.de>
 Google Inc.
 JianXiong Zhou <zhoujianxiong2@gmail.com>
+Kaito Udagawa <umireon@gmail.com>
 Lei Xu <eddyxu@gmail.com>
 Matt Clarkson <mattyclarkson@gmail.com>
 Oleksandr Sochka <sasha.sochka@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -31,6 +31,7 @@ Eugene Zhuk <eugene.zhuk@gmail.com>
 Evgeny Safronov <division494@gmail.com>
 Felix Homann <linuxaudio@showlabor.de>
 JianXiong Zhou <zhoujianxiong2@gmail.com>
+Kaito Udagawa <umireon@gmail.com>
 Lei Xu <eddyxu@gmail.com>
 Matt Clarkson <mattyclarkson@gmail.com>
 Oleksandr Sochka <sasha.sochka@gmail.com>

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -267,7 +267,7 @@ void InitializeSystemInfo() {
   int num_cpus = 0;
   size_t size = sizeof(num_cpus);
   int numcpus_name[] = {CTL_HW, HW_NCPU};
-  if (::sysctl(numcpus_name, arraysize(numcpus_name), &num_cpus, &size, 0, 0) ==
+  if (::sysctl(numcpus_name, arraysize(numcpus_name), &num_cpus, &size, nullptr, 0) ==
           0 &&
       (size == sizeof(num_cpus)))
     cpuinfo_num_cpus = num_cpus;


### PR DESCRIPTION
Fixes #129

Using `0` as a null pointer is illegal when `-Wzero-as-null-pointer-constant` is given to G++. 
To avoid the warning `zero-as-null-pointer-constant`, `nullptr` (C++11 keyword) instead of `0` is used in the `sysctl` invocation.