### PR TITLE
Cmake install libdir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,8 +37,13 @@ endif()
 # Expose public API
 target_include_directories(benchmark PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
+# Pick installation dir depending on bitness if not specified
 if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
-  set(CMAKE_INSTALL_LIBDIR "lib")
+  if ("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+    set(CMAKE_INSTALL_LIBDIR "lib64")
+  else()
+    set(CMAKE_INSTALL_LIBDIR "lib")
+  endif()
 endif()
 
 # Install target (will install the library to specified CMAKE_INSTALL_PREFIX variable)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,11 +37,15 @@ endif()
 # Expose public API
 target_include_directories(benchmark PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
+if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+  set(CMAKE_INSTALL_LIBDIR "lib")
+endif()
+
 # Install target (will install the library to specified CMAKE_INSTALL_PREFIX variable)
 install(
   TARGETS benchmark
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION bin
   COMPONENT library)
 


### PR DESCRIPTION
Honor the CMAKE_INSTALL_LIBDIR variable. By default, Install the 64 bit variant of the library in the lib64 directory. If you prefer a backward compatible solution (install to lib unless explicitly specified), drop the second commit.
