### PR TITLE
Close a memory leak in configuration code

### DIFF
--- a/cmake/posix_regex.cpp
+++ b/cmake/posix_regex.cpp
@@ -7,6 +7,8 @@ int main() {
   if (ec != 0) {
     return ec;
   }
-  return regexec(&re, str.c_str(), 0, nullptr, 0) ? -1 : 0;
+  int ret = regexec(&re, str.c_str(), 0, nullptr, 0) ? -1 : 0;
+  regfree(&re);
+  return ret;
 }
 


### PR DESCRIPTION
This was causing configuration failures on address sanitizer builds.