### PR TITLE
Add support for building with Bazel.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ build.ninja
 install_manifest.txt
 rules.ninja
 
+# bazel output symlinks.
+bazel-*
+
 # out-of-source build top-level folders.
 build/
 _build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -159,11 +159,22 @@ install:
       brew update;
       brew install gcc@7;
     fi
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      sudo apt-get update -qq;
+      sudo apt-get install -qq unzip;
+      wget https://github.com/bazelbuild/bazel/releases/download/0.10.1/bazel-0.10.1-installer-linux-x86_64.sh --output-document bazel-installer.sh;
+      sudo bash bazel-installer.sh;
+    fi
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+      curl -L -o bazel-installer.sh https://github.com/bazelbuild/bazel/releases/download/0.10.1/bazel-0.10.1-installer-darwin-x86_64.sh;
+      sudo bash bazel-installer.sh;
+    fi
 
 script:
   - cmake -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${COMPILER} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS="${EXTRA_FLAGS}" -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON -DBENCHMARK_BUILD_32_BITS=${BUILD_32_BITS} ..
   - make
   - ctest -C ${BUILD_TYPE} --output-on-failure
+  - bazel test -c dbg --define google_benchmark.have_regex=posix --announce_rc --verbose_failures --test_output=errors --keep_going //test/...
 
 after_success:
   - if [ "${BUILD_TYPE}" == "Coverage" -a "${TRAVIS_OS_NAME}" == "linux" ]; then

--- a/AUTHORS
+++ b/AUTHORS
@@ -38,6 +38,7 @@ Radoslav Yovchev <radoslav.tm@gmail.com>
 Roman Lebedev <lebedev.ri@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Steinar H. Gunderson <sgunderson@bigfoot.com>
+Stripe, Inc.
 Yixuan Qiu <yixuanq@gmail.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Zbigniew Skowron <zbychs@gmail.com>

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,21 @@
+licenses(["notice"])
+
+load("//bazel:have_regex.bzl", "have_regex_copts")
+
+cc_library(
+    name = "benchmark",
+    srcs = glob([
+        "src/*.cc",
+        "src/*.h",
+    ]),
+    hdrs = ["include/benchmark/benchmark.h"],
+    copts = have_regex_copts(),
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "benchmark_internal_headers",
+    hdrs = glob(["src/*.h"]),
+    visibility = ["//test:__pkg__"],
+)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -38,6 +38,7 @@ Ismael Jimenez Martinez <ismael.jimenez.martinez@gmail.com>
 Jern-Kuan Leong <jernkuan@gmail.com>
 JianXiong Zhou <zhoujianxiong2@gmail.com>
 Joao Paulo Magalhaes <joaoppmagalhaes@gmail.com>
+John Millikin <jmillikin@stripe.com>
 Jussi Knuuttila <jussi.knuuttila@gmail.com>
 Kai Wolf <kai.wolf@gmail.com>
 Kishan Kumar <kumar.kishan@outlook.com>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "com_github_google_benchmark")
+
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,7 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "com_google_googletest",
+    commit = "3f0cf6b62ad1eb50d8736538363d3580dd640c3e",  # HEAD
+    remote = "https://github.com/google/googletest",
+)

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,0 +1,16 @@
+package(default_visibility = ["//:__subpackages__"])
+
+config_setting(
+    name = "have_std_regex",
+    values = {"define": "google_benchmark.have_regex=std"},
+)
+
+config_setting(
+    name = "have_posix_regex",
+    values = {"define": "google_benchmark.have_regex=posix"},
+)
+
+config_setting(
+    name = "have_gnu_posix_regex",
+    values = {"define": "google_benchmark.have_regex=gnu_posix"},
+)

--- a/bazel/have_regex.bzl
+++ b/bazel/have_regex.bzl
@@ -1,0 +1,7 @@
+def have_regex_copts():
+  return select({
+      "//bazel:have_std_regex": ["-DHAVE_STD_REGEX"],
+      "//bazel:have_posix_regex": ["-DHAVE_POSIX_REGEX"],
+      "//bazel:have_gnu_posix_regex": ["-DHAVE_GNU_POSIX_REGEX"],
+      "//conditions:default": ["-DHAVE_STD_REGEX"],
+  })

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,0 +1,47 @@
+load("//bazel:have_regex.bzl", "have_regex_copts")
+
+NEEDS_GTEST_MAIN = [
+    "statistics_test.cc",
+]
+
+TEST_COPTS = [
+    "-pedantic",
+    "-pedantic-errors",
+    "-std=c++11",
+] + have_regex_copts()
+
+TEST_ARGS = ["--benchmark_min_time=0.01"]
+
+cc_library(
+    name = "output_test_helper",
+    testonly = 1,
+    srcs = ["output_test_helper.cc"],
+    hdrs = ["output_test.h"],
+    copts = TEST_COPTS,
+    deps = [
+        "//:benchmark",
+        "//:benchmark_internal_headers",
+    ],
+)
+
+[cc_test(
+    name = test_src[:-len(".cc")],
+    size = "small",
+    srcs = [test_src],
+    args = TEST_ARGS + ({
+        "user_counters_tabular_test.cc": ["--benchmark_counters_tabular=true"],
+    }).get(test_src, []),
+    copts = TEST_COPTS + ({
+        "cxx03_test.cc": ["-std=c++03"],
+        # Some of the issues with DoNotOptimize only occur when optimization is enabled
+        "donotoptimize_test.cc": ["-O3"],
+    }).get(test_src, []),
+    deps = [
+        ":output_test_helper",
+        "//:benchmark",
+        "//:benchmark_internal_headers",
+        "@com_google_googletest//:gtest",
+    ] + (
+        ["@com_google_googletest//:gtest_main"] if (test_src in NEEDS_GTEST_MAIN) else []
+    ),
+) for test_src in glob(["*_test.cc"])]


### PR DESCRIPTION
Limitations compared to existing CMake rules:
* Defaults to using C++11 `<regex>`, with an override via Bazel flag `--define` of `google_benchmark.have_regex`. The TravisCI config sets the regex implementation to `posix` because it uses ancient compilers.
* Debug vs Opt mode can't be set per test. TravisCI runs all the tests in debug mode to satisfy `diagnostics_test`, which depends on `CHECK` being live.

If accepted, this would obsolete PRs https://github.com/google/benchmark/pull/496 and https://github.com/google/benchmark/pull/501.

I plan to use this for [Envoy](https://github.com/envoyproxy/envoy) to replace [build_recipes/benchmark.sh](https://github.com/envoyproxy/envoy/blob/22e0d08309bdb904287d0cb0f9c8550f35ecbb2b/ci/build_container/build_recipes/benchmark.sh).