### PR TITLE
Do not let StrCat be renamed to lstrcatA

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -16,6 +16,7 @@
 
 #ifdef BENCHMARK_OS_WINDOWS
 #include <Shlwapi.h>
+#undef StrCat // Don't let StrCat in string_util.h be renamed to lstrcatA
 #include <VersionHelpers.h>
 #include <Windows.h>
 #else

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -17,6 +17,7 @@
 
 #ifdef BENCHMARK_OS_WINDOWS
 #include <Shlwapi.h>
+#undef StrCat // Don't let StrCat in string_util.h be renamed to lstrcatA
 #include <VersionHelpers.h>
 #include <Windows.h>
 #else


### PR DESCRIPTION
On Windows the Shlwapi.h file has a macro:

  #define StrCat lstrcatA

And benchmark/src/string_util.h defines StrCat and it is renamed to
lstrcatA if we don't undef the macro in Shlwapi.h. This is an innocuous
bug if string_util.h is included after Shlwapi.h, but it is a compile
error if string_util.h is included before Shlwapi.h.

This fixes issue #545.