### PR TITLE
Fix warnings on MSVC about double `inline`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Christopher Seymour <chris.j.seymour@hotmail.com>
 David Coeurjolly <david.coeurjolly@liris.cnrs.fr>
 Dirac Research 
 Dominik Czarnota <dominik.b.czarnota@gmail.com>
+Elias Kosunen <elias.kosunen@gmail.com>
 Eric Fiselier <eric@efcs.ca>
 Eugene Zhuk <eugene.zhuk@gmail.com>
 Evgeny Safronov <division494@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -30,6 +30,7 @@ Christopher Seymour <chris.j.seymour@hotmail.com>
 David Coeurjolly <david.coeurjolly@liris.cnrs.fr>
 Dominic Hamon <dma@stripysock.com> <dominic@google.com>
 Dominik Czarnota <dominik.b.czarnota@gmail.com>
+Elias Kosunen <elias.kosunen@gmail.com>
 Eric Fiselier <eric@efcs.ca>
 Eugene Zhuk <eugene.zhuk@gmail.com>
 Evgeny Safronov <division494@gmail.com>

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -302,7 +302,7 @@ BENCHMARK_UNUSED static int stream_init_anchor = InitializeStreams();
 // See: https://youtu.be/nXaxk27zwlk?t=2441
 #ifndef BENCHMARK_HAS_NO_INLINE_ASSEMBLY
 template <class Tp>
-inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
+BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   // Clang doesn't like the 'X' constraint on `value` and certain GCC versions
   // don't like the 'g' constraint. Attempt to placate them both.
 #if defined(__clang__)
@@ -313,22 +313,22 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
 }
 // Force the compiler to flush pending writes to global memory. Acts as an
 // effective read/write barrier
-inline BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
+BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
   asm volatile("" : : : "memory");
 }
 #elif defined(_MSC_VER)
 template <class Tp>
-inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
+BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
   _ReadWriteBarrier();
 }
 
-inline BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
+BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
   _ReadWriteBarrier();
 }
 #else
 template <class Tp>
-inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
+BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
 }
 // FIXME Add ClobberMemory() for non-gnu and non-msvc compilers
@@ -642,10 +642,10 @@ struct State::StateIterator {
   State* const parent_;
 };
 
-inline BENCHMARK_ALWAYS_INLINE State::StateIterator State::begin() {
+BENCHMARK_ALWAYS_INLINE State::StateIterator State::begin() {
   return StateIterator(this);
 }
-inline BENCHMARK_ALWAYS_INLINE State::StateIterator State::end() {
+BENCHMARK_ALWAYS_INLINE State::StateIterator State::end() {
   StartKeepRunning();
   return StateIterator();
 }

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -202,7 +202,7 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 
 #if defined(__GNUC__)
 #define BENCHMARK_UNUSED __attribute__((unused))
-#define BENCHMARK_ALWAYS_INLINE __attribute__((always_inline))
+#define BENCHMARK_ALWAYS_INLINE __attribute__((always_inline)) inline
 #define BENCHMARK_NOEXCEPT noexcept
 #define BENCHMARK_NOEXCEPT_OP(x) noexcept(x)
 #elif defined(_MSC_VER) && !defined(__clang__)

--- a/src/cycleclock.h
+++ b/src/cycleclock.h
@@ -58,7 +58,7 @@ namespace benchmark {
 //    https://setisvn.ssl.berkeley.edu/svn/lib/fftw-3.0.1/kernel/cycle.h
 namespace cycleclock {
 // This should return the number of cycles since power-on.  Thread-safe.
-inline BENCHMARK_ALWAYS_INLINE int64_t Now() {
+BENCHMARK_ALWAYS_INLINE int64_t Now() {
 #if defined(BENCHMARK_OS_MACOSX)
   // this goes at the top because we need ALL Macs, regardless of
   // architecture, to return the number of "mach time units" that


### PR DESCRIPTION
When `_MSC_VER` is defined, `BENCHMARK_ALWAYS_INLINE` is defined as `__forceinline`. Some functions were defined as `inline BENCHMARK_ALWAYS_INLINE`, which after preprocessing became `inline __forceinline`. This PR fixes the warnings caused by that by removing the extra `inline`.