### PR TITLE
Fixes #144  CMake fails without Git 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,4 @@ Oleksandr Sochka <sasha.sochka@gmail.com>
 Paul Redmond <paul.redmond@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
+Dirac Research 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -40,3 +40,4 @@ Paul Redmond <paul.redmond@gmail.com>
 Pierre Phaneuf <pphaneuf@google.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
+Tobias Ulvgård <tobias.ulvgard@dirac.se>

--- a/cmake/GetGitVersion.cmake
+++ b/cmake/GetGitVersion.cmake
@@ -10,7 +10,8 @@
 # include(GetGitVersion)
 # get_git_version(GIT_VERSION)
 #
-# Requires CMake 2.6+
+# Requires CMake 2.8.11+
+find_package(Git)
 
 if(__get_git_version)
   return()
@@ -18,16 +19,21 @@ endif()
 set(__get_git_version INCLUDED)
 
 function(get_git_version var)
-  execute_process(COMMAND git describe --match "v[0-9]*.[0-9]*.[0-9]*" --abbrev=8
-      RESULT_VARIABLE status
-      OUTPUT_VARIABLE GIT_VERSION
-      ERROR_QUIET)
-  if(${status})
-      set(GIT_VERSION "v0.0.0")
+  if(GIT_EXECUTABLE)
+      execute_process(COMMAND git describe --match "v[0-9]*.[0-9]*.[0-9]*" --abbrev=8
+          RESULT_VARIABLE status
+          OUTPUT_VARIABLE GIT_VERSION
+          ERROR_QUIET)
+      if(${status})
+          set(GIT_VERSION "v0.0.0")
+      else()
+          string(STRIP ${GIT_VERSION} GIT_VERSION)
+          string(REGEX REPLACE "-[0-9]+-g" "-" GIT_VERSION ${GIT_VERSION})
+      endif()
   else()
-      string(STRIP ${GIT_VERSION} GIT_VERSION)
-      string(REGEX REPLACE "-[0-9]+-g" "-" GIT_VERSION ${GIT_VERSION})
+      set(GIT_VERSION "v0.0.0")
   endif()
+
 
   # Work out if the repository is dirty
   execute_process(COMMAND git update-index -q --refresh


### PR DESCRIPTION
With this patch GetGitVersion.cmake checks for the existance of Git before attempting to get Benchmark version from the logs. If Git is not found, the version is set to v0.0.0 as was the default behaviour of the script.