### PR TITLE
Fixture: add non const Setup() and TearDown().

### DIFF
--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -713,8 +713,8 @@ public:
     virtual void SetUp(const State&) {}
     virtual void TearDown(const State&) {}
     // ... In favor of these.
-    virtual void SetUp(State& st) { SetUp(static_cast<State const&>(st)); }
-    virtual void TearDown(State& st) { TearDown(static_cast<State const&>(st)); }
+    virtual void SetUp(State& st) { SetUp(static_cast<const State&>(st)); }
+    virtual void TearDown(State& st) { TearDown(static_cast<const State&>(st)); }
 
 protected:
     virtual void BenchmarkCase(State&) = 0;

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -713,8 +713,8 @@ public:
     virtual void SetUp(const State&) {}
     virtual void TearDown(const State&) {}
     // ... In favor of these.
-    virtual void SetUp(State& st) { SetUp(static_cast<const State&>(st)); }
-    virtual void TearDown(State& st) { TearDown(static_cast<const State&>(st)); }
+    virtual void SetUp(State& st) { SetUp(const_cast<const State&>(st)); }
+    virtual void TearDown(State& st) { TearDown(const_cast<const State&>(st)); }
 
 protected:
     virtual void BenchmarkCase(State&) = 0;

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -709,8 +709,12 @@ public:
       this->TearDown(st);
     }
 
+    // These will be deprecated ...
     virtual void SetUp(const State&) {}
     virtual void TearDown(const State&) {}
+    // ... In favor of these.
+    virtual void SetUp(State& st) { SetUp(static_cast<State const&>(st)); }
+    virtual void TearDown(State& st) { TearDown(static_cast<State const&>(st)); }
 
 protected:
     virtual void BenchmarkCase(State&) = 0;


### PR DESCRIPTION
This allows write-access to the State argument, which is important in upcoming user-defined counter functionality.