### PR TITLE
Add optional ms time unit for console reporter

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,6 +32,7 @@ Evgeny Safronov <division494@gmail.com>
 Felix Homann <linuxaudio@showlabor.de>
 JianXiong Zhou <zhoujianxiong2@gmail.com>
 Kaito Udagawa <umireon@gmail.com>
+Kai Wolf <kai.wolf@gmail.com>
 Lei Xu <eddyxu@gmail.com>
 Matt Clarkson <mattyclarkson@gmail.com>
 Oleksandr Sochka <sasha.sochka@gmail.com>

--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ static void BM_test(benchmark::State& state) {
 }
 ```
 
+If a benchmark runs a few milliseconds it may be hard to visually compare the
+measured times, since the output data is given in nanoseconds per default. In
+order to manually set the time unit, you can specify it manually:
+
+```c++
+BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
+```
+
 Benchmark Fixtures
 ------------------
 Fixture tests are created by

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -216,6 +216,13 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
 }
 #endif
 
+// TimeUnit is passed to a benchmark in order to specify the order of magnitude
+// for the measured time.
+enum TimeUnit {
+  kNanosecond,
+  kMicrosecond,
+  kMillisecond
+};
 
 // State is passed to a running Benchmark and contains state for the
 // benchmark to use.
@@ -390,6 +397,9 @@ public:
   // REQUIRES: The function passed to the constructor must accept an arg1.
   Benchmark* Arg(int x);
 
+  // Run this benchmark with the given time unit for the generated output report
+  Benchmark* Unit(TimeUnit unit);
+
   // Run this benchmark once for a number of values picked from the
   // range [start..limit].  (start and limit are always picked.)
   // REQUIRES: The function passed to the constructor must accept an arg1.
@@ -534,6 +544,7 @@ protected:
 // Old-style macros
 #define BENCHMARK_WITH_ARG(n, a) BENCHMARK(n)->Arg((a))
 #define BENCHMARK_WITH_ARG2(n, a1, a2) BENCHMARK(n)->ArgPair((a1), (a2))
+#define BENCHMARK_WITH_UNIT(n, t) BENCHMARK(n)->Unit((t))
 #define BENCHMARK_RANGE(n, lo, hi) BENCHMARK(n)->Range((lo), (hi))
 #define BENCHMARK_RANGE2(n, l1, h1, l2, h2) \
   BENCHMARK(n)->RangePair((l1), (h1), (l2), (h2))

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -137,6 +137,13 @@ static void BM_MultiThreaded(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_MultiThreaded)->Threads(4);
+
+
+If a benchmark runs a few milliseconds it may be hard to visually compare the
+measured times, since the output data is given in nanoseconds per default. In
+order to manually set the time unit, you can specify it manually:
+
+BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 */
 
 #ifndef BENCHMARK_BENCHMARK_API_H_

--- a/include/benchmark/reporter.h
+++ b/include/benchmark/reporter.h
@@ -36,13 +36,12 @@ class BenchmarkReporter {
 
     // The number of chars in the longest benchmark name.
     size_t name_field_width;
-    // The time unit for displayed execution time.
-    std::string time_unit;
   };
 
   struct Run {
     Run() :
       iterations(1),
+      time_unit(kNanosecond),
       real_accumulated_time(0),
       cpu_accumulated_time(0),
       bytes_per_second(0),
@@ -52,6 +51,7 @@ class BenchmarkReporter {
     std::string benchmark_name;
     std::string report_label;  // Empty if not set by benchmark.
     int64_t iterations;
+    TimeUnit time_unit;
     double real_accumulated_time;
     double cpu_accumulated_time;
 
@@ -86,17 +86,22 @@ protected:
     static void ComputeStats(std::vector<Run> const& reports, Run* mean, Run* stddev);
 };
 
+typedef std::pair<const char*,double> TimeUnitMultiplier;
+
 // Simple reporter that outputs benchmark data to the console. This is the
 // default reporter used by RunSpecifiedBenchmarks().
 class ConsoleReporter : public BenchmarkReporter {
  public:
   virtual bool ReportContext(const Context& context);
   virtual void ReportRuns(const std::vector<Run>& reports);
-protected:
+
+ protected:
   virtual void PrintRunData(const Run& report);
 
+ private:
+  TimeUnitMultiplier getTimeUnitAndMultiplier(TimeUnit unit);
+
   size_t name_field_width_;
-  std::string time_unit_;
 };
 
 class JSONReporter : public BenchmarkReporter {

--- a/include/benchmark/reporter.h
+++ b/include/benchmark/reporter.h
@@ -22,6 +22,8 @@
 
 namespace benchmark {
 
+typedef std::pair<const char*,double> TimeUnitMultiplier;
+
 // Interface for custom benchmark result printers.
 // By default, benchmark reports are printed to stdout. However an application
 // can control the destination of the reports by calling
@@ -83,10 +85,9 @@ class BenchmarkReporter {
 
   virtual ~BenchmarkReporter();
 protected:
-    static void ComputeStats(std::vector<Run> const& reports, Run* mean, Run* stddev);
+  static void ComputeStats(std::vector<Run> const& reports, Run* mean, Run* stddev);
+  static TimeUnitMultiplier GetTimeUnitAndMultiplier(TimeUnit unit);
 };
-
-typedef std::pair<const char*,double> TimeUnitMultiplier;
 
 // Simple reporter that outputs benchmark data to the console. This is the
 // default reporter used by RunSpecifiedBenchmarks().
@@ -97,9 +98,6 @@ class ConsoleReporter : public BenchmarkReporter {
 
  protected:
   virtual void PrintRunData(const Run& report);
-
- private:
-  TimeUnitMultiplier getTimeUnitAndMultiplier(TimeUnit unit);
 
   size_t name_field_width_;
 };

--- a/include/benchmark/reporter.h
+++ b/include/benchmark/reporter.h
@@ -36,6 +36,8 @@ class BenchmarkReporter {
 
     // The number of chars in the longest benchmark name.
     size_t name_field_width;
+    // The time unit for displayed execution time.
+    std::string time_unit;
   };
 
   struct Run {
@@ -94,6 +96,7 @@ protected:
   virtual void PrintRunData(const Run& report);
 
   size_t name_field_width_;
+  std::string time_unit_;
 };
 
 class JSONReporter : public BenchmarkReporter {

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -29,6 +29,7 @@ namespace benchmark {
 
 bool ConsoleReporter::ReportContext(const Context& context) {
   name_field_width_ = context.name_field_width;
+  time_unit_ = context.time_unit;
 
   std::cerr << "Run on (" << context.num_cpus << " X " << context.mhz_per_cpu
             << " MHz CPU " << ((context.num_cpus > 1) ? "s" : "") << ")\n";
@@ -46,9 +47,11 @@ bool ConsoleReporter::ReportContext(const Context& context) {
                "affected.\n";
 #endif
 
+  std::string timeLabel = "Time(" + time_unit_ + ")";
+  std::string cpuLabel = "CPU(" + time_unit_ + ")";
   int output_width = fprintf(stdout, "%-*s %10s %10s %10s\n",
                              static_cast<int>(name_field_width_), "Benchmark",
-                             "Time(ns)", "CPU(ns)", "Iterations");
+                             timeLabel.c_str(), cpuLabel.c_str(), "Iterations");
   std::cout << std::string(output_width - 1, '-') << "\n";
 
   return true;
@@ -92,7 +95,9 @@ void ConsoleReporter::PrintRunData(const Run& result) {
                    " items/s");
   }
 
-  double const multiplier = 1e9; // nano second multiplier
+  double const multiplier = time_unit_ == "ns" ? 1e9 : 1e3; // nano second or
+                                                            // millis multiplier
+
   ColorPrintf(COLOR_GREEN, "%-*s ",
               name_field_width_, result.benchmark_name.c_str());
   if (result.iterations == 0) {

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -95,7 +95,7 @@ void ConsoleReporter::PrintRunData(const Run& result) {
 
   double multiplier;
   const char* timeLabel;
-  std::tie(timeLabel, multiplier) = getTimeUnitAndMultiplier(result.time_unit);
+  std::tie(timeLabel, multiplier) = GetTimeUnitAndMultiplier(result.time_unit);
 
   ColorPrintf(COLOR_GREEN, "%-*s ",
               name_field_width_, result.benchmark_name.c_str());
@@ -119,18 +119,6 @@ void ConsoleReporter::PrintRunData(const Run& result) {
               13, rate.c_str(),
               18, items.c_str(),
               result.report_label.c_str());
-}
-
-TimeUnitMultiplier ConsoleReporter::getTimeUnitAndMultiplier(TimeUnit unit) {
-  switch (unit) {
-    case kMillisecond:
-      return std::make_pair("ms", 1e3);
-    case kMicrosecond:
-      return std::make_pair("us", 1e6);
-    case kNanosecond:
-    default:
-      return std::make_pair("ns", 1e9);
-  }
 }
 
 }  // end namespace benchmark

--- a/src/csv_reporter.cc
+++ b/src/csv_reporter.cc
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "string_util.h"

--- a/src/csv_reporter.cc
+++ b/src/csv_reporter.cc
@@ -42,7 +42,7 @@ bool CSVReporter::ReportContext(const Context& context) {
   std::cerr << "***WARNING*** Library was built as DEBUG. Timings may be "
                "affected.\n";
 #endif
-  std::cout << "name,iterations,real_time,cpu_time,bytes_per_second,"
+  std::cout << "name,iterations,real_time,cpu_time,time_unit,bytes_per_second,"
                "items_per_second,label\n";
   return true;
 }
@@ -66,7 +66,10 @@ void CSVReporter::ReportRuns(std::vector<Run> const& reports) {
 }
 
 void CSVReporter::PrintRunData(Run const& run) {
-  double const multiplier = 1e9;  // nano second multiplier
+  double multiplier;
+  const char* timeLabel;
+  std::tie(timeLabel, multiplier) = GetTimeUnitAndMultiplier(run.time_unit);
+
   double cpu_time = run.cpu_accumulated_time * multiplier;
   double real_time = run.real_accumulated_time * multiplier;
   if (run.iterations != 0) {
@@ -83,6 +86,7 @@ void CSVReporter::PrintRunData(Run const& run) {
   std::cout << run.iterations << ",";
   std::cout << real_time << ",";
   std::cout << cpu_time << ",";
+  std::cout << timeLabel << ",";
 
   if (run.bytes_per_second > 0.0) {
     std::cout << run.bytes_per_second;

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "string_util.h"

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -120,7 +120,10 @@ void JSONReporter::Finalize() {
 }
 
 void JSONReporter::PrintRunData(Run const& run) {
-    double const multiplier = 1e9; // nano second multiplier
+    double multiplier;
+    const char* timeLabel;
+    std::tie(timeLabel, multiplier) = GetTimeUnitAndMultiplier(run.time_unit);
+
     double cpu_time = run.cpu_accumulated_time * multiplier;
     double real_time = run.real_accumulated_time * multiplier;
     if (run.iterations != 0) {
@@ -140,7 +143,10 @@ void JSONReporter::PrintRunData(Run const& run) {
         << FormatKV("real_time", RoundDouble(real_time))
         << ",\n";
     out << indent
-        << FormatKV("cpu_time", RoundDouble(cpu_time));
+        << FormatKV("cpu_time", RoundDouble(cpu_time))
+        << ",\n";
+    out << indent
+        << FormatKV("time_unit", timeLabel);
     if (run.bytes_per_second > 0.0) {
         out << ",\n" << indent
             << FormatKV("bytes_per_second", RoundDouble(run.bytes_per_second));

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -77,6 +77,18 @@ void BenchmarkReporter::ComputeStats(
   stddev_data->items_per_second = items_per_second_stat.StdDev();
 }
 
+TimeUnitMultiplier BenchmarkReporter::GetTimeUnitAndMultiplier(TimeUnit unit) {
+  switch (unit) {
+    case kMillisecond:
+      return std::make_pair("ms", 1e3);
+    case kMicrosecond:
+      return std::make_pair("us", 1e6);
+    case kNanosecond:
+    default:
+      return std::make_pair("ns", 1e9);
+  }
+}
+
 void BenchmarkReporter::Finalize() {
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Enable the tests
 
+# Allow the source files to find headers in src/
+include_directories(${PROJECT_SOURCE_DIR}/src)
+
 find_package(Threads REQUIRED)
 
 set(CXX03_FLAGS "${CMAKE_CXX_FLAGS}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Enable the tests
 
-# Allow the source files to find headers in src/
+# Allow the test files to find headers in src/ since we rely on
+# SleepForMilliseconds(int milliseconds) in options_test.cc
 include_directories(${PROJECT_SOURCE_DIR}/src)
 
 find_package(Threads REQUIRED)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,5 @@
 # Enable the tests
 
-# Allow the test files to find headers in src/ since we rely on
-# SleepForMilliseconds(int milliseconds) in options_test.cc
-include_directories(${PROJECT_SOURCE_DIR}/src)
-
 find_package(Threads REQUIRED)
 
 set(CXX03_FLAGS "${CMAKE_CXX_FLAGS}")

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -1,5 +1,7 @@
 #include "benchmark/benchmark_api.h"
-#include "sleep.h"
+
+#include <chrono>
+#include <thread>
 
 void BM_basic(benchmark::State& state) {
   while (state.KeepRunning()) {
@@ -7,8 +9,14 @@ void BM_basic(benchmark::State& state) {
 }
 
 void BM_basic_slow(benchmark::State& state) {
+
+  int milliseconds = state.range_x();
+  std::chrono::duration<double, std::milli> sleep_duration {
+    static_cast<double>(milliseconds)
+  };
+
   while (state.KeepRunning()) {
-    benchmark::SleepForMilliseconds(state.range_x());
+    std::this_thread::sleep_for(sleep_duration);
   }
 }
 

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -1,11 +1,22 @@
 #include "benchmark/benchmark_api.h"
+#include "sleep.h"
 
 void BM_basic(benchmark::State& state) {
   while (state.KeepRunning()) {
   }
 }
+
+void BM_basic_slow(benchmark::State& state) {
+  while (state.KeepRunning()) {
+    benchmark::SleepForMilliseconds(state.range_x());
+  }
+}
+
 BENCHMARK(BM_basic);
 BENCHMARK(BM_basic)->Arg(42);
+BENCHMARK(BM_basic_slow)->Arg(10)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_basic_slow)->Arg(100)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_basic_slow)->Arg(1000)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_basic)->Range(1, 8);
 BENCHMARK(BM_basic)->DenseRange(10, 15);
 BENCHMARK(BM_basic)->ArgPair(42, 42);


### PR DESCRIPTION
Some benchmarks may run a few milliseconds which makes it kind of hard to visually compare, since the currently only available nanoseconds numbers can get very large in this case. Therefore this commit adds an optional command line flag `--benchmark_time_unit` which lets the user choose between ns and ms time units for displaying the mean execution time.