### PR TITLE
Use NEW settings for CMP0063 policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project (benchmark)
 foreach(p
     CMP0054 # CMake 3.1
     CMP0056 # export EXE_LINKER_FLAGS to try_run
+    CMP0063 # CMake 3.3 - honour symbol visability for static libraries
     )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)


### PR DESCRIPTION
This removes warnings when using CMake >= 3.3 if you have symbol visibility set.