### PR TITLE
Fixes compilation issue on Macs

### DIFF
--- a/src/cycleclock.h
+++ b/src/cycleclock.h
@@ -26,7 +26,7 @@
 #include "benchmark/macros.h"
 #include "internal_macros.h"
 
-#if defined(OS_MACOSX)
+#if defined(BENCHMARK_OS_MACOSX)
 #include <mach/mach_time.h>
 #endif
 // For MSVC, we want to use '_asm rdtsc' when possible (since it works


### PR DESCRIPTION
ba141ac0d9f2 renamed OS_MACOSX -> BENCHMARK_OS_MACOSX,
except for an include guard in src/cycleclock.h