### PR TITLE
Fixes #159: Add inclusion of cstdio to files using stdout, printf and etc.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ Lei Xu <eddyxu@gmail.com>
 Matt Clarkson <mattyclarkson@gmail.com>
 Oleksandr Sochka <sasha.sochka@gmail.com>
 Paul Redmond <paul.redmond@gmail.com>
+Radoslav Yovchev <radoslav.tm@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Dirac Research 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -38,6 +38,7 @@ Oleksandr Sochka <sasha.sochka@gmail.com>
 Pascal Leroy <phl@google.com>
 Paul Redmond <paul.redmond@gmail.com>
 Pierre Phaneuf <pphaneuf@google.com>
+Radoslav Yovchev <radoslav.tm@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Tobias Ulvgård <tobias.ulvgard@dirac.se>

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -23,6 +23,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <cstdio>
 #include <algorithm>
 #include <atomic>
 #include <condition_variable>

--- a/src/colorprint.cc
+++ b/src/colorprint.cc
@@ -15,6 +15,7 @@
 #include "colorprint.h"
 
 #include <cstdarg>
+#include <cstdio>
 
 #include "commandlineflags.h"
 #include "internal_macros.h"

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -15,6 +15,7 @@
 #include "benchmark/reporter.h"
 
 #include <cstdint>
+#include <cstdio>
 #include <iostream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
I stuck on this issue when trying to compiler with GCC 4.9.3 under Cygwin x64. Fix is just to add the necessary library reference. I think this should be reasonable fix for all build targets.