### PR TITLE
Fix for Ubuntu & Clang & C++14

### DIFF
--- a/src/arraysize.h
+++ b/src/arraysize.h
@@ -1,8 +1,6 @@
 #ifndef BENCHMARK_ARRAYSIZE_H_
 #define BENCHMARK_ARRAYSIZE_H_
 
-#include <cstddef>
-
 #include "internal_macros.h"
 
 namespace benchmark {

--- a/test/basic_test.cc
+++ b/test/basic_test.cc
@@ -1,6 +1,4 @@
 
-#include <cstddef>
-
 #include "benchmark/benchmark_api.h"
 
 #define BASIC_BENCHMARK_TEST(x) \


### PR DESCRIPTION
On modern Ubuntu, there is an issue with certain versions of Clang (notably, but not only, Clang 3.4) and how it uses the headers of GCC 4.9. This comes up if one wants to use -std=c++14, something we've done for the DyND library (https://github.com/libdynd/libdynd). We also include Google Benchmark as a third-party library in DyND.

For reference to this bug, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=744792%E2%80%8B or http://askubuntu.com/questions/523613/upgrade-to-gcc-4-9-broke-clang

There are a couple of ways to fix this, but the easiest workaround is to be careful with how one includes `<cstddef>` or `<stddef.h>`. I removed two unneeded includes of this from Google Benchmark, and was able to make it usable again (woohoo!) on Ubuntu with Clang and C++14. Without doing this, Google Benchmark fails to compile with exactly the error in those bug reports.

Can we merge this? It's such a trivial change to get back a solid use case.