### PR TITLE
added option to change range multiplier

### DIFF
--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -444,6 +444,10 @@ public:
   // Threads, etc.
   Benchmark* Apply(void (*func)(Benchmark* benchmark));
 
+  // Set the range multiplier for non-dense range. If not called, the range multiplier 
+  // kRangeMultiplier will be used.
+  Benchmark* RangeMultiplier(int multiplier);
+
   // Set the minimum amount of time to use when running this benchmark. This
   // option overrides the `benchmark_min_time` flag.
   Benchmark* MinTime(double t);

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -287,6 +287,7 @@ struct Benchmark::Instance {
   bool           has_arg2;
   int            arg2;
   TimeUnit       time_unit;
+  int            range_multiplier;
   bool           use_real_time;
   bool           use_manual_time;
   double         min_time;
@@ -326,6 +327,7 @@ public:
   void DenseRange(int start, int limit);
   void ArgPair(int start, int limit);
   void RangePair(int lo1, int hi1, int lo2, int hi2);
+  void RangeMultiplier(int multiplier);
   void MinTime(double n);
   void UseRealTime();
   void UseManualTime();
@@ -343,6 +345,7 @@ private:
   int arg_count_;
   std::vector< std::pair<int, int> > args_;  // Args for all benchmark runs
   TimeUnit time_unit_;
+  int range_multiplier_;
   double min_time_;
   bool use_real_time_;
   bool use_manual_time_;
@@ -404,6 +407,7 @@ bool BenchmarkFamilies::FindBenchmarks(
         instance.has_arg2 = family->arg_count_ == 2;
         instance.arg2 = args.second;
         instance.time_unit = family->time_unit_;
+        instance.range_multiplier = family->range_multiplier_;
         instance.min_time = family->min_time_;
         instance.use_real_time = family->use_real_time_;
         instance.use_manual_time = family->use_manual_time_;
@@ -416,6 +420,9 @@ bool BenchmarkFamilies::FindBenchmarks(
         }
         if (family->arg_count_ >= 2) {
           AppendHumanReadable(instance.arg2, &instance.name);
+        }
+        if (family->range_multiplier_ >= 2) {
+          instance.name +=  StringPrintF("/range_multiplier:%u",  family->range_multiplier_);
         }
         if (!IsZero(family->min_time_)) {
           instance.name +=  StringPrintF("/min_time:%0.3f",  family->min_time_);
@@ -442,8 +449,8 @@ bool BenchmarkFamilies::FindBenchmarks(
 
 BenchmarkImp::BenchmarkImp(const char* name)
     : name_(name), arg_count_(-1), time_unit_(kNanosecond),
-      min_time_(0.0), use_real_time_(false),
-      use_manual_time_(false) {
+      range_multiplier_(kRangeMultiplier), min_time_(0.0), 
+      use_real_time_(false), use_manual_time_(false) {
 }
 
 BenchmarkImp::~BenchmarkImp() {
@@ -463,7 +470,7 @@ void BenchmarkImp::Range(int start, int limit) {
   CHECK(arg_count_ == -1 || arg_count_ == 1);
   arg_count_ = 1;
   std::vector<int> arglist;
-  AddRange(&arglist, start, limit, kRangeMultiplier);
+  AddRange(&arglist, start, limit, range_multiplier_);
 
   for (int i : arglist) {
     args_.emplace_back(i, -1);
@@ -490,14 +497,19 @@ void BenchmarkImp::RangePair(int lo1, int hi1, int lo2, int hi2) {
   CHECK(arg_count_ == -1 || arg_count_ == 2);
   arg_count_ = 2;
   std::vector<int> arglist1, arglist2;
-  AddRange(&arglist1, lo1, hi1, kRangeMultiplier);
-  AddRange(&arglist2, lo2, hi2, kRangeMultiplier);
+  AddRange(&arglist1, lo1, hi1, range_multiplier_);
+  AddRange(&arglist2, lo2, hi2, range_multiplier_);
 
   for (int i : arglist1) {
     for (int j : arglist2) {
       args_.emplace_back(i, j);
     }
   }
+}
+
+void BenchmarkImp::RangeMultiplier(int multiplier) {
+  CHECK_GE(multiplier, 2);
+  range_multiplier_ = multiplier;
 }
 
 void BenchmarkImp::MinTime(double t) {
@@ -604,6 +616,11 @@ Benchmark* Benchmark::RangePair(int lo1, int hi1, int lo2, int hi2) {
 
 Benchmark* Benchmark::Apply(void (*custom_arguments)(Benchmark* benchmark)) {
   custom_arguments(this);
+  return this;
+}
+
+Benchmark* Benchmark::RangeMultiplier(int multiplier) {
+  imp_->RangeMultiplier(multiplier);
   return this;
 }
 

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -23,6 +23,7 @@ BENCHMARK(BM_basic_slow)->Arg(10)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_basic_slow)->Arg(100)->Unit(benchmark::kMicrosecond);
 BENCHMARK(BM_basic_slow)->Arg(1000)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_basic)->Range(1, 8);
+BENCHMARK(BM_basic)->RangeMultiplier(2)->Range(1, 8);
 BENCHMARK(BM_basic)->DenseRange(10, 15);
 BENCHMARK(BM_basic)->ArgPair(42, 42);
 BENCHMARK(BM_basic)->RangePair(64, 512, 64, 512);


### PR DESCRIPTION
Some times the range multiplier of "8" on non-dense ranges does not suit, so I have added the option to change the range multiplier from 8 to another value greater than 2. 