### PR TITLE
Fix the compiling error under XCode 6 in release mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,4 @@ Oleksandr Sochka <sasha.sochka@gmail.com>
 Paul Redmond <paul.redmond@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
+Pierre Dulac <dulacpier@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -40,3 +40,4 @@ Paul Redmond <paul.redmond@gmail.com>
 Pierre Phaneuf <pphaneuf@google.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
+Pierre Dulac <dulacpier@gmail.com>

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -697,7 +697,7 @@ void RunBenchmark(const benchmark::internal::Benchmark::Instance& b,
         report.benchmark_name = b.name;
         report.report_label = label;
         // Report the total iterations across all threads.
-        report.iterations = static_cast<int64_t>(iters) * b.threads;
+        report.iterations = static_cast<size_t>(static_cast<int64_t>(iters) * b.threads);
         report.real_accumulated_time = real_accumulated_time;
         report.cpu_accumulated_time = cpu_accumulated_time;
         report.bytes_per_second = bytes_per_second;


### PR DESCRIPTION
The implicit cast throws a compiler error because of loosing integer precision, under Xcode 6 in Release mode.

```txt
benchmark.cc:700:57: Implicit conversion loses integer precision: 'long long' to 'size_t' (aka 'unsigned long')
```

Cheers