### PR TITLE
Support State::KeepRunningBatch().

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -623,15 +623,16 @@ bool State::KeepRunning() {
     --total_iterations_;
     return true;
   }
-  if (!started_ && !error_occurred_) {
+  if (!started_) {
     StartKeepRunning();
-    // max_iterations > 0. The first iteration is always valid.
-    --total_iterations_;
-    return true;
-  } else {
-    FinishKeepRunning();
-    return false;
+    if (!error_occurred_) {
+      // max_iterations > 0. The first iteration is always valid.
+      --total_iterations_;
+      return true;
+    }
   }
+  FinishKeepRunning();
+  return false;
 }
 
 inline BENCHMARK_ALWAYS_INLINE
@@ -642,24 +643,25 @@ bool State::KeepRunningBatch(size_t n) {
     total_iterations_ -= n;
     return true;
   }
-  if (!started_ && !error_occurred_) {
+  if (!started_) {
     StartKeepRunning();
-    if (total_iterations_ >= n) {
-      total_iterations_-= n;
-    } else {
-      batch_leftover_  = n - total_iterations_;
-      total_iterations_ = 0;
+    if (!error_occurred_) {
+      if (total_iterations_ >= n) {
+        total_iterations_-= n;
+      } else {
+        batch_leftover_  = n - total_iterations_;
+        total_iterations_ = 0;
+      }
+      return true;
     }
-    return true;
   }
   if (total_iterations_ != 0) {
     batch_leftover_  = n - total_iterations_;
     total_iterations_ = 0;
     return true;
-  } else {
-    FinishKeepRunning();
-    return false;
   }
+  FinishKeepRunning();
+  return false;
 }
 
 struct State::StateIterator {

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -441,7 +441,7 @@ class State {
   //   while (state.KeepRunningBatch(1000)) {
   //     // process 1000 elements
   //   }
-  bool KeepRunningBatch(int n);
+  bool KeepRunningBatch(size_t n);
 
   // REQUIRES: timer is running and 'SkipWithError(...)' has not been called
   //           by the current thread.
@@ -576,7 +576,7 @@ class State {
   bool started_;
   bool finished_;
   // When total_iterations_ is 0, KeepRunning() and friends will return false.
-  int64_t total_iterations_;
+  size_t total_iterations_;
   // May be larger than max_iterations.
 
   std::vector<int> range_;
@@ -635,7 +635,7 @@ bool State::KeepRunning() {
 }
 
 inline BENCHMARK_ALWAYS_INLINE
-bool State::KeepRunningBatch(int n) {
+bool State::KeepRunningBatch(size_t n) {
   // total_iterations_ is set to 0 by the constructor, and always set to a
   // nonzero value by StartKepRunning().
   if (BENCHMARK_BUILTIN_EXPECT(total_iterations_ >= n, true)) {

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -645,13 +645,8 @@ bool State::KeepRunningBatch(size_t n) {
   }
   if (!started_) {
     StartKeepRunning();
-    if (!error_occurred_) {
-      if (total_iterations_ >= n) {
-        total_iterations_-= n;
-      } else {
-        batch_leftover_  = n - total_iterations_;
-        total_iterations_ = 0;
-      }
+    if (!error_occurred_ && total_iterations_ >= n) {
+      total_iterations_-= n;
       return true;
     }
   }

--- a/test/basic_test.cc
+++ b/test/basic_test.cc
@@ -107,7 +107,8 @@ void BM_KeepRunning(benchmark::State& state) {
 BENCHMARK(BM_KeepRunning);
 
 void BM_KeepRunningBatch(benchmark::State& state) {
-  const size_t batch_size = 100;
+  // Choose a prime batch size to avoid evenly dividing max_iterations.
+  const size_t batch_size = 101;
   size_t iter_count = 0;
   while (state.KeepRunningBatch(batch_size)) {
     iter_count += batch_size;

--- a/test/basic_test.cc
+++ b/test/basic_test.cc
@@ -102,9 +102,19 @@ void BM_KeepRunning(benchmark::State& state) {
   while (state.KeepRunning()) {
     ++iter_count;
   }
-  assert(iter_count == state.max_iterations);
+  assert(iter_count == state.iterations());
 }
 BENCHMARK(BM_KeepRunning);
+
+void BM_KeepRunningBatch(benchmark::State& state) {
+  const size_t batch_size = 100;
+  size_t iter_count = 0;
+  while (state.KeepRunningBatch(batch_size)) {
+    iter_count += batch_size;
+  }
+  assert(state.iterations() == iter_count);
+}
+BENCHMARK(BM_KeepRunningBatch);
 
 void BM_RangedFor(benchmark::State& state) {
   size_t iter_count = 0;

--- a/test/skip_with_error_test.cc
+++ b/test/skip_with_error_test.cc
@@ -70,6 +70,16 @@ void BM_error_before_running(benchmark::State& state) {
 BENCHMARK(BM_error_before_running);
 ADD_CASES("BM_error_before_running", {{"", true, "error message"}});
 
+
+void BM_error_before_running_batch(benchmark::State& state) {
+  state.SkipWithError("error message");
+  while (state.KeepRunningBatch(17)) {
+    assert(false);
+  }
+}
+BENCHMARK(BM_error_before_running_batch);
+ADD_CASES("BM_error_before_running_batch", {{"", true, "error message"}});
+
 void BM_error_before_running_range_for(benchmark::State& state) {
   state.SkipWithError("error message");
   for (auto _ : state) {


### PR DESCRIPTION
State::KeepRunning() can take large amounts of time relative to quick
operations (on the order of 1ns, depending on hardware). For such
sensitive operations, it is recommended to run batches of repeated
operations.

This commit simplifies handling of total_iterations_. Rather than
predecrementing such that total_iterations_ == 1 signals that
KeepRunning() should exit, total_iterations_ == 0 now signals the
intention for the benchmark to exit.