### PR TITLE
Report unrecognized arguments from BENCHMARK_MAIN() macro

### DIFF
--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -168,6 +168,9 @@ class BenchmarkReporter;
 
 void Initialize(int* argc, char** argv);
 
+// Report to stdout all arguments in 'argv' as unrecognized except the first.
+void ReportUnrecognizedArguments(int argc, char** argv);
+
 // Generate a list of benchmarks matching the specified --benchmark_filter flag
 // and if --benchmark_list_tests is specified return after printing the name
 // of each matching benchmark. Otherwise run each matching benchmark and
@@ -858,11 +861,8 @@ class Fixture : public internal::Benchmark {
 #define BENCHMARK_MAIN()                   \
   int main(int argc, char** argv) {        \
     ::benchmark::Initialize(&argc, argv);  \
-    for (int i = 1; i < argc; ++i) {       \
-      fprintf(stdout, "%s: error: unrecognised command-line flag: %s\n", \
-              argv[0], argv[i]);           \
-    }                                      \
     if (argc > 1) {                        \
+      ::benchmark::ReportUnrecognizedArguments(argc, argv); \
       return 1;                            \
     }                                      \
     ::benchmark::RunSpecifiedBenchmarks(); \

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -169,7 +169,8 @@ class BenchmarkReporter;
 void Initialize(int* argc, char** argv);
 
 // Report to stdout all arguments in 'argv' as unrecognized except the first.
-void ReportUnrecognizedArguments(int argc, char** argv);
+// Returns true there is at least on unrecognized argument (i.e. 'argc' > 1).
+bool ReportUnrecognizedArguments(int argc, char** argv);
 
 // Generate a list of benchmarks matching the specified --benchmark_filter flag
 // and if --benchmark_list_tests is specified return after printing the name
@@ -861,10 +862,7 @@ class Fixture : public internal::Benchmark {
 #define BENCHMARK_MAIN()                   \
   int main(int argc, char** argv) {        \
     ::benchmark::Initialize(&argc, argv);  \
-    if (argc > 1) {                        \
-      ::benchmark::ReportUnrecognizedArguments(argc, argv); \
-      return 1;                            \
-    }                                      \
+    if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1; \
     ::benchmark::RunSpecifiedBenchmarks(); \
   }
 

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -858,6 +858,13 @@ class Fixture : public internal::Benchmark {
 #define BENCHMARK_MAIN()                   \
   int main(int argc, char** argv) {        \
     ::benchmark::Initialize(&argc, argv);  \
+    for (int i = 1; i < argc; ++i) {       \
+      fprintf(stdout, "%s: error: unrecognised command-line flag: %s\n", \
+              argv[0], argv[i]);           \
+    }                                      \
+    if (argc > 1) {                        \
+      return 1;                            \
+    }                                      \
     ::benchmark::RunSpecifiedBenchmarks(); \
   }
 

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -664,4 +664,10 @@ void Initialize(int* argc, char** argv) {
   internal::LogLevel() = FLAGS_v;
 }
 
+void ReportUnrecognizedArguments(int argc, char** argv) {
+  for (int i = 1; i < argc; ++i) {
+    printf("%s: error: unrecognised command-line flag: %s\n", argv[0], argv[i]);
+  }
+}
+
 }  // end namespace benchmark

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -666,7 +666,7 @@ void Initialize(int* argc, char** argv) {
 
 void ReportUnrecognizedArguments(int argc, char** argv) {
   for (int i = 1; i < argc; ++i) {
-    printf("%s: error: unrecognized command-line flag: %s\n", argv[0], argv[i]);
+    fprintf(stderr, "%s: error: unrecognized command-line flag: %s\n", argv[0], argv[i]);
   }
 }
 

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -666,7 +666,7 @@ void Initialize(int* argc, char** argv) {
 
 void ReportUnrecognizedArguments(int argc, char** argv) {
   for (int i = 1; i < argc; ++i) {
-    printf("%s: error: unrecognised command-line flag: %s\n", argv[0], argv[i]);
+    printf("%s: error: unrecognized command-line flag: %s\n", argv[0], argv[i]);
   }
 }
 

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -664,10 +664,11 @@ void Initialize(int* argc, char** argv) {
   internal::LogLevel() = FLAGS_v;
 }
 
-void ReportUnrecognizedArguments(int argc, char** argv) {
+bool ReportUnrecognizedArguments(int argc, char** argv) {
   for (int i = 1; i < argc; ++i) {
     fprintf(stderr, "%s: error: unrecognized command-line flag: %s\n", argv[0], argv[i]);
   }
+  return argc > 1;
 }
 
 }  // end namespace benchmark


### PR DESCRIPTION
- Add `benchmark::ReportUnrecognizedArguments()`
- Update `BENCHMARK_MAIN()` macro

See #320 for reference