### PR TITLE
fix android compilation

### DIFF
--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -164,7 +164,7 @@ bool BenchmarkFamilies::FindBenchmarks(
             }
           }
           
-#if defined(__ANDROID__) && (defined(__GLIBCXX__) || defined(__GLIBCPP__))
+#if defined(__ANDROID__) && defined(__GLIBCXX__)
           // workaround for Android, http://stackoverflow.com/questions/22774009/android-ndk-stdto-string-support
           std::ostringstream ss;
           ss << arg;

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -31,6 +31,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <thread>
 
 #include "check.h"
@@ -162,8 +163,15 @@ bool BenchmarkFamilies::FindBenchmarks(
                   StringPrintF("%s:", family->arg_names_[arg_i].c_str());
             }
           }
-
+          
+#ifdef __ANDROID__
+          // workaround for Android, http://stackoverflow.com/questions/22774009/android-ndk-stdto-string-support
+          std::ostringstream ss;
+          ss << arg;
+          instance.name += ss.str();
+#else
           instance.name += std::to_string(arg);
+#endif
           ++arg_i;
         }
 

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -164,7 +164,7 @@ bool BenchmarkFamilies::FindBenchmarks(
             }
           }
           
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && (defined(__GLIBCXX__) || defined(__GLIBCPP__))
           // workaround for Android, http://stackoverflow.com/questions/22774009/android-ndk-stdto-string-support
           std::ostringstream ss;
           ss << arg;

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -164,14 +164,7 @@ bool BenchmarkFamilies::FindBenchmarks(
             }
           }
           
-#if defined(__ANDROID__) && defined(__GLIBCXX__)
-          // workaround for Android, http://stackoverflow.com/questions/22774009/android-ndk-stdto-string-support
-          std::ostringstream ss;
-          ss << arg;
-          instance.name += ss.str();
-#else
-          instance.name += std::to_string(arg);
-#endif
+          instance.name += StringPrintF("%d", arg);
           ++arg_i;
         }
 

--- a/src/colorprint.cc
+++ b/src/colorprint.cc
@@ -89,7 +89,11 @@ std::string FormatString(const char* msg, va_list args) {
 
   std::size_t size = 256;
   char local_buff[256];
+#ifdef __ANDROID__
+  auto ret = ::vsnprintf(local_buff, size, msg, args_cp);
+#else 
   auto ret = std::vsnprintf(local_buff, size, msg, args_cp);
+#endif
 
   va_end(args_cp);
 
@@ -104,7 +108,11 @@ std::string FormatString(const char* msg, va_list args) {
     // we did not provide a long enough buffer on our first attempt.
     size = (size_t)ret + 1;  // + 1 for the null byte
     std::unique_ptr<char[]> buff(new char[size]);
+#ifdef __ANDROID__
+    ret = ::vsnprintf(buff.get(), size, msg, args);
+#else 
     ret = std::vsnprintf(buff.get(), size, msg, args);
+#endif
     CHECK(ret > 0 && ((size_t)ret) < size);
     return buff.get();
   }

--- a/src/colorprint.cc
+++ b/src/colorprint.cc
@@ -89,11 +89,7 @@ std::string FormatString(const char* msg, va_list args) {
 
   std::size_t size = 256;
   char local_buff[256];
-#if defined(__ANDROID__) && (defined(__GLIBCXX__) || defined(__GLIBCPP__))
-  auto ret = ::vsnprintf(local_buff, size, msg, args_cp);
-#else 
-  auto ret = std::vsnprintf(local_buff, size, msg, args_cp);
-#endif
+  auto ret = vsnprintf(local_buff, size, msg, args_cp);
 
   va_end(args_cp);
 
@@ -108,11 +104,7 @@ std::string FormatString(const char* msg, va_list args) {
     // we did not provide a long enough buffer on our first attempt.
     size = (size_t)ret + 1;  // + 1 for the null byte
     std::unique_ptr<char[]> buff(new char[size]);
-#if defined(__ANDROID__) && (defined(__GLIBCXX__) || defined(__GLIBCPP__))
-    ret = ::vsnprintf(buff.get(), size, msg, args);
-#else 
-    ret = std::vsnprintf(buff.get(), size, msg, args);
-#endif
+    ret = vsnprintf(buff.get(), size, msg, args);
     CHECK(ret > 0 && ((size_t)ret) < size);
     return buff.get();
   }

--- a/src/colorprint.cc
+++ b/src/colorprint.cc
@@ -89,7 +89,7 @@ std::string FormatString(const char* msg, va_list args) {
 
   std::size_t size = 256;
   char local_buff[256];
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && (defined(__GLIBCXX__) || defined(__GLIBCPP__))
   auto ret = ::vsnprintf(local_buff, size, msg, args_cp);
 #else 
   auto ret = std::vsnprintf(local_buff, size, msg, args_cp);
@@ -108,7 +108,7 @@ std::string FormatString(const char* msg, va_list args) {
     // we did not provide a long enough buffer on our first attempt.
     size = (size_t)ret + 1;  // + 1 for the null byte
     std::unique_ptr<char[]> buff(new char[size]);
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && (defined(__GLIBCXX__) || defined(__GLIBCPP__))
     ret = ::vsnprintf(buff.get(), size, msg, args);
 #else 
     ret = std::vsnprintf(buff.get(), size, msg, args);

--- a/test/register_benchmark_test.cc
+++ b/test/register_benchmark_test.cc
@@ -114,14 +114,14 @@ void TestRegistrationAtRuntime() {
 #endif
 #ifndef BENCHMARK_HAS_NO_VARIADIC_REGISTER_BENCHMARK
   {
-    int x = 42;
+    const char* x = "42";
     auto capturing_lam = [=](benchmark::State& st) {
       while (st.KeepRunning()) {
       }
-      st.SetLabel(std::to_string(x));
+      st.SetLabel(x);
     };
     benchmark::RegisterBenchmark("lambda_benchmark", capturing_lam);
-    AddCases({{"lambda_benchmark", "42"}});
+    AddCases({{"lambda_benchmark", x}});
   }
 #endif
 }


### PR DESCRIPTION
I'm working on GRPC for Android. Here are changes to build benchmark with CMake for Android. Instructions (MSVS + Ninja), related to [this](https://github.com/google/protobuf/pull/2980):

1. Install Android SDK
2. Install Android NDK. Generally only NDK is necessary, SDK just may be useful for other purposes.
3. Set environment variable ANDROID_NDK
4. Install Ninja. Just drop ninja.exe somewhere where it can be accessed from command line, for example, alongside cmake binaries.
5. Build benchmark:
```
    mkdir _android_build
    cd _android_build
    cmake .. -G Ninja -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=21 -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a -DCMAKE_ANDROID_STL_TYPE=gnustl_static -DRUN_HAVE_STD_REGEX=0 -DRUN_HAVE_POSIX_REGEX=0 -DRUN_HAVE_STEADY_CLOCK=0
    cmake --build .
```
