### PR TITLE
Disable iOS CPU Frequency readout

### DIFF
--- a/src/internal_macros.h
+++ b/src/internal_macros.h
@@ -30,9 +30,13 @@
 #elif defined(_WIN32)
 #define BENCHMARK_OS_WINDOWS 1
 #elif defined(__APPLE__)
-// TODO(ericwf) This doesn't actually check that it is a Mac OSX system. Just
-// that it is an apple system.
-#define BENCHMARK_OS_MACOSX 1
+#include "TargetConditionals.h"
+  #if defined(TARGET_OS_MAC)
+    #define BENCHMARK_OS_MACOSX 1
+    #if defined(TARGET_OS_IPHONE)
+      #define BENCHMARK_OS_IOS 1
+    #endif
+  #endif
 #elif defined(__FreeBSD__)
 #define BENCHMARK_OS_FREEBSD 1
 #elif defined(__linux__)

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -295,8 +295,13 @@ void InitializeSystemInfo() {
       (size == sizeof(cpu_freq))) {
     cpuinfo_cycles_per_second = cpu_freq;
   } else {
+    #if defined BENCHMARK_OS_IOS
+    fprintf(stderr, "CPU frequency cannot be detected. \n");
+    cpuinfo_cycles_per_second = 0;
+    #else
     fprintf(stderr, "%s\n", strerror(errno));
     std::exit(EXIT_FAILURE);
+    #endif
   }
 #else
   // Generic cycles per second counter


### PR DESCRIPTION
`hw.cpufrequency` is not available on iOS devices. As there is no way to reliably
retrieve the CPU frequency on iOS we are printing out a warning
that we were unable to detect the CPU frequency and set it to 0.

This only disables cpu frequency readouts on actual physical iOS devices.
Running this code on the simulator still gives the cpu architecture of
the host computer as the simulator passes down the `sysctl` calls to OSX.