### PR TITLE
Support multiple ranges in the benchmark

### DIFF
--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -153,6 +153,8 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #include <stddef.h>
 #include <stdint.h>
 
+#include <vector>
+
 #include "macros.h"
 
 namespace benchmark {
@@ -258,7 +260,7 @@ typedef double(BigOFunc)(int);
 // benchmark to use.
 class State {
 public:
-  State(size_t max_iters, bool has_x, int x, bool has_y, int y,
+  State(size_t max_iters, const std::vector<int>& ranges,
         int thread_i, int n_threads);
 
   // Returns true if the benchmark should continue through another iteration.
@@ -414,16 +416,18 @@ public:
   // Range arguments for this run. CHECKs if the argument has been set.
   BENCHMARK_ALWAYS_INLINE
   int range_x() const {
-    assert(has_range_x_);
-    ((void)has_range_x_); // Prevent unused warning.
-    return range_x_;
+    return range(0);
   }
 
   BENCHMARK_ALWAYS_INLINE
   int range_y() const {
-    assert(has_range_y_);
-    ((void)has_range_y_); // Prevent unused warning.
-    return range_y_;
+      return range(1);
+  }
+
+  BENCHMARK_ALWAYS_INLINE
+  int range(std::size_t pos) const {
+      assert(range_.size() > pos);
+      return range_[pos];
   }
 
   BENCHMARK_ALWAYS_INLINE
@@ -434,11 +438,7 @@ private:
   bool finished_;
   size_t total_iterations_;
 
-  bool has_range_x_;
-  int range_x_;
-
-  bool has_range_y_;
-  int range_y_;
+  std::vector<int> range_;
 
   size_t bytes_processed_;
   size_t items_processed_;
@@ -504,6 +504,16 @@ public:
   // (i.e., for all combinations of the values in A and B).
   // REQUIRES: The function passed to the constructor must accept arg1,arg2.
   Benchmark* RangePair(int lo1, int hi1, int lo2, int hi2);
+
+  // Run this benchmark once with "args" as the extra arguments passed
+  // to the function.
+  // REQUIRES: The function passed to the constructor must accept arg1, arg2 ...
+  Benchmark* Args(const std::vector<int>& args);
+
+  // Run this benchmark once for a number of values picked from the
+  // ranges [start..limit].  (starts and limits are always picked.)
+  // REQUIRES: The function passed to the constructor must accept arg1, arg2 ...
+  Benchmark* Ranges(const std::vector<int>& starts, const std::vector<int>& limits);
 
   // Pass this benchmark object to *func, which can customize
   // the benchmark by calling various methods like Arg, ArgPair,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,9 @@ add_test(fixture_test fixture_test --benchmark_min_time=0.01)
 compile_benchmark_test(map_test)
 add_test(map_test map_test --benchmark_min_time=0.01)
 
+compile_benchmark_test(multiple_ranges_test)
+add_test(multiple_ranges_test multiple_ranges_test --benchmark_min_time=0.01)
+
 compile_benchmark_test(reporter_output_test)
 add_test(reporter_output_test reporter_output_test --benchmark_min_time=0.01)
 

--- a/test/multiple_ranges_test.cc
+++ b/test/multiple_ranges_test.cc
@@ -1,0 +1,14 @@
+#include "benchmark/benchmark.h"
+
+void BM_empty(benchmark::State& state) {
+  while (state.KeepRunning()) {
+    int product = state.range(0) * state.range(1) * state.range(2);
+    for (int x = 0; x < product; x++) {
+      benchmark::DoNotOptimize(x);
+    }
+  }
+}
+
+BENCHMARK(BM_empty)->RangeMultiplier(2)->Ranges({1, 3, 5}, {2, 7, 15})->Args({7, 6, 3});
+
+BENCHMARK_MAIN()


### PR DESCRIPTION
google-benchmark library allows to provide up to two ranges to the
benchmark method (range_x and range_y). However, in many cases it's not
sufficient. The patch introduces multi-range features, so user can easily
define multiple ranges by passing a vector of integers, and access values
through the method range(i).