### PR TITLE
Fix librt linking on systems which has it

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,10 @@ set_target_properties(benchmark PROPERTIES
 
 # Link threads.
 target_link_libraries(benchmark  ${BENCHMARK_CXX_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+find_library(LIBRT rt)
+if(LIBRT)
+  target_link_libraries(benchmark ${LIBRT})
+endif()
 
 # We need extra libraries on Windows
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")


### PR DESCRIPTION
I had linking error with building on centos6 system
```
[root@centos6 benchmark]# make install
Scanning dependencies of target benchmark
[  3%] Building CXX object src/CMakeFiles/benchmark.dir/commandlineflags.cc.o
[  7%] Building CXX object src/CMakeFiles/benchmark.dir/colorprint.cc.o
[ 10%] Building CXX object src/CMakeFiles/benchmark.dir/complexity.cc.o
[ 14%] Building CXX object src/CMakeFiles/benchmark.dir/console_reporter.cc.o
[ 17%] Building CXX object src/CMakeFiles/benchmark.dir/string_util.cc.o
[ 21%] Building CXX object src/CMakeFiles/benchmark.dir/benchmark.cc.o
[ 25%] Building CXX object src/CMakeFiles/benchmark.dir/timers.cc.o
[ 28%] Building CXX object src/CMakeFiles/benchmark.dir/sleep.cc.o
[ 32%] Building CXX object src/CMakeFiles/benchmark.dir/csv_reporter.cc.o
[ 35%] Building CXX object src/CMakeFiles/benchmark.dir/sysinfo.cc.o
[ 39%] Building CXX object src/CMakeFiles/benchmark.dir/benchmark_register.cc.o
[ 42%] Building CXX object src/CMakeFiles/benchmark.dir/json_reporter.cc.o
[ 46%] Building CXX object src/CMakeFiles/benchmark.dir/reporter.cc.o
Linking CXX static library libbenchmark.a
[ 46%] Built target benchmark
Scanning dependencies of target basic_test
[ 50%] Building CXX object test/CMakeFiles/basic_test.dir/basic_test.cc.o
Linking CXX executable basic_test
../src/libbenchmark.a(timers.cc.o): In function `benchmark::ProcessCPUUsage()':
timers.cc:(.text+0x105): undefined reference to `clock_gettime'
../src/libbenchmark.a(timers.cc.o): In function `benchmark::ThreadCPUUsage()':
timers.cc:(.text+0x14f): undefined reference to `clock_gettime'
collect2: error: ld returned 1 exit status
make[2]: *** [test/basic_test] Ошибка 1
make[1]: *** [test/CMakeFiles/basic_test.dir/all] Ошибка 2
make: *** [all] Ошибка 2  

```

So i fixed CMakeLists to match that.