### PR TITLE
Update the required CMake version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 2.8.12)
 project (benchmark)
 
 foreach(p

--- a/cmake/CXXFeatureCheck.cmake
+++ b/cmake/CXXFeatureCheck.cmake
@@ -10,7 +10,7 @@
 #
 # include(CXXFeatureCheck)
 # cxx_feature_check(STD_REGEX)
-# Requires CMake 2.6+
+# Requires CMake 2.8.12+
 
 if(__cxx_feature_check)
   return()


### PR DESCRIPTION
Currently CMake 2.8.11 doesn't work (See issue #314). 

Instead of attempting to work around older CMake behavior I believe we should simply require 2.8.12. I don't think dropping 2.8.11 will cause many problems, especially with how easy it is to upgrade CMake on all platforms.

For reference the LLVM project requires CMake 3.4.3 or greater.