### PR TITLE
CMake: add headers to the list of source files.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,18 @@ set(SOURCE_FILES "benchmark.cc" "colorprint.cc" "commandlineflags.cc"
                  "console_reporter.cc" "csv_reporter.cc" "json_reporter.cc"
                  "log.cc" "reporter.cc" "sleep.cc" "string_util.cc"
                  "sysinfo.cc" "walltime.cc" "complexity.cc")
+# Add headers to the list of source files. cmake does not require this,
+# but IDEs such as Visual Studio need this to add the headers
+# to the generated project.
+set(_d "${PROJECT_SOURCE_DIR}/include/benchmark")
+list(APPEND SOURCE_FILES "${_d}/benchmark.h" "${_d}/benchmark_api.h"
+            "${_d}/macros.h" "${_d}/reporter.h" "arraysize.h" "check.h"
+            "colorprint.h" "commandlineflags.h" "complexity.h"
+            "cycleclock.h" "internal_macros.h" "log.h" "mutex.h"
+            "re.h" "sleep.h" "stat.h" "string_util.h" "sysinfo.h"
+            "walltime.h")
+unset(_d)
+
 # Determine the correct regular expression engine to use
 if(HAVE_STD_REGEX)
   set(RE_FILES "re_std.cc")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ endmacro(compile_benchmark_test)
 
 
 macro(compile_output_test name)
-  add_executable(${name} "${name}.cc")
+  add_executable(${name} "${name}.cc" output_test.h)
   target_link_libraries(${name} output_test_helper benchmark
           ${BENCHMARK_CXX_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 endmacro(compile_output_test)


### PR DESCRIPTION
cmake does not require this, but IDEs such as VisualStudio or QtCreator need this to add the headers to the generated project.