### PR TITLE
Rename StrCat to StringCat

### DIFF
--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -117,14 +117,14 @@ void ConsoleReporter::PrintRunData(const Run& result) {
   // Format bytes per second
   std::string rate;
   if (result.bytes_per_second > 0) {
-    rate = StrCat(" ", HumanReadableNumber(result.bytes_per_second), "B/s");
+    rate = StringCat(" ", HumanReadableNumber(result.bytes_per_second), "B/s");
   }
 
   // Format items per second
   std::string items;
   if (result.items_per_second > 0) {
-    items =
-        StrCat(" ", HumanReadableNumber(result.items_per_second), " items/s");
+    items = StringCat(" ", HumanReadableNumber(result.items_per_second),
+        " items/s");
   }
 
   const double real_time = result.GetAdjustedRealTime();

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -26,7 +26,7 @@ inline std::ostream& StringCatImp(std::ostream& out, First&& f,
 }
 
 template <class... Args>
-inline std::string StrCat(Args&&... args) {
+inline std::string StringCat(Args&&... args) {
   std::ostringstream ss;
   StringCatImp(ss, std::forward<Args>(args)...);
   return ss.str();

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -191,8 +191,8 @@ bool CpuScalingEnabled(int num_cpus) {
   // running on Linux, so we silently ignore all the read errors.
   std::string res;
   for (int cpu = 0; cpu < num_cpus; ++cpu) {
-    std::string governor_file =
-        StrCat("/sys/devices/system/cpu/cpu", cpu, "/cpufreq/scaling_governor");
+    std::string governor_file = StringCat("/sys/devices/system/cpu/cpu", cpu,
+        "/cpufreq/scaling_governor");
     if (ReadFromFile(governor_file, &res) && res != "performance") return true;
   }
 #endif
@@ -225,8 +225,8 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizesFromKVFS() {
   int Idx = 0;
   while (true) {
     CPUInfo::CacheInfo info;
-    std::string FPath = StrCat(dir, "index", Idx++, "/");
-    std::ifstream f(StrCat(FPath, "size").c_str());
+    std::string FPath = StringCat(dir, "index", Idx++, "/");
+    std::ifstream f(StringCat(FPath, "size").c_str());
     if (!f.is_open()) break;
     std::string suffix;
     f >> info.size;
@@ -242,12 +242,12 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizesFromKVFS() {
       else if (suffix == "K")
         info.size *= 1000;
     }
-    if (!ReadFromFile(StrCat(FPath, "type"), &info.type))
+    if (!ReadFromFile(StringCat(FPath, "type"), &info.type))
       PrintErrorAndDie("Failed to read from file ", FPath, "type");
-    if (!ReadFromFile(StrCat(FPath, "level"), &info.level))
+    if (!ReadFromFile(StringCat(FPath, "level"), &info.level))
       PrintErrorAndDie("Failed to read from file ", FPath, "level");
     std::string map_str;
-    if (!ReadFromFile(StrCat(FPath, "shared_cpu_map"), &map_str))
+    if (!ReadFromFile(StringCat(FPath, "shared_cpu_map"), &map_str))
       PrintErrorAndDie("Failed to read from file ", FPath, "shared_cpu_map");
     info.num_sharing = CountSetBitsInCPUMap(map_str);
     res.push_back(info);


### PR DESCRIPTION
StrCat is a macro in Shlwapi.h that conflicts with StrCat in string_util.h:

   #defines StrCat lstrcatA

When Shlwapi.h is included in sysinfo.cc and all references to StrCat are
renamed to lstrcatA in string_util.h and sysinfo.cc, therefore this
renaming is innocuous, although unintended.

But if string_util.h is moved above Shlwapi.h then errors occur because
StrCat is not renamed in string_util.h but are renamed in sysinfo.cc:

  ClCompile:
    C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.12.25827\bin\HostX86\x64\CL.exe /c /I"C:\Users\winks\prgs\google-benchmark\include" /I"C:\Users\winks\prgs\google-benchmark\src" /I"C:\Users\winks\prgs\google-benchmark\src\..\include" /Zi /nologo /W4 /WX- /diagnostics:classic /Od /Ob0 /D WIN32 /D _WINDOWS /D _CRT_SECURE_NO_WARNINGS /D HAVE_STD_REGEX /D HAVE_STEADY_CLOCK /D "CMAKE_INTDIR=\"Debug\"" /D _MBCS /Gm- /EHsc /RTC1 /MDd /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR /Fo"benchmark.dir\Debug\\" /Fd"benchmark.dir\Debug\benchmark.pdb" /Gd /TP /errorReport:queue "C:\Users\winks\prgs\google-benchmark\src\sysinfo.cc"
    sysinfo.cc
  C:\Users\winks\prgs\google-benchmark\src\sysinfo.cc(228): error C2660: 'lstrcatA': function does not take 4 arguments [C:\Users\winks\prgs\google-benchmark\build\src\benchmark.vcxproj]
  C:\Users\winks\prgs\google-benchmark\src\sysinfo.cc(229): error C2664: 'LPSTR lstrcatA(LPSTR,LPCSTR)': cannot convert argument 1 from 'std::string' to 'LPSTR' [C:\Users\winks\prgs\google-benchmark\build\src\benchmark.vcxproj]
  ...
  Done Building Project "C:\Users\winks\prgs\google-benchmark\build\test\basic_test.vcxproj" (default targets) -- FAILED.

This PR renames StrCat to StringCat in string_util.h, sysinfo.cc and
console_reporter.cc to fix this issue.