### PR TITLE
Add export linker flags policy to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project (benchmark)
 
 foreach(p
     CMP0054 # CMake 3.1
+    CMP0056 # export EXE_LINKER_FLAGS to try_run
     )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)


### PR DESCRIPTION
Add policy CMP0056, which honors the link flags in try_compile and
try_run. This allows for building against non-system libc++ by providing
the correct -L and rpath options in a containing project.

For example:

    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L ${LLVM_ROOT}/lib -l c++ -l c++abi")
    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath,${LLVM_ROOT}/lib")