### PR TITLE
Updates Initialize() to work with an argv as 'char**'

### DIFF
--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -151,7 +151,7 @@ BENCHMARK(BM_MultiThreaded)->Threads(4);
 namespace benchmark {
 class BenchmarkReporter;
 
-void Initialize(int* argc, const char** argv);
+void Initialize(int* argc, char** argv);
 
 // Otherwise, run all benchmarks specified by the --benchmark_filter flag,
 // and exit after running the benchmarks.
@@ -593,10 +593,10 @@ protected:                                                  \
 
 
 // Helper macro to create a main routine in a test that runs the benchmarks
-#define BENCHMARK_MAIN()                             \
-  int main(int argc, const char** argv) {            \
-    ::benchmark::Initialize(&argc, argv);            \
-    ::benchmark::RunSpecifiedBenchmarks();           \
+#define BENCHMARK_MAIN()                   \
+  int main(int argc, char** argv) {        \
+    ::benchmark::Initialize(&argc, argv);  \
+    ::benchmark::RunSpecifiedBenchmarks(); \
   }
 
 #endif  // BENCHMARK_BENCHMARK_API_H_

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -863,7 +863,7 @@ void PrintUsageAndExit() {
   exit(0);
 }
 
-void ParseCommandLineFlags(int* argc, const char** argv) {
+void ParseCommandLineFlags(int* argc, char** argv) {
   using namespace benchmark;
   for (int i = 1; i < *argc; ++i) {
     if (
@@ -904,7 +904,7 @@ Benchmark* RegisterBenchmarkInternal(Benchmark* bench) {
 
 } // end namespace internal
 
-void Initialize(int* argc, const char** argv) {
+void Initialize(int* argc, char** argv) {
   internal::ParseCommandLineFlags(argc, argv);
   internal::SetLogLevel(FLAGS_v);
   // TODO remove this. It prints some output the first time it is called.

--- a/test/filter_test.cc
+++ b/test/filter_test.cc
@@ -67,7 +67,7 @@ BENCHMARK(BM_FooBa);
 
 
 
-int main(int argc, const char* argv[]) {
+int main(int argc, char* argv[]) {
   benchmark::Initialize(&argc, argv);
 
   TestReporter test_reporter;
@@ -82,4 +82,3 @@ int main(int argc, const char* argv[]) {
     return -1;
   }
 }
-


### PR DESCRIPTION
This change was created to fix https://github.com/google/benchmark/issues/142. The issue is that the main() function should be declared like `int main(int argc, char* argv[])`, i.e., argv should be an array of pointers to **non-const** char. See http://en.cppreference.com/w/cpp/language/main_function

> ...
>  The strings are modifiable
> ...

Previously the `benchmark::Initialize()` function expected an argv that was declared as `const char* argv[]`, which doesn't match how `main()` should be declared. This issue could be avoided by simply declaring main with an argv array of pointers to const char. However, that workaround would cause other problems such as when using the [Google Test library](https://github.com/google/googletest), which has its own initialization function that expects the correct signature for argv.

I think the best solution is to change `benchmark::Initialize()`'s signature.