### PR TITLE
 Improve BM_SetInsert example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ static void BM_SetInsert(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_SetInsert)
-    ->Args({1<<10, 1})
-    ->Args({1<<10, 8})
-    ->Args({1<<10, 64})
+    ->Args({1<<10, 128})
+    ->Args({2<<10, 128})
+    ->Args({4<<10, 128})
+    ->Args({8<<10, 128})
     ->Args({1<<10, 512})
-    ->Args({8<<10, 1})
-    ->Args({8<<10, 8})
-    ->Args({8<<10, 64})
+    ->Args({2<<10, 512})
+    ->Args({4<<10, 512})
     ->Args({8<<10, 512});
 ```
 
@@ -110,7 +110,7 @@ product of the two specified ranges and will generate a benchmark for each such
 pair.
 
 ```c++
-BENCHMARK(BM_SetInsert)->Ranges({{1<<10, 8<<10}, {1, 512}});
+BENCHMARK(BM_SetInsert)->Ranges({{1<<10, 8<<10}, {128, 512}});
 ```
 
 For more complex patterns of inputs, passing a custom function to `Apply` allows

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ insertion.
 
 ```c++
 static void BM_SetInsert(benchmark::State& state) {
+  std::set<int> data;
   for (auto _ : state) {
     state.PauseTiming();
-    std::set<int> data = ConstructRandomSet(state.range(0));
+    data = ConstructRandomSet(state.range(0));
     state.ResumeTiming();
     for (int j = 0; j < state.range(1); ++j)
       data.insert(RandomNumber());

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -72,9 +72,10 @@ BENCHMARK(BM_memcpy)->Range(8, 8<<10);
 // example, the following code defines a family of microbenchmarks for
 // measuring the speed of set insertion.
 static void BM_SetInsert(benchmark::State& state) {
+  set<int> data;
   for (auto _ : state) {
     state.PauseTiming();
-    set<int> data = ConstructRandomSet(state.range(0));
+    data = ConstructRandomSet(state.range(0));
     state.ResumeTiming();
     for (int j = 0; j < state.range(1); ++j)
       data.insert(RandomNumber());

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -82,20 +82,20 @@ static void BM_SetInsert(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_SetInsert)
-   ->Args({1<<10, 1})
-   ->Args({1<<10, 8})
-   ->Args({1<<10, 64})
+   ->Args({1<<10, 128})
+   ->Args({2<<10, 128})
+   ->Args({4<<10, 128})
+   ->Args({8<<10, 128})
    ->Args({1<<10, 512})
-   ->Args({8<<10, 1})
-   ->Args({8<<10, 8})
-   ->Args({8<<10, 64})
+   ->Args({2<<10, 512})
+   ->Args({4<<10, 512})
    ->Args({8<<10, 512});
 
 // The preceding code is quite repetitive, and can be replaced with
 // the following short-hand.  The following macro will pick a few
 // appropriate arguments in the product of the two specified ranges
 // and will generate a microbenchmark for each such pair.
-BENCHMARK(BM_SetInsert)->Ranges({{1<<10, 8<<10}, {1, 512}});
+BENCHMARK(BM_SetInsert)->Ranges({{1<<10, 8<<10}, {128, 512}});
 
 // For more complex patterns of inputs, passing a custom function
 // to Apply allows programmatic specification of an

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -83,16 +83,17 @@ BENCHMARK(BM_CalculatePi)->ThreadPerCpu();
 
 static void BM_SetInsert(benchmark::State& state) {
   std::set<int> data;
+  std::set<int> orig = ConstructRandomSet(state.range(0));
   for (auto _ : state) {
     state.PauseTiming();
-    data = ConstructRandomSet(state.range(0));
+    data = orig;
     state.ResumeTiming();
     for (int j = 0; j < state.range(1); ++j) data.insert(rand());
   }
   state.SetItemsProcessed(state.iterations() * state.range(1));
   state.SetBytesProcessed(state.iterations() * state.range(1) * sizeof(int));
 }
-BENCHMARK(BM_SetInsert)->Ranges({{1 << 10, 8 << 10}, {1, 10}});
+BENCHMARK(BM_SetInsert)->Ranges({{1 << 12, 1 << 15}, {100, 500}});
 
 template <typename Container,
           typename ValueType = typename Container::value_type>

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -42,7 +42,7 @@ double CalculatePi(int depth) {
 
 std::set<int> ConstructRandomSet(int size) {
   std::set<int> s;
-  for (int i = 0; i < size; ++i) s.insert(i);
+  for (int i = 0; i < size; ++i) s.insert(s.end(), i);
   return s;
 }
 
@@ -83,17 +83,19 @@ BENCHMARK(BM_CalculatePi)->ThreadPerCpu();
 
 static void BM_SetInsert(benchmark::State& state) {
   std::set<int> data;
-  std::set<int> orig = ConstructRandomSet(state.range(0));
   for (auto _ : state) {
     state.PauseTiming();
-    data = orig;
+    data = ConstructRandomSet(state.range(0));
     state.ResumeTiming();
     for (int j = 0; j < state.range(1); ++j) data.insert(rand());
   }
   state.SetItemsProcessed(state.iterations() * state.range(1));
   state.SetBytesProcessed(state.iterations() * state.range(1) * sizeof(int));
 }
-BENCHMARK(BM_SetInsert)->Ranges({{1 << 12, 1 << 15}, {100, 500}});
+
+// Test many inserts at once to reduce the total iterations needed. Otherwise, the slower,
+// non-timed part of each iteration will make the benchmark take forever.
+BENCHMARK(BM_SetInsert)->Ranges({{1 << 10, 8 << 10}, {128, 512}});
 
 template <typename Container,
           typename ValueType = typename Container::value_type>

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -82,9 +82,10 @@ BENCHMARK(BM_CalculatePi)->ThreadRange(1, 32);
 BENCHMARK(BM_CalculatePi)->ThreadPerCpu();
 
 static void BM_SetInsert(benchmark::State& state) {
+  std::set<int> data;
   for (auto _ : state) {
     state.PauseTiming();
-    std::set<int> data = ConstructRandomSet(state.range(0));
+    data = ConstructRandomSet(state.range(0));
     state.ResumeTiming();
     for (int j = 0; j < state.range(1); ++j) data.insert(rand());
   }

--- a/test/map_test.cc
+++ b/test/map_test.cc
@@ -18,9 +18,10 @@ std::map<int, int> ConstructRandomMap(int size) {
 // Basic version.
 static void BM_MapLookup(benchmark::State& state) {
   const int size = state.range(0);
+  std::map<int, int> m;
   for (auto _ : state) {
     state.PauseTiming();
-    std::map<int, int> m = ConstructRandomMap(size);
+    m = ConstructRandomMap(size);
     state.ResumeTiming();
     for (int i = 0; i < size; ++i) {
       benchmark::DoNotOptimize(m.find(rand() % size));


### PR DESCRIPTION
Fix #464 

Move declaration of the container outside the timing loop, so the destructor is not timed.

The catch is the test now takes an unreasonably long time. `ConstructRandomSet` takes much longer than `insert`, and only `insert` is used to determine the number of iterations.

There are a few ways to speed it up:
  - Increase the `Ranges()` parameters
  - Cache `ConstructRandomSet()` result (it's not random anyway), and just copy it every iteration

Any feedback is appreciated.