### PR TITLE
fix static initialization order problem

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -711,4 +711,6 @@ bool ReportUnrecognizedArguments(int argc, char** argv) {
   return argc > 1;
 }
 
+Fixture::~Fixture() {}
+
 }  // end namespace benchmark


### PR DESCRIPTION
    This commit can fix the static initalization problem (see https://github.com/google/benchmark/issues/497 ), the commit pass all the tests and won't break sane codes.
Two problem the commit tries to solve is (1) Benchmark.Apply() calls user defined function during static initialization. (2) Fixture's construtor is user defined, and can do anything during static initialization.
    To solve problem (1), Benchmark.Apply() doesn't run the the user defined function, but push it to a vector to run later(specifically, in BenchmarkFamilies.FindBenchmarks() just before benchmark's argument is checked, see https://github.com/lijinpei/benchmark/blob/v2/src/benchmark_register.cc#L130 and https://github.com/lijinpei/benchmark/blob/v2/src/benchmark_register.cc#L130 )
    To solve problem (2), the class hierarchy is changed(but the change won't break existing code, after recompiling). The old classs hierarchy is Benchmark->Fixture->UserDefinedFixture->FixtureDefinedThroughMacro, now the hierarchy is Benchmark->FixtureBenchmark(the other two classed derived from Benchmark are FunctionBenchmark and LambdaBenchmark), Fixture->UserdefinedFixture->FixtureDefinedThroughMacro, and now FixtureDefinedThroughMacro has a static method which takes no argument and return a Fixture*. FixtureBenchmark stores a Fixture* and a function pointer(the static member of FixtureDefinedThroughMacro). During static initialization, FixtureBenchmark is created and registered, no user defined class involved, just a function to generate a user defined class is recorded. When the benchmark is run, the function pointer is used to generate the fixture if necessary. See https://github.com/lijinpei/benchmark/blob/v2/src/benchmark_register.cc#L489 ,  https://github.com/lijinpei/benchmark/blob/v2/src/benchmark_register.cc#L525 , and https://github.com/lijinpei/benchmark/blob/v2/include/benchmark/benchmark.h#L1043 .