### PR TITLE
Fix working on mac clock_gettime

### DIFF
--- a/src/timers.cc
+++ b/src/timers.cc
@@ -101,6 +101,7 @@ BENCHMARK_NORETURN static void  DiagnoseAndExit(const char* msg) {
 
 
 double ProcessCPUUsage() {
+// FIXME We want to use clock_gettime, but its not available in MacOS 10.11. See https://github.com/google/benchmark/pull/292
 #if defined(CLOCK_PROCESS_CPUTIME_ID) && !defined(BENCHMARK_OS_MACOSX)
   struct timespec spec;
   if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &spec) == 0)
@@ -124,6 +125,7 @@ double ProcessCPUUsage() {
 }
 
 double ThreadCPUUsage() {
+// FIXME We want to use clock_gettime, but its not available in MacOS 10.11. See https://github.com/google/benchmark/pull/292
 #if defined(CLOCK_THREAD_CPUTIME_ID) && !defined(BENCHMARK_OS_MACOSX)
   struct timespec ts;
   if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) == 0)

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -101,7 +101,7 @@ BENCHMARK_NORETURN static void  DiagnoseAndExit(const char* msg) {
 
 
 double ProcessCPUUsage() {
-#if defined(CLOCK_PROCESS_CPUTIME_ID)
+#if defined(CLOCK_PROCESS_CPUTIME_ID) && !defined(BENCHMARK_OS_MACOSX)
   struct timespec spec;
   if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &spec) == 0)
     return MakeTime(spec);
@@ -124,7 +124,7 @@ double ProcessCPUUsage() {
 }
 
 double ThreadCPUUsage() {
-#if defined(CLOCK_THREAD_CPUTIME_ID)
+#if defined(CLOCK_THREAD_CPUTIME_ID) && !defined(BENCHMARK_OS_MACOSX)
   struct timespec ts;
   if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) == 0)
     return MakeTime(ts);


### PR DESCRIPTION
The problem was mac os x has CLOCK_PROCESS_CPUTIME_ID definition, but does not have clock_gettime()