### PR TITLE
Convert negative 0 to 0 in console reporter.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,11 @@ if (BENCHMARK_BUILD_32_BITS)
   add_required_cxx_compiler_flag(-m32)
 endif()
 
+
+if (BENCHMARK_MINGW)
+  add_definitions(-D__USE_MINGW_ANSI_STDIO=1)
+endif (BENCHMARK_MINGW)
+
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # Turn compiler warnings up to 11
   string(REGEX REPLACE "[-/]W[1-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
@@ -51,10 +56,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     add_cxx_compiler_flag(-EHs-)
     add_cxx_compiler_flag(-EHa-)
   endif()
-
-  if (BENCHMARK_MINGW)
-    add_definitions(-D__USE_MINGW_ANSI_STDIO=1)
-  endif (BENCHMARK_MINGW)
 
   # Link time optimisation
   if (BENCHMARK_ENABLE_LTO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     add_cxx_compiler_flag(-EHs-)
     add_cxx_compiler_flag(-EHa-)
   endif()
+
+  if (BENCHMARK_MINGW)
+    add_definitions(-D__USE_MINGW_ANSI_STDIO=1)
+  endif (BENCHMARK_MINGW)
+
   # Link time optimisation
   if (BENCHMARK_ENABLE_LTO)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /GL")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,14 +6,13 @@ configuration:
   - Debug
   - Release
 
-mingw: OFF
-
 environment:
+  mingw: "OFF"
   matrix:
     - compiler: gcc-5.3.0-posix
       generator: "MinGW Makefiles"
       cxx_path: 'C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin'
-      mingw: ON
+      mingw: "ON"
 
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
@@ -46,7 +45,7 @@ install:
 build_script:
   - md _build -Force
   - cd _build
-  - echo %configuration%
+  - echo %configuration% %mingw%
   - cmake -G "%generator%" "-DCMAKE_BUILD_TYPE=%configuration%"  "-DBENCHMARK_MINGW=%mingw%" ..
   - cmake --build . --config %configuration%
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,12 @@ configuration:
 
 environment:
   matrix:
+    - compiler: gcc-5.3.0-posix
+      generator: "MinGW Makefiles"
+      cxx_path: 'C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin'
+
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
     - compiler: msvc-15-seh
       generator: "Visual Studio 15 2017"
 
@@ -25,11 +31,6 @@ environment:
 
     - compiler: msvc-12-seh
       generator: "Visual Studio 12 2013 Win64"
-
-    - compiler: gcc-5.3.0-posix
-      generator: "MinGW Makefiles"
-      cxx_path: 'C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin'
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,14 @@ configuration:
   - Debug
   - Release
 
+mingw: OFF
+
 environment:
   matrix:
     - compiler: gcc-5.3.0-posix
       generator: "MinGW Makefiles"
       cxx_path: 'C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin'
+      mingw: ON
 
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
@@ -44,7 +47,7 @@ build_script:
   - md _build -Force
   - cd _build
   - echo %configuration%
-  - cmake -G "%generator%" "-DCMAKE_BUILD_TYPE=%configuration%" ..
+  - cmake -G "%generator%" "-DCMAKE_BUILD_TYPE=%configuration%"  "-DBENCHMARK_MINGW=%mingw%" ..
   - cmake --build . --config %configuration%
 
 test_script:

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -127,8 +127,19 @@ void ConsoleReporter::PrintRunData(const Run& result) {
         StrCat(" ", HumanReadableNumber(result.items_per_second), " items/s");
   }
 
-  const double real_time = result.GetAdjustedRealTime();
-  const double cpu_time = result.GetAdjustedCPUTime();
+  double real_time = result.GetAdjustedRealTime();
+  if (real_time < 0) {
+    if (std::fabs(real_time) < std::numeric_limits<double>::epsilon()) {
+      real_time = 0.0;
+    }
+  }
+
+  double cpu_time = result.GetAdjustedCPUTime();
+  if (cpu_time < 0) {
+    if (std::fabs(cpu_time) < std::numeric_limits<double>::epsilon()) {
+      cpu_time = 0.0;
+    }
+  }
 
   if (result.report_big_o) {
     std::string big_o = GetBigOString(result.complexity);

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -39,6 +39,7 @@
 #include <emscripten.h>
 #endif
 
+#include <cassert>
 #include <cerrno>
 #include <cstdint>
 #include <cstdio>
@@ -113,7 +114,7 @@ double ProcessCPUUsage() {
   if (GetProcessTimes(proc, &creation_time, &exit_time, &kernel_time,
                       &user_time))
     return MakeTime(kernel_time, user_time);
-  DiagnoseAndExit("GetProccessTimes() failed");
+  DiagnoseAndExit("GetProcessTimes() failed");
 #elif defined(BENCHMARK_OS_EMSCRIPTEN)
   // clock_gettime(CLOCK_PROCESS_CPUTIME_ID, ...) returns 0 on Emscripten.
   // Use Emscripten-specific API. Reported CPU time would be exactly the
@@ -141,9 +142,10 @@ double ThreadCPUUsage() {
   FILETIME exit_time;
   FILETIME kernel_time;
   FILETIME user_time;
-  assert(GetThreadTimes(this_thread, &creation_time, &exit_time, &kernel_time,
-                        &user_time) != 0);
-  return MakeTime(kernel_time, user_time);
+  if (GetThreadTimes(this_thread, &creation_time, &exit_time,
+                                &kernel_time, &user_time))
+    return MakeTime(kernel_time, user_time);
+  DiagnoseAndExit("GetThreadTimes failed");
 #elif defined(BENCHMARK_OS_MACOSX)
   // FIXME We want to use clock_gettime, but its not available in MacOS 10.11. See
   // https://github.com/google/benchmark/pull/292

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -141,8 +141,8 @@ double ThreadCPUUsage() {
   FILETIME exit_time;
   FILETIME kernel_time;
   FILETIME user_time;
-  GetThreadTimes(this_thread, &creation_time, &exit_time, &kernel_time,
-                 &user_time);
+  assert(GetThreadTimes(this_thread, &creation_time, &exit_time, &kernel_time,
+                        &user_time) != 0);
   return MakeTime(kernel_time, user_time);
 #elif defined(BENCHMARK_OS_MACOSX)
   // FIXME We want to use clock_gettime, but its not available in MacOS 10.11. See

--- a/test/output_test_helper.cc
+++ b/test/output_test_helper.cc
@@ -40,7 +40,7 @@ SubMap& GetSubstitutions() {
       {"%hrfloat", "[0-9]*[.]?[0-9]+([eE][-+][0-9]+)?[kMGTPEZYmunpfazy]?"},
       {"%int", "[ ]*[0-9]+"},
       {" %s ", "[ ]+"},
-      {"%time", "[ ]*[0-9]{1,5} ns"},
+      {"%time", "[ ]*[0-9]{1,9} ns"},
       {"%console_report", "[ ]*[0-9]{1,5} ns [ ]*[0-9]{1,5} ns [ ]*[0-9]+"},
       {"%console_us_report", "[ ]*[0-9] us [ ]*[0-9] us [ ]*[0-9]+"},
       {"%csv_header",


### PR DESCRIPTION
Windows builds will occasionally show -0 for CPU times when the time is
very short. This is likely related to the weaknesses in GetThreadTimes.

As a workaround, check for small negative numbers and ensure they're 0
in the console reporter.