### PR TITLE
Implement ClobberMemory() and fix DoNotOptimize on MSVC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ static void BM_vector_push_back(benchmark::State& state) {
 }
 ```
 
-Note that `ClobberMemory()` is only available for GNU based compilers.
+Note that `ClobberMemory()` is only available for GNU or MSVC based compilers.
 
 ### Set time unit manually
 If a benchmark runs a few milliseconds it may be hard to visually compare the


### PR DESCRIPTION
I recently learned Windows provides a function called _ReadWriteBarrier
which is literally ClobberMemory under a different name. This patch
uses it to implement ClobberMemory under MSVC.

I'll commit this once the Microsoft bots confirm it's working.