### PR TITLE
Improve README's basic usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ IRC channel: https://freenode.net #googlebenchmark
 Define a function that executes the code to be measured.
 
 ```c++
+#include <benchmark/benchmark.h>
+
 static void BM_StringCreation(benchmark::State& state) {
   while (state.KeepRunning())
     std::string empty_string;
@@ -35,6 +37,8 @@ BENCHMARK(BM_StringCopy);
 
 BENCHMARK_MAIN();
 ```
+
+Don't forget to inform your linker to add benchmark library e.g. through `-lbenchmark` compilation flag.
 
 ### Passing arguments
 Sometimes a family of benchmarks can be implemented with just one routine that


### PR DESCRIPTION
I guess below discussion from #googlebenchmark explains why we need that :)
```
19:09 <disconnect3d> hey, is there any example of how to use gbenchmark in terms of building a simple benchmark?
19:10 <LebedevRI> building as in compiling, or writing?
19:11 <disconnect3d> writing a benchmark
19:11 <disconnect3d> like... I've instaled a google benchmark package from AUR for Arch Linux
19:11 <LebedevRI> https://github.com/google/benchmark/blob/master/README.md has samples
19:11 <disconnect3d> I mean I have no idea how to use it :\
19:11 <disconnect3d> well i took the code from 'basic usage'
19:12 <disconnect3d> but it doesnt include anything
19:12 <disconnect3d> nor it tells to use any -lgoogle-benchmark and so on
19:12 <LebedevRI> true, #include <benchmark/benchmark.h> is needed
19:13 <disconnect3d> better
19:13 <disconnect3d> got it compiled, thanks!
19:13 <disconnect3d> will make a PR
```