### PR TITLE
Prevent GTest and GMock from being installed with Google Benchmark.

### DIFF
--- a/cmake/HandleGTest.cmake
+++ b/cmake/HandleGTest.cmake
@@ -67,6 +67,8 @@ endmacro(build_external_gtest)
 
 if (BENCHMARK_ENABLE_GTEST_TESTS)
   if (IS_DIRECTORY ${CMAKE_SOURCE_DIR}/googletest)
+    set(INSTALL_GTEST OFF CACHE INTERNAL "")
+    set(INSTALL_GMOCK OFF CACHE INTERNAL "")
     add_subdirectory(${CMAKE_SOURCE_DIR}/googletest)
     set(GTEST_BOTH_LIBRARIES gtest gtest_main)
   elseif(BENCHMARK_DOWNLOAD_DEPENDENCIES)


### PR DESCRIPTION
When users satisfy the GTest dependancy by placing a googletest
directory in the project, the targets from GTest and GMock incorrectly
get installed along side this library. We shouldn't be installing
our test dependancies.

This patch forces the options that control installation for googletest
to OFF.