### PR TITLE
added meta data to benchmarks

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -570,6 +570,9 @@ class State {
   BENCHMARK_DISALLOW_COPY_AND_ASSIGN(State);
 };
 
+
+
+
 namespace internal {
 
 typedef void(Function)(State&);
@@ -583,7 +586,7 @@ typedef void(Function)(State&);
 class Benchmark {
  public:
   virtual ~Benchmark();
-
+  typedef std::map<std::string, std::string> MetaDataType;
   // Note: the following methods all return "this" so that multiple
   // method calls can be chained together in one expression.
 
@@ -705,6 +708,10 @@ class Benchmark {
   // Run one instance of this benchmark concurrently in t threads.
   Benchmark* Threads(int t);
 
+
+  Benchmark* AddMetaData(const std::string & key, const std::string & val);
+  const MetaDataType & MetaData()const;
+
   // Pick a set of values T from [min_threads,max_threads].
   // min_threads and max_threads are always included in T.  Run this
   // benchmark once for each value in T.  The benchmark run for a
@@ -759,7 +766,7 @@ class Benchmark {
   BigO complexity_;
   BigOFunc* complexity_lambda_;
   std::vector<int> thread_counts_;
-
+  MetaDataType meta_data_;
   Benchmark& operator=(Benchmark const&);
 };
 
@@ -1029,7 +1036,11 @@ class BenchmarkReporter {
           complexity_n(0),
           report_big_o(false),
           report_rms(false),
-          counters() {}
+          counters(),
+          meta_data(){
+
+          }
+
 
     std::string benchmark_name;
     std::string report_label;  // Empty if not set by benchmark.
@@ -1070,6 +1081,7 @@ class BenchmarkReporter {
     bool report_rms;
 
     UserCounters counters;
+    std::map<std::string, std::string> meta_data;
   };
 
   // Construct a BenchmarkReporter with the output stream set to 'std::cout'

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -235,6 +235,8 @@ BenchmarkReporter::Run CreateRunReport(
   report.iterations = static_cast<int64_t>(iters) * b.threads;
   report.time_unit = b.time_unit;
 
+  // meta data
+  report.meta_data = b.benchmark->MetaData();
   if (!report.error_occurred) {
     double bytes_per_second = 0;
     if (results.bytes_processed > 0 && seconds > 0.0) {

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -398,6 +398,16 @@ Benchmark* Benchmark::UseManualTime() {
   return this;
 }
 
+
+Benchmark* Benchmark::AddMetaData(const std::string & key, const std::string & val){
+  meta_data_[key] = val;
+  return this;
+}
+
+const Benchmark::MetaDataType & Benchmark::MetaData()const{
+  return meta_data_;
+}
+
 Benchmark* Benchmark::Complexity(BigO complexity) {
   complexity_ = complexity;
   return this;

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -146,7 +146,9 @@ void ConsoleReporter::PrintRunData(const Run& result) {
   if (!result.report_big_o && !result.report_rms) {
     printer(Out, COLOR_CYAN, "%10lld", result.iterations);
   }
-
+  for (auto & kv : result.meta_data) {
+    printer(Out, COLOR_DEFAULT, " %s=%s",kv.first.c_str(), kv.second.c_str());
+  }
   for (auto& c : result.counters) {
     auto const& s = HumanReadableNumber(c.second.value);
     if (output_options_ & OO_Tabular) {
@@ -161,6 +163,7 @@ void ConsoleReporter::PrintRunData(const Run& result) {
               unit);
     }
   }
+
 
   if (!rate.empty()) {
     printer(Out, COLOR_DEFAULT, " %*s", 13, rate.c_str());

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -154,9 +154,28 @@ void JSONReporter::PrintRunData(Run const& run) {
         << indent
         << FormatKV("items_per_second", RoundDouble(run.items_per_second));
   }
+  if(!run.meta_data.empty()){
+
+    out <<",\n"
+        <<indent
+        <<"\"meta_data\" : {\n";
+    std::size_t c=0;
+    for (auto & kv : run.meta_data) {
+      out << indent << "  "
+          << FormatKV(kv.first, kv.second.c_str());
+      if(c + 1 < run.meta_data.size()){
+        out<<",\n";
+      }
+      else{
+        out<<"\n";
+      }
+      ++c;
+    }
+    out<<indent<<"}";
+  }
   for(auto &c : run.counters) {
     out << ",\n"
-        << indent
+        << indent 
         << FormatKV(c.first, RoundDouble(c.second));
   }
   if (!run.report_label.empty()) {


### PR DESCRIPTION
With this little hack one can add meta-data to a benchmark
and store the meta data also to json.

```
static void BM_memcpy(benchmark::State& state) {
  char* src = new char[state.range(0)];
  char* dst = new char[state.range(0)];
  memset(src, 'x', state.range(0));
  while (state.KeepRunning())
    memcpy(dst, src, state.range(0));
  state.SetBytesProcessed(int64_t(state.iterations()) *
                          int64_t(state.range(0)));
  delete[] src;
  delete[] dst;
}
BENCHMARK(BM_memcpy)->Range(8, 8<<10)->AddMetaData("key1","val1")->AddMetaData("foo", "bar")
```

If you consider to merge this PR I can do some cleanup