### PR TITLE
Avoid implicit float to double conversion

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@
 
 Albert Pretorius <pretoalb@gmail.com>
 Arne Beer <arne@twobeer.de>
+Carto
 Christopher Seymour <chris.j.seymour@hotmail.com>
 David Coeurjolly <david.coeurjolly@liris.cnrs.fr>
 Dirac Research 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -50,6 +50,7 @@ Pascal Leroy <phl@google.com>
 Paul Redmond <paul.redmond@gmail.com>
 Pierre Phaneuf <pphaneuf@google.com>
 Radoslav Yovchev <radoslav.tm@gmail.com>
+Raul Marin <rmrodriguez@cartodb.com>
 Ray Glover <ray.glover@uk.ibm.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Tobias Ulvgård <tobias.ulvgard@dirac.se>

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -491,7 +491,7 @@ void RunBenchmarks(const std::vector<Benchmark::Instance>& benchmarks,
   // Print header here
   BenchmarkReporter::Context context;
   context.num_cpus = NumCPUs();
-  context.mhz_per_cpu = CyclesPerSecond() / 1000000.0f;
+  context.mhz_per_cpu = CyclesPerSecond() / 1000000.0;
 
   context.cpu_scaling_enabled = CpuScalingEnabled();
   context.name_field_width = name_field_width;


### PR DESCRIPTION
Fixing build error triggered by `-Wdouble-promotion`:
```
Scanning dependencies of target benchmark
[  1%] Building CXX object src/CMakeFiles/benchmark.dir/benchmark.cc.o
/home/raul/dev/public/benchmark/src/benchmark.cc: In function 'void benchmark::internal::{anonymous}::RunBenchmarks(const std::vector<benchmark::internal::Benchmark::Instance>&, benchmark::BenchmarkReporter*, benchmark::BenchmarkReporter*)'
/home/raul/dev/public/benchmark/src/benchmark.cc:494:43: error: implicit conversion from 'float' to 'double' to match other operand of binary expression [-Werror=double-promotion]
   context.mhz_per_cpu = CyclesPerSecond() / 1000000.0f;
                         ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```