### PR TITLE
Mark sudo: required for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,5 @@ after_success:
   - if [ "${BUILD_TYPE}" == "Coverage" -a "${TRAVIS_OS_NAME}" == "linux" ]; then
       coveralls --include src --include include --gcov-options '\-lp' --root .. --build-root .;
     fi
+
+sudo: required


### PR DESCRIPTION
Google Benchmark's Travis build currently requires "sudo" to install newer
versions of CMake and similar. See this for more details:

https://docs.travis-ci.com/user/workers/container-based-infrastructure/

Since Google Benchmark was put into Travis before 2015-01-01, it gets the
standard infrastructure implicitly, so sudo works. But anyone who forks this
repository and tries to add Travis.CI (so they can see if the build works
before creating a PR) gets broken builds before this change.