### PR TITLE
Ensure all the necessary keys are present before parsing JSON data

### DIFF
--- a/tools/gbench/report.py
+++ b/tools/gbench/report.py
@@ -80,7 +80,9 @@ def generate_difference_report(json1, json2, use_color=True):
     first_line = "{:<{}s}     Time           CPU           Old           New".format(
         'Benchmark', first_col_width)
     output_strs = [first_line, '-' * len(first_line)]
-    for bn in json1['benchmarks']:
+
+    gen = (bn for bn in json1['benchmarks'] if 'real_time' in bn and 'cpu_time' in bn)
+    for bn in gen:
         other_bench = find_test(bn['name'])
         if not other_bench:
             continue


### PR DESCRIPTION
This prevents errors when additional non-timing data are present in
the JSON that is loaded, for example when complexity data has been
computed (see #379).