### PR TITLE
Fixes compilation error caused by integer truncation in sysinfo.cc

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -303,7 +303,7 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizesWindows() {
     if (!B.test(0)) continue;
     CInfo* Cache = &it->Cache;
     CPUInfo::CacheInfo C;
-    C.num_sharing = B.count();
+    C.num_sharing = static_cast<int>(B.count());
     C.level = Cache->Level;
     C.size = Cache->Size;
     switch (Cache->Type) {


### PR DESCRIPTION
This commit fixes the following compilation error:
```
[ 26%] Building CXX object src/CMakeFiles/benchmark.dir/sysinfo.cc.obj
C:/Users/alski/msys64/alski/projects/Neo/build/Windows-x64/external/benchmark/source/src/sysinfo.cc:306:23: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long long') to 'int' [-Werror,-Wshorten-64-to-32]
    C.num_sharing = B.count();
                  ~ ~~^~~~~~~
1 error generated.
make[2]: *** [src/CMakeFiles/benchmark.dir/build.make:389: src/CMakeFiles/benchmark.dir/sysinfo.cc.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:86: src/CMakeFiles/benchmark.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```

My build environment is:
- OS: Windows 10
- Toolchain: MSYS2 MinGW64
```
alski@DESKTOP-BVS5O40 MINGW64 ~/projects/google-benchmark/build
$ clang --version
clang version 4.0.0 (tags/RELEASE_400/final)
Target: x86_64-w64-windows-gnu
Thread model: posix
InstalledDir: D:\msys64\mingw64\bin
```

The following command line was used to build the software:
```
cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
    -DBENCHMARK_DOWNLOAD_DEPENDENCIES=OFF -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
    -DCMAKE_INSTALL_PREFIX=/mingw64 ../source
cmake --build . --target install
```

NOTE: I'm not familiar with this project. I made assumption that integer truncation should not be an issue, and so it's okay to explicitly convert `std::size_t` to `int` in that context.
