### PR TITLE
Reorder inline to avoid warning on MSVC

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -642,10 +642,10 @@ struct State::StateIterator {
   State* const parent_;
 };
 
-BENCHMARK_ALWAYS_INLINE inline State::StateIterator State::begin() {
+inline BENCHMARK_ALWAYS_INLINE State::StateIterator State::begin() {
   return StateIterator(this);
 }
-BENCHMARK_ALWAYS_INLINE inline State::StateIterator State::end() {
+inline BENCHMARK_ALWAYS_INLINE State::StateIterator State::end() {
   StartKeepRunning();
   return StateIterator();
 }


### PR DESCRIPTION
This matches the other uses of BENCHMARK_ALWAYS_INLINE in the file.

Fixes #467 
