### PR TITLE
Add MakeUnpredictable to hide an objects value from the optimizer.

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -236,13 +236,17 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #define BENCHMARK_WARNING_MSG(msg) __pragma(message(__FILE__ "(" BENCHMARK_INTERNAL_TOSTRING(__LINE__) ") : warning note: " msg))
 #endif
 
-#if defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard) \
-  && __cplusplus > 201402L
-#define BENCHMARK_NODISCARD [[nodiscard]]
-#elif defined(__GNUC__)
-#define BENCHMARK_NODISCARD __attribute__((warn_unused_result))
-#else
-#define BENCHMARK_NODISCARD
+#if __cplusplus > 201402L && defined(__has_cpp_attribute)
+# if __has_cpp_attribute(nodiscard)
+#   define BENCHMARK_NODISCARD [[nodiscard]]
+# endif
+#endif
+#ifndef BENCHMARK_NODISCARD
+# if defined(__GNUC__)
+#   define BENCHMARK_NODISCARD __attribute__((warn_unused_result))
+# else
+#   define BENCHMARK_NODISCARD
+# endif
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,12 +81,15 @@ compile_benchmark_test(skip_with_error_test)
 add_test(skip_with_error_test skip_with_error_test --benchmark_min_time=0.01)
 
 compile_benchmark_test(donotoptimize_test)
+compile_benchmark_test(makeunpredictable_test)
 # Some of the issues with DoNotOptimize only occur when optimization is enabled
 check_cxx_compiler_flag(-O3 BENCHMARK_HAS_O3_FLAG)
 if (BENCHMARK_HAS_O3_FLAG)
   set_target_properties(donotoptimize_test PROPERTIES COMPILE_FLAGS "-O3")
+  set_target_properties(makeunpredictable_test PROPERTIES COMPILE_FLAGS "-O3")
 endif()
 add_test(donotoptimize_test donotoptimize_test --benchmark_min_time=0.01)
+add_test(makeunpredictable_test makeunpredictable_test --benchmark_min_time=0.01)
 
 compile_benchmark_test(fixture_test)
 add_test(fixture_test fixture_test --benchmark_min_time=0.01)
@@ -177,6 +180,7 @@ if (BENCHMARK_ENABLE_ASSEMBLY_TESTS)
   add_filecheck_test(donotoptimize_assembly_test)
   add_filecheck_test(state_assembly_test)
   add_filecheck_test(clobber_memory_assembly_test)
+  add_filecheck_test(makeunpredictable_assembly_test)
 endif()
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,7 +27,11 @@ set(BENCHMARK_O3_FLAG "")
 if (BENCHMARK_HAS_O3_FLAG)
   set(BENCHMARK_O3_FLAG "-O3")
 endif()
-
+check_cxx_compiler_flag(-O0 BENCHMARK_HAS_O0_FLAG)
+set(BENCHMARK_O0_FLAG "")
+if (BENCHMARK_HAS_O0_FLAG)
+  set(BENCHMARK_O0_FLAG "-O0")
+endif()
 # NOTE: These flags must be added after find_package(Threads REQUIRED) otherwise
 # they will break the configuration check.
 if (DEFINED BENCHMARK_CXX_LINKER_FLAGS)
@@ -36,10 +40,15 @@ endif()
 
 add_library(output_test_helper STATIC output_test_helper.cc output_test.h)
 
-macro(compile_benchmark_test name)
-  add_executable(${name} "${name}.cc")
-  target_link_libraries(${name} benchmark ${CMAKE_THREAD_LIBS_INIT})
-endmacro(compile_benchmark_test)
+function(compile_benchmark_test name)
+  cmake_parse_arguments(ARG "" "TARGET" "" ${ARGN})
+  set(target "${name}")
+  if (ARG_TARGET)
+    set(target "${ARG_TARGET}")
+  endif()
+  add_executable(${target} "${name}.cc")
+  target_link_libraries(${target} benchmark ${CMAKE_THREAD_LIBS_INIT})
+endfunction(compile_benchmark_test)
 
 
 macro(compile_output_test name)
@@ -82,15 +91,21 @@ add_test(skip_with_error_test skip_with_error_test --benchmark_min_time=0.01)
 
 compile_benchmark_test(donotoptimize_test)
 compile_benchmark_test(makeunpredictable_test)
-# Some of the issues with DoNotOptimize only occur when optimization is enabled
-check_cxx_compiler_flag(-O3 BENCHMARK_HAS_O3_FLAG)
 if (BENCHMARK_HAS_O3_FLAG)
   set_target_properties(donotoptimize_test PROPERTIES COMPILE_FLAGS "-O3")
   set_target_properties(makeunpredictable_test PROPERTIES COMPILE_FLAGS "-O3")
 endif()
 add_test(donotoptimize_test donotoptimize_test --benchmark_min_time=0.01)
 add_test(makeunpredictable_test makeunpredictable_test --benchmark_min_time=0.01)
