### PR TITLE
Console reporter: properly account for the lenght of custom counter n…

### DIFF
--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -148,12 +148,14 @@ void ConsoleReporter::PrintRunData(const Run& result) {
   }
 
   for (auto& c : result.counters) {
+    const std::size_t cNameLen = std::max(std::string::size_type(10),
+                                          c.first.length());
     auto const& s = HumanReadableNumber(c.second.value, 1000);
     if (output_options_ & OO_Tabular) {
       if (c.second.flags & Counter::kIsRate) {
-        printer(Out, COLOR_DEFAULT, " %8s/s", s.c_str());
+        printer(Out, COLOR_DEFAULT, " %*s/s", cNameLen - 2, s.c_str());
       } else {
-        printer(Out, COLOR_DEFAULT, " %10s", s.c_str());
+        printer(Out, COLOR_DEFAULT, " %*s", cNameLen, s.c_str());
       }
     } else {
       const char* unit = (c.second.flags & Counter::kIsRate) ? "/s" : "";


### PR DESCRIPTION
…ames

Old output example:
```
Benchmark                                                 Time           CPU Iterations  CPUTime,s   Pixels/s ThreadingFactor
------------------------------------------------------------------------------------------------------------------------------
20170525_0036TEST.RAF/threads:8/real_time                45 ms         45 ms         16   0.718738 79.6277M/s   0.999978   2.41419GB/s    22.2613 items/s FileSize,MB=111.050781; MPix=57.231360
```

New output example:
```
Benchmark                                                 Time           CPU Iterations  CPUTime,s   Pixels/s ThreadingFactor
------------------------------------------------------------------------------------------------------------------------------
20170525_0036TEST.RAF/threads:8/real_time                45 ms         45 ms         16   0.713575 80.1713M/s        0.999571   2.43067GB/s    22.4133 items/s FileSize,MB=111.050781; MPix=57.231360
```

The `user_counters_tabular_test` does not care about the exact spacing, so there are no test changes...