### PR TITLE
Always use inline asm DoNotOptimize with clang.

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -295,6 +295,7 @@ BENCHMARK_UNUSED static int stream_init_anchor = InitializeStreams();
 # define BENCHMARK_HAS_NO_INLINE_ASSEMBLY
 #endif
 
+
 // The DoNotOptimize(...) function can be used to prevent a value or
 // expression from being optimized away by the compiler. This function is
 // intended to add little to no overhead.

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -290,7 +290,8 @@ BENCHMARK_UNUSED static int stream_init_anchor = InitializeStreams();
 }  // namespace internal
 
 
-#if !defined(__GNUC__) || defined(__pnacl__) || defined(EMSCRIPTN)
+#if (!defined(__GNUC__) && !defined(__clang__)) || defined(__pnacl__) || \
+    defined(EMSCRIPTN)
 # define BENCHMARK_HAS_NO_INLINE_ASSEMBLY
 #endif
 


### PR DESCRIPTION
clang-cl masquerades as MSVC but not GCC, so it was using the
MSVC-compatible definitions of DoNotOptimize and ClobberMemory.
Presumably, it's better in general to use the targeted assembly for
this functionality (the codegen is different), but the specific issue
is that clang-cl deprecates the usage of _ReadWriteBarrier, and this
gets rid of that warning.