+if (BENCHMARK_HAS_O0_FLAG)
+  compile_benchmark_test(donotoptimize_test TARGET donotoptimize_test_O0)
+  set_target_properties(donotoptimize_test_O0 PROPERTIES COMPILE_FLAGS "-O0")
+  add_test(donotoptimize_test_O0 donotoptimize_test_O0 --benchmark_min_time=0.01)
 
+  compile_benchmark_test(makeunpredictable_test TARGET makeunpredictable_test_O0)
+  set_target_properties(makeunpredictable_test_O0 PROPERTIES COMPILE_FLAGS "-O0")
+  add_test(makeunpredictable_test_O0 makeunpredictable_test_O0 --benchmark_min_time=0.01)
+endif()
 compile_benchmark_test(fixture_test)
 add_test(fixture_test fixture_test --benchmark_min_time=0.01)
 

--- a/test/makeunpredictable_assembly_test.cc
+++ b/test/makeunpredictable_assembly_test.cc
@@ -1,0 +1,29 @@
+#include <benchmark/benchmark.h>
+
+// CHECK-LABEL: test_div_by_two_lvalue:
+extern "C" int test_div_by_two_lvalue(int input) {
+  int divisor = 2;
+  benchmark::MakeUnpredictable(divisor);
+  return input / divisor;
+  // CHECK: movl $2, [[DEST:.*]]
+  // CHECK: idivl [[DEST]]
+  // CHECK: ret
+}
+
+// CHECK-LABEL: test_div_by_two_rvalue:
+extern "C" int test_div_by_two_rvalue(int input) {
+  int divisor = benchmark::MakeUnpredictable(2);
+  return input / divisor;
+  // CHECK: movl $2, [[DEST:.*]]
+  // CHECK: idivl [[DEST]]
+  // CHECK: ret
+}
+
+// CHECK-LABEL: test_div_by_two_rvalue_2:
+extern "C" int test_div_by_two_rvalue_2(int input) {
+  return input / benchmark::MakeUnpredictable(2);
+  // CHECK: movl $2, [[DEST:.*]]
+  // CHECK: idivl [[DEST]]
+  // CHECK: ret
+}
+

