### PR TITLE
Fix appveyor's older MSVC++ builds by working around 2015 Update 2 bugfix

### DIFF
--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -186,7 +186,8 @@ static void BM_ManualTiming(benchmark::State& state) {
   while (state.KeepRunning()) {
     auto start   = std::chrono::high_resolution_clock::now();
     // Simulate some useful workload with a sleep
-    std::this_thread::sleep_for(sleep_duration);
+    std::this_thread::sleep_for(std::chrono::duration_cast<
+      std::chrono::nanoseconds>(sleep_duration));
     auto end     = std::chrono::high_resolution_clock::now();
 
     auto elapsed =

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -9,14 +9,11 @@ void BM_basic(benchmark::State& state) {
 }
 
 void BM_basic_slow(benchmark::State& state) {
-
-  int milliseconds = state.range_x();
-  std::chrono::duration<double, std::milli> sleep_duration {
-    static_cast<double>(milliseconds)
-  };
-
+  std::chrono::milliseconds sleep_duration(state.range_x());
   while (state.KeepRunning()) {
-    std::this_thread::sleep_for(sleep_duration);
+    std::this_thread::sleep_for(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(sleep_duration)
+      );
   }
 }
 


### PR DESCRIPTION
MSVC++ before 2015 Update 2 has a bug in sleep_for where it tries to
implicitly += the input with a nanoseconds variable. Work around this by
using nanoseconds directly (which can be implicitly +='d with
chrono::nanoseconds).