### PR TITLE
Fix issue #141. Use size_t instead of int for the iteration count

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -596,7 +596,7 @@ namespace {
 // Execute one thread of benchmark b for the specified number of iterations.
 // Adds the stats collected for the thread into *total.
 void RunInThread(const benchmark::internal::Benchmark::Instance* b,
-                 int iters, int thread_id,
+                 size_t iters, int thread_id,
                  ThreadStats* total) EXCLUDES(GetBenchmarkLock()) {
   State st(iters, b->has_arg1, b->arg1, b->has_arg2, b->arg2, thread_id);
   b->benchmark->Run(st);
@@ -613,7 +613,7 @@ void RunInThread(const benchmark::internal::Benchmark::Instance* b,
 
 void RunBenchmark(const benchmark::internal::Benchmark::Instance& b,
                   BenchmarkReporter* br) EXCLUDES(GetBenchmarkLock()) {
-  int iters = 1;
+  size_t iters = 1;
 
   std::vector<BenchmarkReporter::Run> reports;
 

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -101,7 +101,7 @@ bool IsZero(double n) {
 
 // For non-dense Range, intermediate values are powers of kRangeMultiplier.
 static const int kRangeMultiplier = 8;
-static const int kMaxIterations = 1000000000;
+static const size_t kMaxIterations = 1000000000;
 
 bool running_benchmark = false;
 

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -101,8 +101,7 @@ static void BM_Sequential(benchmark::State& state) {
     for (int i = state.range_x(); --i; )
       c.push_back(v);
   }
-  const int64_t items_processed =
-      static_cast<int64_t>(state.iterations()) * state.range_x();
+  const size_t items_processed = state.iterations() * state.range_x();
   state.SetItemsProcessed(items_processed);
   state.SetBytesProcessed(items_processed * sizeof(v));
 }


### PR DESCRIPTION
This patch fixes the warnings but there is still a bug where the iteration count cannot be greater that what is represented in an integer. This is because kMaxIterationCount is an int. We should fix that at some point. 