### PR TITLE
Enforce using a semicolon after BENCHMARK_MAIN to remove compiler warnings

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1146,7 +1146,8 @@ class Fixture : public internal::Benchmark {
     ::benchmark::Initialize(&argc, argv);  \
     if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1; \
     ::benchmark::RunSpecifiedBenchmarks(); \
-  }
+  }                                        \
+  int main(int, char**)
 
 
 // ------------------------------------------------------

--- a/test/basic_test.cc
+++ b/test/basic_test.cc
@@ -115,4 +115,4 @@ void BM_RangedFor(benchmark::State& state) {
 }
 BENCHMARK(BM_RangedFor);
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -241,4 +241,4 @@ BENCHMARK(BM_DenseThreadRanges)->Arg(1)->DenseThreadRange(1, 3);
 BENCHMARK(BM_DenseThreadRanges)->Arg(2)->DenseThreadRange(1, 4, 2);
 BENCHMARK(BM_DenseThreadRanges)->Arg(3)->DenseThreadRange(5, 14, 3);
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();

--- a/test/cxx03_test.cc
+++ b/test/cxx03_test.cc
@@ -60,4 +60,4 @@ void BM_counters(benchmark::State& state) {
 }
 BENCHMARK(BM_counters);
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();

--- a/test/fixture_test.cc
+++ b/test/fixture_test.cc
@@ -46,4 +46,4 @@ BENCHMARK_DEFINE_F(MyFixture, Bar)(benchmark::State& st) {
 BENCHMARK_REGISTER_F(MyFixture, Bar)->Arg(42);
 BENCHMARK_REGISTER_F(MyFixture, Bar)->Arg(42)->ThreadPerCpu();
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();

--- a/test/map_test.cc
+++ b/test/map_test.cc
@@ -54,4 +54,4 @@ BENCHMARK_DEFINE_F(MapFixture, Lookup)(benchmark::State& state) {
 }
 BENCHMARK_REGISTER_F(MapFixture, Lookup)->Range(1 << 3, 1 << 12);
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();

--- a/test/multiple_ranges_test.cc
+++ b/test/multiple_ranges_test.cc
@@ -71,4 +71,4 @@ static void BM_MultipleRanges(benchmark::State& st) {
 }
 BENCHMARK(BM_MultipleRanges)->Ranges({{5, 5}, {6, 6}});
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -62,4 +62,4 @@ void BM_explicit_iteration_count(benchmark::State& state) {
 }
 BENCHMARK(BM_explicit_iteration_count)->Iterations(42);
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();

--- a/test/templated_fixture_test.cc
+++ b/test/templated_fixture_test.cc
@@ -25,4 +25,4 @@ BENCHMARK_TEMPLATE_DEFINE_F(MyFixture, Bar, double)(benchmark::State& st) {
 }
 BENCHMARK_REGISTER_F(MyFixture, Bar);
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();


### PR DESCRIPTION
This fixes #494.

In #494, I claim that `BENCHMARK_MAIN()` without semicolon is probably never used. Funnily enough, it seems like the tests of the library itself were using it without a semicolon, as can be seen from the fixes I had to make.

Since the documentation used a semicolon, it may be safe to assume that people have not been relying on it, but it's not 100% sure either. Another possibility is to change the documentation to _not_ use a semicolon (that may be unfriendly to syntax highlighters & al, but that's a tradeoff).