### PR TITLE
fix the calculation in SleepForMilliseconds

### DIFF
--- a/src/sleep.cc
+++ b/src/sleep.cc
@@ -40,7 +40,7 @@ void SleepForMicroseconds(int microseconds) {
 }
 
 void SleepForMilliseconds(int milliseconds) {
-  SleepForMicroseconds(static_cast<int>(milliseconds) * kNumMicrosPerMilli);
+  SleepForMicroseconds(static_cast<int>(milliseconds * kNumMicrosPerMilli));
 }
 
 void SleepForSeconds(double seconds) {


### PR DESCRIPTION
static_cast should be done after the multiplication operation. Otherwise the milliseconds is already an int.
