### PR TITLE
Print the executable name as part of the context.

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1246,7 +1246,7 @@ class BenchmarkReporter {
     CPUInfo const& cpu_info;
     // The number of chars in the longest benchmark name.
     size_t name_field_width;
-
+    static const char *executable_name;
     Context();
   };
 

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -661,6 +661,7 @@ void PrintUsageAndExit() {
 
 void ParseCommandLineFlags(int* argc, char** argv) {
   using namespace benchmark;
+  BenchmarkReporter::Context::executable_name = argv[0];
   for (int i = 1; i < *argc; ++i) {
     if (ParseBoolFlag(argv[i], "benchmark_list_tests",
                       &FLAGS_benchmark_list_tests) ||

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -77,6 +77,10 @@ bool JSONReporter::ReportContext(const Context& context) {
   std::string walltime_value = LocalDateTimeString();
   out << indent << FormatKV("date", walltime_value) << ",\n";
 
+  if (Context::executable_name) {
+    out << indent << FormatKV("executable", Context::executable_name) << ",\n";
+  }
+
   CPUInfo const& info = context.cpu_info;
   out << indent << FormatKV("num_cpus", static_cast<int64_t>(info.num_cpus))
       << ",\n";

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -37,6 +37,9 @@ void BenchmarkReporter::PrintBasicContext(std::ostream *out,
 
   Out << LocalDateTimeString() << "\n";
 
+  if (context.executable_name)
+    Out << "Running " << context.executable_name << "\n";
+
   const CPUInfo &info = context.cpu_info;
   Out << "Run on (" << info.num_cpus << " X "
       << (info.cycles_per_second / 1000000.0) << " MHz CPU "
@@ -63,6 +66,9 @@ void BenchmarkReporter::PrintBasicContext(std::ostream *out,
          "affected.\n";
 #endif
 }
+
+// No initializer because it's already initialized to NULL.
+const char* BenchmarkReporter::Context::executable_name;
 
 BenchmarkReporter::Context::Context() : cpu_info(CPUInfo::Get()) {}
 

--- a/test/reporter_output_test.cc
+++ b/test/reporter_output_test.cc
@@ -17,13 +17,13 @@ static int AddContextCases() {
   AddCases(TC_ConsoleErr,
            {
                {"%int[-/]%int[-/]%int %int:%int:%int$", MR_Default},
-               {"Running .*/test/reporter_output_test(\\.exe)?$", MR_Next},
+               {"Running .*/reporter_output_test(\\.exe)?$", MR_Next},
                {"Run on \\(%int X %float MHz CPU s\\)", MR_Next},
            });
   AddCases(TC_JSONOut, {{"^\\{", MR_Default},
                         {"\"context\":", MR_Next},
                         {"\"date\": \"", MR_Next},
-                        {"\"executable\": \".*/test/reporter_output_test(\\.exe)?\",", MR_Next},
+                        {"\"executable\": \".*/reporter_output_test(\\.exe)?\",", MR_Next},
                         {"\"num_cpus\": %int,$", MR_Next},
                         {"\"mhz_per_cpu\": %float,$", MR_Next},
                         {"\"cpu_scaling_enabled\": ", MR_Next},

--- a/test/reporter_output_test.cc
+++ b/test/reporter_output_test.cc
@@ -17,11 +17,13 @@ static int AddContextCases() {
   AddCases(TC_ConsoleErr,
            {
                {"%int[-/]%int[-/]%int %int:%int:%int$", MR_Default},
+               {"Running .*/test/reporter_output_test$", MR_Next},
                {"Run on \\(%int X %float MHz CPU s\\)", MR_Next},
            });
   AddCases(TC_JSONOut, {{"^\\{", MR_Default},
                         {"\"context\":", MR_Next},
                         {"\"date\": \"", MR_Next},
+                        {"\"executable\": \".*/test/reporter_output_test\",", MR_Next},
                         {"\"num_cpus\": %int,$", MR_Next},
                         {"\"mhz_per_cpu\": %float,$", MR_Next},
                         {"\"cpu_scaling_enabled\": ", MR_Next},

--- a/test/reporter_output_test.cc
+++ b/test/reporter_output_test.cc
@@ -17,13 +17,13 @@ static int AddContextCases() {
   AddCases(TC_ConsoleErr,
            {
                {"%int[-/]%int[-/]%int %int:%int:%int$", MR_Default},
-               {"Running .*/test/reporter_output_test$", MR_Next},
+               {"Running .*/test/reporter_output_test(\\.exe)?$", MR_Next},
                {"Run on \\(%int X %float MHz CPU s\\)", MR_Next},
            });
   AddCases(TC_JSONOut, {{"^\\{", MR_Default},
                         {"\"context\":", MR_Next},
                         {"\"date\": \"", MR_Next},
-                        {"\"executable\": \".*/test/reporter_output_test\",", MR_Next},
+                        {"\"executable\": \".*/test/reporter_output_test(\\.exe)?\",", MR_Next},
                         {"\"num_cpus\": %int,$", MR_Next},
                         {"\"mhz_per_cpu\": %float,$", MR_Next},
                         {"\"cpu_scaling_enabled\": ", MR_Next},


### PR DESCRIPTION
A common use case of the library is to run two different
versions of a benchmark to compare them. In my experience
this often means compiling a benchmark twice, renaming
one of the executables, and then running the executables
back-to-back. In this case the name of the executable
is important contextually information.  Unfortunately the
benchmark does not report this information.

This patch adds the executable name to the context reported
by the benchmark.