### PR TITLE
Pass const State to Fixture::TearDown. Fix memory leak in fixture_test

### DIFF
--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -491,11 +491,11 @@ public:
     virtual void Run(State& st) {
       this->SetUp(st);
       this->BenchmarkCase(st);
-      this->TearDown();
+      this->TearDown(st);
     }
 
     virtual void SetUp(const State&) {}
-    virtual void TearDown() {}
+    virtual void TearDown(const State&) {}
 
 protected:
     virtual void BenchmarkCase(State&) = 0;

--- a/test/fixture_test.cc
+++ b/test/fixture_test.cc
@@ -6,14 +6,18 @@
 
 class MyFixture : public ::benchmark::Fixture {
  public:
-  void SetUp(const ::benchmark::State&) {
-    assert(data.get() == nullptr);
-    data.reset(new int(42));
+  void SetUp(const ::benchmark::State& state) {
+    if (state.thread_index == 0) {
+      assert(data.get() == nullptr);
+      data.reset(new int(42));
+    }
   }
 
-  void TearDown() {
-    assert(data.get() != nullptr);
-    data.release();
+  void TearDown(const ::benchmark::State& state) {
+    if (state.thread_index == 0) {
+      assert(data.get() != nullptr);
+      data.reset();
+    }
   }
 
   ~MyFixture() {
@@ -32,10 +36,17 @@ BENCHMARK_F(MyFixture, Foo)(benchmark::State& st) {
 }
 
 BENCHMARK_DEFINE_F(MyFixture, Bar)(benchmark::State& st) {
+  if (st.thread_index == 0) {
+    assert(data.get() != nullptr);
+    assert(*data == 42);
+  }
   while (st.KeepRunning()) {
+    assert(data.get() != nullptr);
+    assert(*data == 42);
   }
   st.SetItemsProcessed(st.range_x());
 }
 BENCHMARK_REGISTER_F(MyFixture, Bar)->Arg(42);
+BENCHMARK_REGISTER_F(MyFixture, Bar)->Arg(42)->ThreadPerCpu();
 
 BENCHMARK_MAIN()

--- a/test/map_test.cc
+++ b/test/map_test.cc
@@ -36,7 +36,7 @@ class MapFixture : public ::benchmark::Fixture {
     m = ConstructRandomMap(st.range_x());
   }
 
-  void TearDown() {
+  void TearDown(const ::benchmark::State&) {
     m.clear();
   }
 


### PR DESCRIPTION
As in Fixture::SetUp, it is desirable to pass const State to Fixture::TearDown. For instance, this could be used for resources cleaning in a thread-safe manner (perform a test against the thread_index).
Also in TearDown method in test/fixture_test.cc, there is a memory leak due: data.release() call instead of data.reset().