### PR TITLE
Supply old `RangePair` and `ArgPair` API for C++03 compatibility.

### DIFF
--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -425,10 +425,16 @@ public:
 
   // Range arguments for this run. CHECKs if the argument has been set.
   BENCHMARK_ALWAYS_INLINE
-  int range(std::size_t pos) const {
+  int range(std::size_t pos = 0) const {
       assert(range_.size() > pos);
       return range_[pos];
   }
+
+  BENCHMARK_DEPRECATED_MSG("use 'range(0)' instead")
+  int range_x() const { return range(0); }
+
+  BENCHMARK_DEPRECATED_MSG("use 'range(1)' instead")
+  int range_y() const { return range(1); }
 
   BENCHMARK_ALWAYS_INLINE
   size_t iterations() const { return total_iterations_; }
@@ -498,10 +504,30 @@ public:
   // REQUIRES: The function passed to the constructor must accept arg1, arg2 ...
   Benchmark* Args(const std::vector<int>& args);
 
+  // Equivalent to Args({x, y})
+  // NOTE: This is a legacy C++03 interface provided for compatibility only.
+  //   New code should use 'Args'.
+  Benchmark* ArgPair(int x, int y) {
+      std::vector<int> args;
+      args.push_back(x);
+      args.push_back(y);
+      return Args(args);
+  }
+
   // Run this benchmark once for a number of values picked from the
   // ranges [start..limit].  (starts and limits are always picked.)
   // REQUIRES: The function passed to the constructor must accept arg1, arg2 ...
   Benchmark* Ranges(const std::vector<std::pair<int, int> >& ranges);
+
+  // Equivalent to Ranges({{lo1, hi1}, {lo2, hi2}}).
+  // NOTE: This is a legacy C++03 interface provided for compatibility only.
+  //   New code should use 'Ranges'.
+  Benchmark* RangePair(int lo1, int hi1, int lo2, int hi2) {
+      std::vector<std::pair<int, int> > ranges;
+      ranges.push_back(std::make_pair(lo1, hi1));
+      ranges.push_back(std::make_pair(lo2, hi2));
+      return Ranges(ranges);
+  }
 
   // Pass this benchmark object to *func, which can customize
   // the benchmark by calling various methods like Arg, Args,

--- a/include/benchmark/macros.h
+++ b/include/benchmark/macros.h
@@ -53,8 +53,10 @@
 
 #if defined(__GNUC__)
 # define BENCHMARK_BUILTIN_EXPECT(x, y) __builtin_expect(x, y)
+# define BENCHMARK_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
 #else
 # define BENCHMARK_BUILTIN_EXPECT(x, y) x
+# define BENCHMARK_DEPRECATED_MSG(msg)
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__)

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -115,6 +115,9 @@ bool IsZero(double n) {
 
 // For non-dense Range, intermediate values are powers of kRangeMultiplier.
 static const int kRangeMultiplier = 8;
+// The size of a benchmark family determines is the number of inputs to repeat
+// the benchmark on. If this is "large" then warn the user during configuration.
+static const size_t kMaxFamilySize = 100;
 static const size_t kMaxIterations = 1000000000;
 
 bool running_benchmark = false;
@@ -434,8 +437,7 @@ bool BenchmarkFamilies::FindBenchmarks(
   }
 
   // Special list of thread counts to use when none are specified
-  std::vector<int> one_thread;
-  one_thread.push_back(1);
+  const std::vector<int> one_thread = {1};
 
   MutexLock l(mutex_);
   for (std::unique_ptr<Benchmark>& bench_family : families_) {
@@ -446,12 +448,23 @@ bool BenchmarkFamilies::FindBenchmarks(
     if (family->ArgsCnt() == -1) {
       family->Args({});
     }
-
-    for (auto const& args : family->args_) {
-      const std::vector<int>* thread_counts =
+    const std::vector<int>* thread_counts =
         (family->thread_counts_.empty()
          ? &one_thread
-         : &family->thread_counts_);
+         : &static_cast<const std::vector<int>&>(family->thread_counts_));
+    const size_t family_size = family->args_.size() * thread_counts->size();
+    // The benchmark will be run at least 'total' different inputs. If 'total'
+    // is very large warn the user.
+    if (family_size > kMaxFamilySize) {
+      std::cerr <<  "The number of inputs is very large. " << family->name_
+                << " will be repeated at least " << family_size << " times.\n";
+    }
+    // reserve in the special case the regex ".", since we know the final
+    // family size.
+    if (spec == ".")
+      benchmarks->reserve(family_size);
+
+    for (auto const& args : family->args_) {
       for (int num_threads : *thread_counts) {
 
         Benchmark::Instance instance;
@@ -493,8 +506,8 @@ bool BenchmarkFamilies::FindBenchmarks(
         }
 
         if (re.Match(instance.name)) {
-          instance.last_benchmark_instance = (args == family->args_.back());
-          benchmarks->push_back(instance);
+          instance.last_benchmark_instance = (&args == &family->args_.back());
+          benchmarks->push_back(std::move(instance));
         }
       }
     }
@@ -547,7 +560,7 @@ void BenchmarkImp::Args(const std::vector<int>& args)
 
 void BenchmarkImp::Ranges(const std::vector<std::pair<int, int>>& ranges) {
   std::vector<std::vector<int>> arglists(ranges.size());
-  int total = 1;
+  size_t total = 1;
   for (std::size_t i = 0; i < ranges.size(); i++) {
     AddRange(&arglists[i], ranges[i].first, ranges[i].second, range_multiplier_);
     total *= arglists[i].size();
@@ -555,14 +568,14 @@ void BenchmarkImp::Ranges(const std::vector<std::pair<int, int>>& ranges) {
 
   std::vector<std::size_t> ctr(total, 0);
 
-  for (int i = 0; i < total; i++) {
+  for (std::size_t i = 0; i < total; i++) {
     std::vector<int> tmp;
 
     for (std::size_t j = 0; j < arglists.size(); j++) {
-      tmp.push_back(arglists[j][ctr[j]]);
+      tmp.push_back(arglists[j].at(ctr[j]));
     }
 
-    args_.push_back(tmp);
+    args_.push_back(std::move(tmp));
 
     for (std::size_t j = 0; j < arglists.size(); j++) {
       if (ctr[j] + 1 < arglists[j].size()) {

--- a/test/cxx03_test.cc
+++ b/test/cxx03_test.cc
@@ -1,5 +1,6 @@
-
+#undef NDEBUG
 #include <cstddef>
+#include <cassert>
 
 #include "benchmark/benchmark.h"
 
@@ -14,6 +15,16 @@ void BM_empty(benchmark::State& state) {
     }
 }
 BENCHMARK(BM_empty);
+
+// The new C++11 interface for args/ranges requires initializer list support.
+// Therefore we provide the old interface to support C++03.
+void BM_old_arg_range_interface(benchmark::State& state) {
+    assert((state.range(0) == 1 && state.range(1) == 2) ||
+           (state.range(0) == 5 && state.range(1) == 6));
+    while (state.KeepRunning()) {
+    }
+}
+BENCHMARK(BM_old_arg_range_interface)->ArgPair(1, 2)->RangePair(5, 5, 6, 6);
 
 template <class T, class U>
 void BM_template2(benchmark::State& state) {

--- a/test/multiple_ranges_test.cc
+++ b/test/multiple_ranges_test.cc
@@ -2,7 +2,6 @@
 
 #include <set>
 #include <cassert>
-#include <limits>
 
 class MultipleRangesFixture : public ::benchmark::Fixture {
  public:

--- a/test/multiple_ranges_test.cc
+++ b/test/multiple_ranges_test.cc
@@ -2,6 +2,7 @@
 
 #include <set>
 #include <cassert>
+#include <limits>
 
 class MultipleRangesFixture : public ::benchmark::Fixture {
  public:
@@ -41,6 +42,20 @@ BENCHMARK_DEFINE_F(MultipleRangesFixture, Empty)(benchmark::State& state) {
   }
 }
 
-BENCHMARK_REGISTER_F(MultipleRangesFixture, Empty)->RangeMultiplier(2)->Ranges({{1, 2}, {3, 7}, {5, 15}})->Args({7, 6, 3});
+BENCHMARK_REGISTER_F(MultipleRangesFixture, Empty)->RangeMultiplier(2)
+    ->Ranges({{1, 2}, {3, 7}, {5, 15}})->Args({7, 6, 3});
 
+void BM_CheckDefaultArgument(benchmark::State& state) {
+  // Test that the 'range()' without an argument is the same as 'range(0)'.
+  assert(state.range() == state.range(0));
+  assert(state.range() != state.range(1));
+  while (state.KeepRunning()) {}
+}
+BENCHMARK(BM_CheckDefaultArgument)->Ranges({{1, 5}, {6, 10}});
+
+void BM_CheckOverflow(benchmark::State& state) {
+  while (state.KeepRunning()) {}
+}
+int x = std::numeric_limits<int>::max();
+BENCHMARK(BM_CheckOverflow)->Ranges({{0, x}, {1, x}});
 BENCHMARK_MAIN()

--- a/test/multiple_ranges_test.cc
+++ b/test/multiple_ranges_test.cc
@@ -53,9 +53,4 @@ void BM_CheckDefaultArgument(benchmark::State& state) {
 }
 BENCHMARK(BM_CheckDefaultArgument)->Ranges({{1, 5}, {6, 10}});
 
-void BM_CheckOverflow(benchmark::State& state) {
-  while (state.KeepRunning()) {}
-}
-int x = std::numeric_limits<int>::max();
-BENCHMARK(BM_CheckOverflow)->Ranges({{0, x}, {1, x}});
 BENCHMARK_MAIN()


### PR DESCRIPTION
The new `Ranges` and `Args` interface requires C++11 initializer lists to be useful. In C++03 the new interface is almost impossible to use. This patch re-adds the old C++03 interface for continued compatibility.

Additionally this patch re-adds the `range_x()` and `range_y()` methods but marks them as deprecated. This should allow older benchmarks to continue to compile while making it clear that this interface is deprecated.

The final change in this patch gives `ranges(pos)` the default argument `0` allowing `ranges()` to work. This seems like a convenience to me but I"m happy to remove it.