### PR TITLE
Use PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   target_link_libraries(benchmark Shlwapi)
 endif()
 
-set(include_install_dir "include/benchmark")
+set(include_install_dir "include")
 set(lib_install_dir "lib/")
 set(bin_install_dir "bin/")
 set(config_install_dir "lib/cmake/${PROJECT_NAME}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,7 @@ write_basic_package_version_file(
     "${version_config}" VERSION ${GIT_VERSION} COMPATIBILITY SameMajorVersion
 )
 
-configure_file("${CMAKE_SOURCE_DIR}/cmake/Config.cmake.in" "${project_config}" @ONLY)
+configure_file("${PROJECT_SOURCE_DIR}/cmake/Config.cmake.in" "${project_config}" @ONLY)
 
 # Install target (will install the library to specified CMAKE_INSTALL_PREFIX variable)
 install(


### PR DESCRIPTION
As pointed out [here](https://github.com/google/benchmark/commit/824bbb818e2d34e546c77d719687ab732264603c#commitcomment-21670288) we should use PROJCT_SOURCE_DIR instead of CMAKE_SOURCE_DIR.
