### PR TITLE
Disable cxx03_test for GCC 5.x and above. (#420)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ matrix:
     - compiler: gcc
       env: COMPILER=g++ C_COMPILER=gcc BUILD_TYPE=Release
     - compiler: gcc
-      env: COMPILER=g++-5.8 C_COMPILER=gcc-5.8 BUILD_TYPE=Release
-    - compiler: gcc
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
     - compiler: gcc
       env: COMPILER=g++ C_COMPILER=gcc BUILD_TYPE=Release
     - compiler: gcc
+      env: COMPILER=g++-5.8 C_COMPILER=gcc-5.8 BUILD_TYPE=Release
+    - compiler: gcc
       addons:
         apt:
           packages:

--- a/README.md
+++ b/README.md
@@ -715,7 +715,8 @@ The following minimum versions are strongly recommended build the library:
 Anything older *may* work.
 
 Note: Using the library and its headers in C++03 is supported. C++11 is only
-required to build the library.
+required to build the library. (Although this will not work for gcc 5.1 and
+above - for these complilers, stick with -std=c++11.)
 
 # Known Issues
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -105,7 +105,7 @@ compile_output_test(user_counters_tabular_test)
 add_test(user_counters_tabular_test user_counters_tabular_test --benchmark_counters_tabular=true --benchmark_min_time=0.01)
 
 check_cxx_compiler_flag(-std=c++03 BENCHMARK_HAS_CXX03_FLAG)
-if (BENCHMARK_HAS_CXX03_FLAG)
+if (BENCHMARK_HAS_CXX03_FLAG AND CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
   set(CXX03_FLAGS "${CMAKE_CXX_FLAGS}")
   string(REPLACE "-std=c++11" "-std=c++03" CXX03_FLAGS "${CXX03_FLAGS}")
   string(REPLACE "-std=c++0x" "-std=c++03" CXX03_FLAGS "${CXX03_FLAGS}")


### PR DESCRIPTION
GCC 5.x does not keep the same definitions for std::map between
C++11 and C++03, leading to ODR violations for anything using
std::map with link type optimizations.