### PR TITLE
HumanReadableNumber(): Simplify output for simple numbers. Examples:

### DIFF
--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -45,12 +45,10 @@ void ToExponentAndMantissa(double val, double thresh, int precision,
       std::max(thresh, 1.0 / std::pow(10.0, precision));
   const double big_threshold = adjusted_threshold * one_k;
   const double small_threshold = adjusted_threshold;
+  // Values in ]simple_threshold,small_threshold[ will be printed as-is
+  const double simple_threshold = 0.01;
 
-  if (val > 0.01 && val < small_threshold) {
-    // maybe the magic number above should be configurable
-    mantissa_stream << val;
-    *exponent = 0;
-  } else if (val > big_threshold) {
+  if (val > big_threshold) {
     // Positive powers
     double scaled = val;
     for (size_t i = 0; i < arraysize(kBigSIUnits); ++i) {
@@ -66,14 +64,16 @@ void ToExponentAndMantissa(double val, double thresh, int precision,
     *exponent = 0;
   } else if (val < small_threshold) {
     // Negative powers
-    double scaled = val;
-    for (size_t i = 0; i < arraysize(kSmallSIUnits); ++i) {
-      scaled *= one_k;
-      if (scaled >= small_threshold) {
-        mantissa_stream << scaled;
-        *exponent = -static_cast<int64_t>(i + 1);
-        *mantissa = mantissa_stream.str();
-        return;
+    if (val < simple_threshold) {
+      double scaled = val;
+      for (size_t i = 0; i < arraysize(kSmallSIUnits); ++i) {
+        scaled *= one_k;
+        if (scaled >= small_threshold) {
+          mantissa_stream << scaled;
+          *exponent = -static_cast<int64_t>(i + 1);
+          *mantissa = mantissa_stream.str();
+          return;
+        }
       }
     }
     mantissa_stream << val;

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -46,7 +46,7 @@ void ToExponentAndMantissa(double val, double thresh, int precision,
   const double big_threshold = adjusted_threshold * one_k;
   const double small_threshold = adjusted_threshold;
 
-  if (val > 0.001 && val < small_threshold) {
+  if (val > 0.01 && val < small_threshold) {
     // maybe the magic number above should be configurable
     mantissa_stream << val;
     *exponent = 0;

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -46,7 +46,11 @@ void ToExponentAndMantissa(double val, double thresh, int precision,
   const double big_threshold = adjusted_threshold * one_k;
   const double small_threshold = adjusted_threshold;
 
-  if (val > big_threshold) {
+  if (val > 0.001 && val < small_threshold) {
+    // maybe the magic number above should be configurable
+    mantissa_stream << val;
+    *exponent = 0;
+  } else if (val > big_threshold) {
     // Positive powers
     double scaled = val;
     for (size_t i = 0; i < arraysize(kBigSIUnits); ++i) {


### PR DESCRIPTION
```
HumanReadableNumber(    0.0)=      0    ---->         0
HumanReadableNumber(    0.5)=   512m    ---->       0.5
HumanReadableNumber(    0.9)= 921.6m    ---->       0.9
HumanReadableNumber(    1.0)=  1024m    ---->         1
HumanReadableNumber(   1.05)=1075.2m    ---->      1.05
HumanReadableNumber(    1.1)=    1.1    ---->       1.1
HumanReadableNumber(    1.2)=    1.2    ---->       1.2
HumanReadableNumber( 0.5e-1)=  51.2m    ---->      0.05
HumanReadableNumber( 0.9e-1)= 92.16m    ---->      0.09
HumanReadableNumber( 1.0e-1)= 102.4m    ---->       0.1
HumanReadableNumber(1.05e-1)=107.52m    ---->     0.105
HumanReadableNumber( 1.1e-1)=112.64m    ---->      0.11
HumanReadableNumber( 1.2e-1)=122.88m    ---->      0.12
HumanReadableNumber( 0.5e-3)=524.288u   ---->   524.288u
HumanReadableNumber( 0.9e-3)=943.718u   ---->   943.718u
HumanReadableNumber( 1.0e-3)=1048.58u   ---->   1048.58u
HumanReadableNumber(1.05e-3)=  1101u    ---->   0.00105
HumanReadableNumber( 1.1e-3)=1.1264m    ---->    0.0011
HumanReadableNumber( 1.2e-3)=1.2288m    ---->    0.0012
```
