### PR TITLE
Add Benchmark::ThreadRange() version with increment instead of multiply

### DIFF
--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -595,7 +595,13 @@ public:
   //    Foo in 4 threads
   //    Foo in 8 threads
   //    Foo in 16 threads
-  Benchmark* ThreadRange(int min_threads, int max_threads);
+  Benchmark *ThreadRange(int min_threads, int max_threads);
+
+  // For each value n in the range, run this benchmark once using n threads.
+  // min_threads and max_threads are always included in the range.
+  // stride specifies the increment. E.g. DenseThreadRange(1, 8, 3) starts
+  // a benchmark with 1, 4, 7 and 8 threads.
+  Benchmark *DenseThreadRange(int min_threads, int max_threads, int stride = 1);
 
   // Equivalent to ThreadRange(NumCPUs(), NumCPUs())
   Benchmark* ThreadPerCpu();

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -293,6 +293,7 @@ public:
   void ComplexityLambda(BigOFunc* complexity);
   void Threads(int t);
   void ThreadRange(int min_threads, int max_threads);
+  void DenseThreadRange(int min_threads, int max_threads, int stride);
   void ThreadPerCpu();
   void SetName(const char* name);
 
@@ -548,6 +549,18 @@ void BenchmarkImp::ThreadRange(int min_threads, int max_threads) {
   AddRange(&thread_counts_, min_threads, max_threads, 2);
 }
 
+void BenchmarkImp::DenseThreadRange(int min_threads, int max_threads,
+                                    int stride) {
+  CHECK_GT(min_threads, 0);
+  CHECK_GE(max_threads, min_threads);
+  CHECK_GE(stride, 1);
+
+  for (auto i = min_threads; i < max_threads; i += stride) {
+    thread_counts_.push_back(i);
+  }
+  thread_counts_.push_back(max_threads);
+}
+
 void BenchmarkImp::ThreadPerCpu() {
   static int num_cpus = NumCPUs();
   thread_counts_.push_back(num_cpus);
@@ -579,6 +592,7 @@ void BenchmarkImp::AddRange(std::vector<int>* dst, int lo, int hi, int mult) {
     dst->push_back(hi);
   }
 }
+
 
 Benchmark::Benchmark(const char* name)
     : imp_(new BenchmarkImp(name))
@@ -684,6 +698,12 @@ Benchmark* Benchmark::Threads(int t) {
 
 Benchmark* Benchmark::ThreadRange(int min_threads, int max_threads) {
   imp_->ThreadRange(min_threads, max_threads);
+  return this;
+}
+
+Benchmark *Benchmark::DenseThreadRange(int min_threads, int max_threads,
+                                       int stride) {
+  imp_->DenseThreadRange(min_threads, max_threads, stride);
   return this;
 }
 

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -220,5 +220,26 @@ BENCHMARK_CAPTURE(BM_non_template_args, basic_test, 0, 0);
 
 #endif // __cplusplus >= 201103L
 
-BENCHMARK_MAIN()
+static void BM_DenseThreadRanges(benchmark::State &st) {
+  switch (st.range(0)) {
+  case 1:
+    assert(st.threads == 1 || st.threads == 2 || st.threads == 3);
+    break;
+  case 2:
+    assert(st.threads == 1 || st.threads == 3 || st.threads == 4);
+    break;
+  case 3:
+    assert(st.threads == 5 || st.threads == 8 || st.threads == 11 ||
+           st.threads == 14);
+    break;
+  default:
+    assert(false && "Invalid test case number");
+  }
+  while (st.KeepRunning()) {
+  }
+}
+BENCHMARK(BM_DenseThreadRanges)->Arg(1)->DenseThreadRange(1, 3);
+BENCHMARK(BM_DenseThreadRanges)->Arg(2)->DenseThreadRange(1, 4, 2);
+BENCHMARK(BM_DenseThreadRanges)->Arg(3)->DenseThreadRange(5, 14, 3);
 
+BENCHMARK_MAIN()


### PR DESCRIPTION
Hi,

referring to #282.

>> for my work I want to use a range of threads.
>> So far the incrementing strategy seems to be limited to just multiplying with a factor.
>> I.e. you can only use thread counts like 1, 2, 4, 8, 16 or 1, 3, 9, 27.

>> So I made this small patch.

>> Should I create a pull request?

> If you have an idea and a patch you should always make a PR. Issues are for people without patches :-P

>> for my work I want to use a range of threads

> You must have a lot of threads... I'm initially skeptical of the need for this feature. Typically you don't want to exceed the number of threads supported by the hardware (at least by much). Please try and add a motivating example when you open the PR.

> I'm closing this issue to make way for the PR.

Yes we do have up to 24 or 48 threads per board at the moment.

I use it for benchmarking synchronization algorithms. (Not a very common thing to do,)
I will probably need a few more things in the future like thread pinning and more accurate version of PauseTiming so I can make sure they leave at an exact time.
I'm not even sure google/benchmark is the right tool for the job. But it seems nice. The output, functionality and code is pretty simple and clear.

Motivating example:

```c++
template<typename barrier>
static void BM_barrier(benchmark::State& state) {

    while (state.KeepRunning()) {

        static barrier b;
        if (state.thread_index == 0) { b.init(state.threads); }

        state.PauseTiming();

        auto start = std::chrono::high_resolution_clock::now();
        b.wait(state.thread_index);
        auto end   = std::chrono::high_resolution_clock::now();

        auto elapsed_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(end - start);

        if (elapsed_seconds < std::chrono::nanoseconds(0)) {
            state.SkipWithError("elapsed seconds < 0");
            break;
        }
                                                                                                                                                                   
        state.SetIterationTime(elapsed_seconds.count());       
                                                                                                                                                                            
        if (state.thread_index == 0) { b.destroy(); }
    }                                                                                                                                                                       
}

BENCHMARK_TEMPLATE(BM_barrier, baseline_barrier)->ThreadRange2(1, 4)->UseManualTime();
BENCHMARK_TEMPLATE(BM_barrier, central_counter_barrier)->ThreadRange2(1, 4)->UseManualTime();
BENCHMARK_TEMPLATE(BM_barrier, sense_reversing_centralized_barrier)->ThreadRange2(1, 4)->UseManualTime();

BENCHMARK_MAIN();
```