### PR TITLE
added option to change range multiplier

### DIFF
--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -444,6 +444,10 @@ public:
   // Threads, etc.
   Benchmark* Apply(void (*func)(Benchmark* benchmark));
 
+  // Set the range multiplier for non-dense range. If not called, the range multiplier 
+  // kRangeMultiplier will be used.
+  Benchmark* RangeMultiplier(int multiplier);
+
   // Set the minimum amount of time to use when running this benchmark. This
   // option overrides the `benchmark_min_time` flag.
   Benchmark* MinTime(double t);

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -505,7 +505,6 @@ void BenchmarkImp::RangePair(int lo1, int hi1, int lo2, int hi2) {
 }
 
 void BenchmarkImp::RangeMultiplier(int multiplier) {
-  CHECK_GE(multiplier, 2);
   range_multiplier_ = multiplier;
 }
 
@@ -548,6 +547,7 @@ void BenchmarkImp::SetName(const char* name) {
 void BenchmarkImp::AddRange(std::vector<int>* dst, int lo, int hi, int mult) {
   CHECK_GE(lo, 0);
   CHECK_GE(hi, lo);
+  CHECK_GE(mult, 2);
 
   // Add "lo"
   dst->push_back(lo);

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -23,6 +23,7 @@ BENCHMARK(BM_basic_slow)->Arg(10)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_basic_slow)->Arg(100)->Unit(benchmark::kMicrosecond);
 BENCHMARK(BM_basic_slow)->Arg(1000)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_basic)->Range(1, 8);
+BENCHMARK(BM_basic)->RangeMultiplier(2)->Range(1, 8);
 BENCHMARK(BM_basic)->DenseRange(10, 15);
 BENCHMARK(BM_basic)->ArgPair(42, 42);
 BENCHMARK(BM_basic)->RangePair(64, 512, 64, 512);


### PR DESCRIPTION
Added option to change range multiplier to a number bigger than two, because for some benchmarks a range multiplier different than 8 is more suitable.