### PR TITLE
Fix get_git_version to use GIT_EXECUTABLE.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Paul Redmond <paul.redmond@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Dirac Research 
+Zbigniew Skowron <zbychs@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -41,3 +41,4 @@ Pierre Phaneuf <pphaneuf@google.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Tobias Ulvgård <tobias.ulvgard@dirac.se>
+Zbigniew Skowron <zbychs@gmail.com>

--- a/cmake/GetGitVersion.cmake
+++ b/cmake/GetGitVersion.cmake
@@ -20,7 +20,7 @@ set(__get_git_version INCLUDED)
 
 function(get_git_version var)
   if(GIT_EXECUTABLE)
-      execute_process(COMMAND git describe --match "v[0-9]*.[0-9]*.[0-9]*" --abbrev=8
+      execute_process(COMMAND ${GIT_EXECUTABLE} describe --match "v[0-9]*.[0-9]*.[0-9]*" --abbrev=8
           RESULT_VARIABLE status
           OUTPUT_VARIABLE GIT_VERSION
           ERROR_QUIET)
@@ -30,22 +30,22 @@ function(get_git_version var)
           string(STRIP ${GIT_VERSION} GIT_VERSION)
           string(REGEX REPLACE "-[0-9]+-g" "-" GIT_VERSION ${GIT_VERSION})
       endif()
+
+      # Work out if the repository is dirty
+      execute_process(COMMAND ${GIT_EXECUTABLE} update-index -q --refresh
+          OUTPUT_QUIET
+          ERROR_QUIET)
+      execute_process(COMMAND ${GIT_EXECUTABLE} diff-index --name-only HEAD --
+          OUTPUT_VARIABLE GIT_DIFF_INDEX
+          ERROR_QUIET)
+      string(COMPARE NOTEQUAL "${GIT_DIFF_INDEX}" "" GIT_DIRTY)
+      if (${GIT_DIRTY})
+          set(GIT_VERSION "${GIT_VERSION}-dirty")
+      endif()
   else()
       set(GIT_VERSION "v0.0.0")
   endif()
 
-
-  # Work out if the repository is dirty
-  execute_process(COMMAND git update-index -q --refresh
-      OUTPUT_QUIET
-      ERROR_QUIET)
-  execute_process(COMMAND git diff-index --name-only HEAD --
-      OUTPUT_VARIABLE GIT_DIFF_INDEX
-      ERROR_QUIET)
-  string(COMPARE NOTEQUAL "${GIT_DIFF_INDEX}" "" GIT_DIRTY)
-  if (${GIT_DIRTY})
-      set(GIT_VERSION "${GIT_VERSION}-dirty")
-  endif()
   message("-- git Version: ${GIT_VERSION}")
   set(${var} ${GIT_VERSION} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
get_git_version CMake function uses 'git' command directly, instead of
GIT_EXECUTABLE variable. This causes CMake errors while generating
project files in environments, where 'git' command is not present
in PATH.

This is pull request for issue #155.