### PR TITLE
Fix missing include in map_test.cc

### DIFF
--- a/test/map_test.cc
+++ b/test/map_test.cc
@@ -1,5 +1,6 @@
 #include "benchmark/benchmark.h"
 
+#include <cstdlib>
 #include <map>
 
 namespace {


### PR DESCRIPTION
std::rand isn't properly included right now when building with libc++. This adds the necessary include to avoid the resulting compilation errors.