--- a/test/makeunpredictable_test.cc
+++ b/test/makeunpredictable_test.cc
@@ -36,7 +36,10 @@ struct MoveOnly {
 
 using benchmark::MakeUnpredictable;
 
-#define UNUSED (void)
+template <class Tp>
+void UseResult(Tp const& val) {
+  ((void)val);
+}
 
 void verify_compile() {
   // this test verifies compilation of MakeUnpredictable() for some types
@@ -49,21 +52,20 @@ void verify_compile() {
 
   char buffer1024[1024];
   MakeUnpredictable(buffer1024);
-  UNUSED MakeUnpredictable(&buffer1024[0]);
+  UseResult(MakeUnpredictable(&buffer1024[0]));
 
   int x = 123;
   MakeUnpredictable(x);
-  UNUSED MakeUnpredictable(&x);
-  UNUSED MakeUnpredictable(x += 42);
+  UseResult(MakeUnpredictable(&x));
+  MakeUnpredictable(x += 42);
 
-  UNUSED MakeUnpredictable(double_up(x));
+  UseResult(MakeUnpredictable(double_up(x)));
 
   // These tests are to e
-  UNUSED MakeUnpredictable(BitRef::Make());
+  UseResult(MakeUnpredictable(BitRef::Make()));
   BitRef lval = BitRef::Make();
   MakeUnpredictable(lval);
 }
-#undef UNUSED
 
 #define ASSERT_TYPE(Expr, Expect) \
   static_assert(std::is_same<decltype(MakeUnpredictable(Expr)), Expect>::value, "")

--- a/test/makeunpredictable_test.cc
+++ b/test/makeunpredictable_test.cc
@@ -34,6 +34,14 @@ struct MoveOnly {
   int value;
 };
 
+
+struct CopyOnly {
+  explicit CopyOnly(int xvalue) : value(xvalue) {}
+  CopyOnly(CopyOnly const& other) : value(other.value) {
+  }
+  int value;
+};
+
 using benchmark::MakeUnpredictable;
 
 template <class Tp>
@@ -100,6 +108,11 @@ void verify_return_type() {
     int result = MakeUnpredictable(std::move(const_rvalue));
     assert(const_rvalue == 42);
     assert(result == 42);
+  }
+  {
+    const CopyOnly cp(42);
+    CopyOnly result = MakeUnpredictable(cp);
+    assert(result.value == 42);
   }
   {
     MoveOnly mv(42);

--- a/test/makeunpredictable_test.cc
+++ b/test/makeunpredictable_test.cc
@@ -1,0 +1,114 @@
+#include "benchmark/benchmark.h"
+
+#include <cstdint>
+#include <type_traits>
+
+namespace {
+#if defined(__GNUC__)
+std::uint64_t double_up(const std::uint64_t x) __attribute__((const));
+#endif
+std::uint64_t double_up(const std::uint64_t x) { return x * 2; }
+}
+
+// Using MakeUnpredictable on types like BitRef seem to cause a lot of problems
+// with the inline assembly on both GCC and Clang.
+struct BitRef {
+  int index;
+  unsigned char &byte;
+
+public:
+  static BitRef Make() {
+    static unsigned char arr[2] = {};
+    BitRef b(1, arr[0]);
+    return b;
+  }
+private:
+  BitRef(int i, unsigned char& b) : index(i), byte(b) {}
+};
+
+struct MoveOnly {
+  explicit MoveOnly(int xvalue) : value(xvalue) {}
+  MoveOnly(MoveOnly&& other) : value(other.value) {
+    other.value = -1;
+  }
+  int value;
+};
+
+using benchmark::MakeUnpredictable;
+
+#define UNUSED (void)
+
+void verify_compile() {
+  // this test verifies compilation of MakeUnpredictable() for some types
+
+  char buffer8[8];
+  MakeUnpredictable(buffer8);
+
+  char buffer20[20];
+  MakeUnpredictable(buffer20);
+
+  char buffer1024[1024];
+  MakeUnpredictable(buffer1024);
+  UNUSED MakeUnpredictable(&buffer1024[0]);
+
+  int x = 123;
+  MakeUnpredictable(x);
+  UNUSED MakeUnpredictable(&x);
+  UNUSED MakeUnpredictable(x += 42);
+
+  UNUSED MakeUnpredictable(double_up(x));
+
+  // These tests are to e
+  UNUSED MakeUnpredictable(BitRef::Make());
+  BitRef lval = BitRef::Make();
+  MakeUnpredictable(lval);
+}
+#undef UNUSED
+
+#define ASSERT_TYPE(Expr, Expect) \
+  static_assert(std::is_same<decltype(MakeUnpredictable(Expr)), Expect>::value, "")
+
+void verify_return_type() {
+  {
+    int lvalue = 42;
+    ASSERT_TYPE(lvalue, int&);
+    int &result = MakeUnpredictable(lvalue);
+    assert(&result == &lvalue);
+    assert(lvalue == 42);
+  }
+  {
+    const int clvalue = 42;
+    ASSERT_TYPE(clvalue, int);
+    assert(MakeUnpredictable(clvalue) == 42);
+  }
+  {
+    ASSERT_TYPE(42, int);
+    assert(MakeUnpredictable(42) == 42);
+  }
+  {
+    int rvalue = -1;
+    ASSERT_TYPE(std::move(rvalue), int);
+    int result = MakeUnpredictable(std::move(rvalue));
+    assert(rvalue == -1);
+    assert(result == -1);
+  }
+  {
+    const int const_rvalue = 42;
+    ASSERT_TYPE(std::move(const_rvalue), int);
+    int result = MakeUnpredictable(std::move(const_rvalue));
+    assert(const_rvalue == 42);
+    assert(result == 42);
+  }
+  {
+    MoveOnly mv(42);
+    ASSERT_TYPE(std::move(mv), MoveOnly);
+    MoveOnly result = MakeUnpredictable(std::move(mv));
+    assert(result.value == 42);
+    assert(mv.value == -1); // We moved from it during MakeUnpredictable
+  }
+}
+
+int main() {
+  verify_compile();
+  verify_return_type();
+}


### PR DESCRIPTION
This patch addresses issue #341 by adding the function MakeUnpredictable.
The MakeUnpredictable(...) functions can be used to prevent the optimizer
from knowing the value of the specified 'object'. The function returns
the "laundered" input, either by reference if the input was a non-const
lvalue reference, or by value (when the input was a const lvalue or rvalue).

When MakeUnpredictable is supplied a non-const lvalue, the object
referenced by the input is made unpredictable and the return value
can be ignored. Otherwise, only the return value is considered
"unpredictable". In the latter the MakeUnpredictable function
is marked [[nodiscard]] and a warning is emitted if the return
value is ignored. For example:

```c++
int divide_by_two(int Value) {
  const int Divisor = 2;
  DoNotOptimize(Divisor); // INCORRECT! Has no effect on Divisor
  MakeUnpredictable(Divisor); // INCORRECT! should warn that return is ignored.
  // Correct Usage #1
  return Value / MakeUnpredictable(Divisor);
  // Correct Usage #2
  const int Divisor = MakeUnpredictable(2);
  return Value / Divisor;
}