### PR TITLE
Fix ThreadCPUUsage for when compiling for RTEMS.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -51,6 +51,7 @@ Pierre Phaneuf <pphaneuf@google.com>
 Radoslav Yovchev <radoslav.tm@gmail.com>
 Ray Glover <ray.glover@uk.ibm.com>
 Shuo Chen <chenshuo@chenshuo.com>
+Tom Madams <tom.ej.madams@gmail.com> <tmadams@google.com>
 Yixuan Qiu <yixuanq@gmail.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Tobias Ulvgård <tobias.ulvgard@dirac.se>

--- a/src/internal_macros.h
+++ b/src/internal_macros.h
@@ -45,6 +45,8 @@
 #define BENCHMARK_OS_NACL 1
 #elif defined(EMSCRIPTEN)
 #define BENCHMARK_OS_EMSCRIPTEN 1
+#elif defined(__rtems__)
+#define BENCHMARK_OS_RTEMS 1
 #endif
 
 #if !__has_feature(cxx_exceptions) && !defined(__cpp_exceptions) \

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -158,6 +158,10 @@ double ThreadCPUUsage() {
 #elif defined(BENCHMARK_OS_EMSCRIPTEN)
   // Emscripten doesn't support traditional threads
   return ProcessCPUUsage();
+#elif defined(BENCHMARK_OS_RTEMS)
+  // RTEMS doesn't support CLOCK_THREAD_CPUTIME_ID. See
+  // https://github.com/RTEMS/rtems/blob/master/cpukit/posix/src/clockgettime.c
+  return ProcessCPUUsage();
 #elif defined(CLOCK_THREAD_CPUTIME_ID)
   struct timespec ts;
   if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) == 0) return MakeTime(ts);


### PR DESCRIPTION
Change ThreadCPUUsage to call ProcessCPUUsage if __rtems__ is defined.

RTEMS real time OS doesn't support CLOCK_THREAD_CPUTIME_ID. See
https://github.com/RTEMS/rtems/blob/master/cpukit/posix/src/clockgettime.c#L58-L59

Prior to this change the first call to ThreadCPUUsage() made when running
on RTEMS would fail with:
  ERROR: clock_gettime(CLOCK_THREAD_CPUTIME_ID, ...) failed