### PR TITLE
Improve State packing: put important members on first cache line.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,13 @@ else()
     cxx_feature_check(THREAD_SAFETY_ATTRIBUTES)
   endif()
 
+  # GCC doesn't report invalid -Wno-warning flags, so check the positive
+  # version, and if it exists add the negative.
+  check_cxx_warning_flag(-Winvalid-offsetof)
+  if (HAVE_CXX_FLAG_WINVALID_OFFSETOF)
+    add_cxx_compiler_flag(-Wno-invalid-offsetof)
+  endif()
+
   # On most UNIX like platforms g++ and clang++ define _GNU_SOURCE as a
   # predefined macro, which turns on all of the wonderful libc extensions.
   # However g++ doesn't do this in Cygwin so we have to define it ourselfs

--- a/cmake/AddCXXCompilerFlag.cmake
+++ b/cmake/AddCXXCompilerFlag.cmake
@@ -62,3 +62,13 @@ function(add_required_cxx_compiler_flag FLAG)
     message(FATAL_ERROR "Required flag '${FLAG}' is not supported by the compiler")
   endif()
 endfunction()
+
+function(check_cxx_warning_flag FLAG)
+  mangle_compiler_flag("${FLAG}" MANGLED_FLAG)
+  set(OLD_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  # Add -Werror to ensure the compiler generates an error if the warning flag
+  # doesn't exist.
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -Werror ${FLAG}")
+  check_cxx_compiler_flag("${FLAG}" ${MANGLED_FLAG})
+  set(CMAKE_REQUIRED_FLAGS "${OLD_CMAKE_REQUIRED_FLAGS}")
+endfunction()

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -573,9 +573,9 @@ class State {
   }
 
 private: // items we expect on the first cache line (ie 64 bytes of the struct)
-  bool started_ : 1;
-  bool finished_ : 1;
-  bool error_occurred_ : 1;
+  bool started_;
+  bool finished_;
+  bool error_occurred_;
   // When total_iterations_ is 0, KeepRunning() and friends will return false.
   // May be larger than max_iterations.
   size_t total_iterations_;

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -573,9 +573,7 @@ class State {
   }
 
 private: // items we expect on the first cache line (ie 64 bytes of the struct)
-  bool started_;
-  bool finished_;
-  bool error_occurred_;
+
   // When total_iterations_ is 0, KeepRunning() and friends will return false.
   // May be larger than max_iterations.
   size_t total_iterations_;
@@ -587,6 +585,11 @@ private: // items we expect on the first cache line (ie 64 bytes of the struct)
 
 public:
   const size_t max_iterations;
+
+private:
+  bool started_;
+  bool finished_;
+  bool error_occurred_;
 
 private: // items we don't need on the first cache line
   std::vector<int> range_;

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -572,26 +572,29 @@ class State {
     return (max_iterations - total_iterations_ + batch_leftover_);
   }
 
- private:
-  bool started_;
-  bool finished_;
+private: // items we expect on the first cache line (ie 64 bytes of the struct)
+  bool started_ : 1;
+  bool finished_ : 1;
+  bool error_occurred_ : 1;
   // When total_iterations_ is 0, KeepRunning() and friends will return false.
-  size_t total_iterations_;
   // May be larger than max_iterations.
+  size_t total_iterations_;
 
+  // When using KeepRunningBatch(), batch_leftover_ holds the number of
+  // iterations beyond max_iters that were run. Used to track
+  // completed_iterations_ accurately.
+  size_t batch_leftover_;
+
+public:
+  const size_t max_iterations;
+
+private: // items we don't need on the first cache line
   std::vector<int> range_;
 
   size_t bytes_processed_;
   size_t items_processed_;
 
   int complexity_n_;
-
-  bool error_occurred_;
-
-  // When using KeepRunningBatch(), batch_leftover_ holds the number of
-  // iterations beyond max_iters that were run. Used to track
-  // completed_iterations_ accurately.
-  size_t batch_leftover_;
 
  public:
   // Container for user-defined counters.
@@ -600,7 +603,7 @@ class State {
   const int thread_index;
   // Number of threads concurrently executing the benchmark.
   const int threads;
-  const size_t max_iterations;
+
 
   // TODO(EricWF) make me private
   State(size_t max_iters, const std::vector<int>& ranges, int thread_i,

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -397,12 +397,12 @@ std::vector<BenchmarkReporter::Run> RunBenchmark(
 State::State(size_t max_iters, const std::vector<int>& ranges, int thread_i,
              int n_threads, internal::ThreadTimer* timer,
              internal::ThreadManager* manager)
-    : started_(false),
-      finished_(false),
-      error_occurred_(false),
-      total_iterations_(0),
+    : total_iterations_(0),
       batch_leftover_(0),
       max_iterations(max_iters),
+      started_(false),
+      finished_(false),
+      error_occurred_(false),
       range_(ranges),
       bytes_processed_(0),
       items_processed_(0),
@@ -417,8 +417,8 @@ State::State(size_t max_iters, const std::vector<int>& ranges, int thread_i,
 
   // Offset tests to ensure commonly accessed data is on the first cache line.
   const int cache_line_size = 64;
-  static_assert(offsetof(State, max_iterations) <=
-                (cache_line_size - sizeof(max_iterations)), "");
+  static_assert(offsetof(State, finished_) <=
+                (cache_line_size + sizeof(finished_)), "");
 }
 
 void State::PauseTiming() {

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -417,8 +417,8 @@ State::State(size_t max_iters, const std::vector<int>& ranges, int thread_i,
 
   // Offset tests to ensure commonly accessed data is on the first cache line.
   const int cache_line_size = 64;
-  static_assert(offsetof(State, finished_) <=
-                (cache_line_size + sizeof(finished_)), "");
+  static_assert(offsetof(State, error_occurred_) <=
+                (cache_line_size - sizeof(error_occurred_)), "");
 }
 
 void State::PauseTiming() {


### PR DESCRIPTION
This patch does a few different things to ensure commonly accessed
data is on the first cache line of the `State` object.

First, it moves the `error_occurred_` member to reside after
the `started_` and `finished_` bools, since there was internal
padding there that was unused.

Second, it moves `batch_leftover_` and `max_iterations` further up
in the struct declaration. These variables are used in the calculation
of `iterations()` which users might call within the loop. Therefore
it's more important they exist on the first cache line.