### PR TITLE
Issue 327

### DIFF
--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -163,7 +163,7 @@ bool BenchmarkFamilies::FindBenchmarks(
             }
           }
 
-          AppendHumanReadable(arg, &instance.name);
+          instance.name += std::to_string(arg);
           ++arg_i;
         }
 


### PR DESCRIPTION
Arguments shouldn't be AppendHumanReadable()-ed, they should just be shown as-is. Otherwise, when I try to run a benchmark with an argument of 10000 it gets printed as 9.76562k, which is very confusing. 