### PR TITLE
Change `config_install_dir` to share/benchmark

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 set(include_install_dir "include")
 set(lib_install_dir "lib/")
 set(bin_install_dir "bin/")
-set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(config_install_dir "share/${PROJECT_NAME}")
 
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 


### PR DESCRIPTION
Hi.

Can we change `config_install_dir` to `share/benchmark`?
CMake works well with both paths, but new path allows me to use google benchmark without patching your CMakeLists.txt on [vcpkg](https://github.com/Microsoft/vcpkg)