### PR TITLE
Android fix

### DIFF
--- a/src/commandlineflags.cc
+++ b/src/commandlineflags.cc
@@ -14,10 +14,10 @@
 
 #include "commandlineflags.h"
 
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <limits>
-#include <cstdlib>
 
 namespace benchmark {
 // Parses 'str' for a 32-bit signed integer.  If successful, writes

--- a/src/commandlineflags.cc
+++ b/src/commandlineflags.cc
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <iostream>
 #include <limits>
+#include <cstdlib>
 
 namespace benchmark {
 // Parses 'str' for a 32-bit signed integer.  If successful, writes

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -5,7 +5,6 @@
 #include <array>
 #include <memory>
 #include <sstream>
-
 #include <stdio.h>
 
 #include "arraysize.h"

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -128,7 +128,7 @@ std::string StringPrintFImp(const char *msg, va_list args)
   // allocation guess what the size might be
   std::array<char, 256> local_buff;
   std::size_t size = local_buff.size();
-  // 8/10/2015: vsnprintf is used instead of snd::vsnprintf due to a limitation in the android-ndk
+  // 2015-10-08: vsnprintf is used instead of snd::vsnprintf due to a limitation in the android-ndk
   auto ret = vsnprintf(local_buff.data(), size, msg, args_cp);
 
   va_end(args_cp);
@@ -143,7 +143,7 @@ std::string StringPrintFImp(const char *msg, va_list args)
   // add 1 to size to account for null-byte in size cast to prevent overflow
   size = static_cast<std::size_t>(ret) + 1;
   auto buff_ptr = std::unique_ptr<char[]>(new char[size]);
-  // 8/10/2015: vsnprintf is used instead of snd::vsnprintf due to a limitation in the android-ndk
+  // 2015-10-08: vsnprintf is used instead of snd::vsnprintf due to a limitation in the android-ndk
   ret = vsnprintf(buff_ptr.get(), size, msg, args);
   return std::string(buff_ptr.get());
 }

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -6,6 +6,8 @@
 #include <memory>
 #include <sstream>
 
+#include <stdio.h>
+
 #include "arraysize.h"
 
 namespace benchmark {
@@ -127,7 +129,7 @@ std::string StringPrintFImp(const char *msg, va_list args)
   // allocation guess what the size might be
   std::array<char, 256> local_buff;
   std::size_t size = local_buff.size();
-  auto ret = std::vsnprintf(local_buff.data(), size, msg, args_cp);
+  auto ret = vsnprintf(local_buff.data(), size, msg, args_cp);
 
   va_end(args_cp);
 
@@ -141,7 +143,7 @@ std::string StringPrintFImp(const char *msg, va_list args)
   // add 1 to size to account for null-byte in size cast to prevent overflow
   size = static_cast<std::size_t>(ret) + 1;
   auto buff_ptr = std::unique_ptr<char[]>(new char[size]);
-  ret = std::vsnprintf(buff_ptr.get(), size, msg, args);
+  ret = vsnprintf(buff_ptr.get(), size, msg, args);
   return std::string(buff_ptr.get());
 }
 

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -129,6 +129,7 @@ std::string StringPrintFImp(const char *msg, va_list args)
   // allocation guess what the size might be
   std::array<char, 256> local_buff;
   std::size_t size = local_buff.size();
+  // 8/10/2015: vsnprintf is used instead of snd::vsnprintf due to a limitation in the android-ndk
   auto ret = vsnprintf(local_buff.data(), size, msg, args_cp);
 
   va_end(args_cp);
@@ -143,6 +144,7 @@ std::string StringPrintFImp(const char *msg, va_list args)
   // add 1 to size to account for null-byte in size cast to prevent overflow
   size = static_cast<std::size_t>(ret) + 1;
   auto buff_ptr = std::unique_ptr<char[]>(new char[size]);
+  // 8/10/2015: vsnprintf is used instead of snd::vsnprintf due to a limitation in the android-ndk
   ret = vsnprintf(buff_ptr.get(), size, msg, args);
   return std::string(buff_ptr.get());
 }

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -25,7 +25,7 @@
 #include <sys/types.h> // this header must be included before 'sys/sysctl.h' to avoid compilation error on FreeBSD
 #include <sys/time.h>
 #include <unistd.h>
-#if defined OS_FREEBSD || defined OS_MACOSX
+#if defined BENCHMARK_OS_FREEBSD || defined BENCHMARK_OS_MACOSX
 #include <sys/sysctl.h>
 #endif
 #endif

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -23,9 +23,11 @@
 #include <fcntl.h>
 #include <sys/resource.h>
 #include <sys/types.h> // this header must be included before 'sys/sysctl.h' to avoid compilation error on FreeBSD
-#include <sys/sysctl.h>
 #include <sys/time.h>
 #include <unistd.h>
+#if defined OS_FREEBSD || defined OS_MACOSX
+#include <sys/sysctl.h>
+#endif
 #endif
 
 #include <cerrno>

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <stdint.h>
 
+#include <cstdlib>
 #include <iostream>
 #include <limits>
 #include <list>
@@ -13,7 +14,6 @@
 #include <sstream>
 #include <string>
 #include <vector>
-#include <cstdlib>
 
 #if defined(__GNUC__)
 # define BENCHMARK_NOINLINE __attribute__((noinline))

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <cstdlib>
 
 #if defined(__GNUC__)
 # define BENCHMARK_NOINLINE __attribute__((noinline))

--- a/test/filter_test.cc
+++ b/test/filter_test.cc
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 
 #include <iostream>
 #include <limits>
@@ -75,7 +76,7 @@ int main(int argc, char* argv[]) {
 
   // Make sure we ran all of the tests
   const size_t count = test_reporter.GetCount();
-  const size_t expected = (argc == 2) ? std::stoul(argv[1]) : count;
+  const size_t expected = (argc == 2) ? std::atol(argv[1]) : count;
   if (count != expected) {
     std::cerr << "ERROR: Expected " << expected << " tests to be ran but only "
               << count << " completed" << std::endl;

--- a/test/filter_test.cc
+++ b/test/filter_test.cc
@@ -74,12 +74,18 @@ int main(int argc, char* argv[]) {
   TestReporter test_reporter;
   benchmark::RunSpecifiedBenchmarks(&test_reporter);
 
-  // Make sure we ran all of the tests
-  const size_t count = test_reporter.GetCount();
-  const size_t expected = (argc == 2) ? std::atol(argv[1]) : count;
-  if (count != expected) {
-    std::cerr << "ERROR: Expected " << expected << " tests to be ran but only "
-              << count << " completed" << std::endl;
-    return -1;
+  if (argc == 2) {
+    // Make sure we ran all of the tests
+    std::stringstream ss(argv[1]);
+    size_t expected;
+    ss >> expected;
+
+    const size_t count = test_reporter.GetCount();
+    if (count != expected) {
+      std::cerr << "ERROR: Expected " << expected << " tests to be ran but only "
+                << count << " completed" << std::endl;
+      return -1;
+    }
   }
+  return 0;
 }


### PR DESCRIPTION
This patch makes it possible to build google-benchmark with the android-ndk.
A few of the fixes are questionable, like changing std::vsnprintf to just vsnprintf and std:stoul to std::atol but I have not found any better solution. The changes are needed due to limitations in Bionic (see: http://stackoverflow.com/questions/17950814/how-to-use-stdstoul-and-stdstoull-in-android).