### PR TITLE
Force DoNotOptimize operand to memory for both gcc and clang

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@
 #
 # Please keep the list sorted.
 
+Albert Pretorius <pretoalb@gmail.com>
 Arne Beer <arne@twobeer.de>
 Christopher Seymour <chris.j.seymour@hotmail.com>
 David Coeurjolly <david.coeurjolly@liris.cnrs.fr>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,6 +22,7 @@
 #
 # Please keep the list sorted.
 
+Albert Pretorius <pretoalb@gmail.com>
 Arne Beer <arne@twobeer.de>
 Billy Robert O'Neal III <billy.oneal@gmail.com> <bion@microsoft.com>
 Chris Kennelly <ckennelly@google.com> <ckennelly@ckennelly.com>

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -210,19 +210,17 @@ Benchmark* RegisterBenchmarkInternal(Benchmark*);
 // expression from being optimized away by the compiler. This function is
 // intented to add little to no overhead.
 // See: http://stackoverflow.com/questions/28287064
-#if defined(__clang__) && defined(__GNUC__)
+#if defined(__GNUC__)
 // TODO(ericwf): Clang has a bug where it tries to always use a register
 // even if value must be stored in memory. This causes codegen to fail.
 // To work around this we remove the "r" modifier so the operand is always
 // loaded into memory.
+// GCC also has a bug where it complains about inconsistent operand constraints
+// when "+rm" is used for a type larger than can fit in a register or two.
+// For now force the operand to memory for both GCC and Clang.
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
     asm volatile("" : "+m" (const_cast<Tp&>(value)));
-}
-#elif defined(__GNUC__)
-template <class Tp>
-inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
-    asm volatile("" : "+rm" (const_cast<Tp&>(value)));
 }
 #else
 template <class Tp>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,9 @@ add_test(basic_benchmark basic_test --benchmark_min_time=0.01)
 compile_benchmark_test(diagnostics_test)
 add_test(diagnostics_test diagnostics_test --benchmark_min_time=0.01)
 
+compile_benchmark_test(donotoptimize_test)
+add_test(donotoptimize_test donotoptimize_test --benchmark_min_time=0.01)
+
 compile_benchmark_test(fixture_test)
 add_test(fixture_test fixture_test --benchmark_min_time=0.01)
 

--- a/test/donotoptimize_test.cc
+++ b/test/donotoptimize_test.cc
@@ -1,0 +1,36 @@
+#include "benchmark/benchmark.h"
+
+#include <cstdint>
+
+namespace {
+#if defined(__GNUC__)
+  std::uint64_t double_up(const std::uint64_t x) __attribute__ ((const));
+#endif
+  std::uint64_t double_up(const std::uint64_t x) {
+    return x * 2;
+  }
+}
+
+int main(int, char*[]) {
+
+  // this test verifies compilation of DoNotOptimize() for some types
+
+  char buffer8[8];
+  benchmark::DoNotOptimize(buffer8);
+
+  char buffer20[20];
+  benchmark::DoNotOptimize(buffer20);
+
+  char buffer1024[1024];
+  benchmark::DoNotOptimize(buffer1024);
+  benchmark::DoNotOptimize(&buffer1024[0]);
+
+  int x = 123;
+  benchmark::DoNotOptimize(x);
+  benchmark::DoNotOptimize(&x);
+  benchmark::DoNotOptimize(x += 42);
+
+  benchmark::DoNotOptimize(double_up(x));
+
+  return 0;
+}


### PR DESCRIPTION
I added some types I had problems with, please let me know if there is any additional test that would make sense or if some of the ones I added is not relevant.
I corrected my email (sorry about that).
thanks