### PR TITLE
Wrap COMPILER macros.

### DIFF
--- a/src/internal_macros.h
+++ b/src/internal_macros.h
@@ -11,29 +11,35 @@
 #endif
 
 #if defined(__clang__)
-#define COMPILER_CLANG
+  #if !defined(COMPILER_CLANG)
+    #define COMPILER_CLANG
+  #endif
 #elif defined(_MSC_VER)
-#define COMPILER_MSVC
+  #if !defined(COMPILER_MSVC)
+    #define COMPILER_MSVC
+  #endif
 #elif defined(__GNUC__)
-#define COMPILER_GCC
+  #if !defined(COMPILER_GCC)
+    #define COMPILER_GCC
+  #endif
 #endif
 
 #if __has_feature(cxx_attributes)
-#define BENCHMARK_NORETURN [[noreturn]]
+  #define BENCHMARK_NORETURN [[noreturn]]
 #elif defined(__GNUC__)
-#define BENCHMARK_NORETURN __attribute__((noreturn))
+  #define BENCHMARK_NORETURN __attribute__((noreturn))
 #elif defined(COMPILER_MSVC)
-#define BENCHMARK_NORETURN __declspec(noreturn)
+  #define BENCHMARK_NORETURN __declspec(noreturn)
 #else
-#define BENCHMARK_NORETURN
+  #define BENCHMARK_NORETURN
 #endif
 
 #if defined(__CYGWIN__)
-#define BENCHMARK_OS_CYGWIN 1
+  #define BENCHMARK_OS_CYGWIN 1
 #elif defined(_WIN32)
-#define BENCHMARK_OS_WINDOWS 1
+  #define BENCHMARK_OS_WINDOWS 1
 #elif defined(__APPLE__)
-#include "TargetConditionals.h"
+  #include "TargetConditionals.h"
   #if defined(TARGET_OS_MAC)
     #define BENCHMARK_OS_MACOSX 1
     #if defined(TARGET_OS_IPHONE)
@@ -41,36 +47,36 @@
     #endif
   #endif
 #elif defined(__FreeBSD__)
-#define BENCHMARK_OS_FREEBSD 1
+  #define BENCHMARK_OS_FREEBSD 1
 #elif defined(__NetBSD__)
-#define BENCHMARK_OS_NETBSD 1
+  #define BENCHMARK_OS_NETBSD 1
 #elif defined(__linux__)
-#define BENCHMARK_OS_LINUX 1
+  #define BENCHMARK_OS_LINUX 1
 #elif defined(__native_client__)
-#define BENCHMARK_OS_NACL 1
+  #define BENCHMARK_OS_NACL 1
 #elif defined(EMSCRIPTEN)
-#define BENCHMARK_OS_EMSCRIPTEN 1
+  #define BENCHMARK_OS_EMSCRIPTEN 1
 #elif defined(__rtems__)
-#define BENCHMARK_OS_RTEMS 1
+  #define BENCHMARK_OS_RTEMS 1
 #endif
 
 #if !__has_feature(cxx_exceptions) && !defined(__cpp_exceptions) \
      && !defined(__EXCEPTIONS)
-#define BENCHMARK_HAS_NO_EXCEPTIONS
+  #define BENCHMARK_HAS_NO_EXCEPTIONS
 #endif
 
 #if defined(COMPILER_CLANG) || defined(COMPILER_GCC)
-#define BENCHMARK_MAYBE_UNUSED __attribute__((unused))
+  #define BENCHMARK_MAYBE_UNUSED __attribute__((unused))
 #else
-#define BENCHMARK_MAYBE_UNUSED
+  #define BENCHMARK_MAYBE_UNUSED
 #endif
 
 #if defined(COMPILER_GCC) || __has_builtin(__builtin_unreachable)
-#define BENCHMARK_UNREACHABLE() __builtin_unreachable()
+  #define BENCHMARK_UNREACHABLE() __builtin_unreachable()
 #elif defined(COMPILER_MSVC)
-#define BENCHMARK_UNREACHABLE() __assume(false)
+  #define BENCHMARK_UNREACHABLE() __assume(false)
 #else
-#define BENCHMARK_UNREACHABLE() ((void)0)
+  #define BENCHMARK_UNREACHABLE() ((void)0)
 #endif
 
 #endif  // BENCHMARK_INTERNAL_MACROS_H_


### PR DESCRIPTION
Some command line or build systems may already set these (eg, bazel) so
make sure that takes priority.

Fixes #513