### PR TITLE
Cleanup test/CMakeLists.txt

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,12 +22,6 @@ if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
   endforeach()
 endif()
 
-check_cxx_compiler_flag(-O3 BENCHMARK_HAS_O3_FLAG)
-set(BENCHMARK_O3_FLAG "")
-if (BENCHMARK_HAS_O3_FLAG)
-  set(BENCHMARK_O3_FLAG "-O3")
-endif()
-
 # NOTE: These flags must be added after find_package(Threads REQUIRED) otherwise
 # they will break the configuration check.
 if (DEFINED BENCHMARK_CXX_LINKER_FLAGS)
@@ -35,29 +29,74 @@ if (DEFINED BENCHMARK_CXX_LINKER_FLAGS)
 endif()
 
 add_library(output_test_helper STATIC output_test_helper.cc output_test.h)
+target_link_libraries(output_test_helper benchmark)
 
-macro(compile_benchmark_test name)
-  add_executable(${name} "${name}.cc")
-  target_link_libraries(${name} benchmark ${CMAKE_THREAD_LIBS_INIT})
-endmacro(compile_benchmark_test)
+function(add_benchmark_test target)
+  cmake_parse_arguments(ARG
+      "EXCLUDE_FROM_TEST;OUTPUT_TEST;GTEST_TEST"
+      "SOURCE;REQUIRES"
+      "COMPILE_FLAGS;LINK_FLAGS;LIBRARIES;TEST_ARGS"
+      ${ARGN})
+  if (NOT BENCHMARK_ENABLE_GTEST_TESTS AND ARG_GTEST_TEST)
+    return()
+  endif()
+  if (ARG_REQUIRES)
+    if (NOT ${ARG_REQUIRES})
+      return()
+    endif()
+  endif()
 
+  # Create the test executable
+  if (NOT ARG_SOURCE)
+    set(ARG_SOURCE "${target}.cc")
+  endif()
+  add_executable(${target} ${ARG_SOURCE})
+  set_target_properties(${target}
+      PROPERTIES
+        COMPILE_FLAGS "${ARG_COMPILE_FLAGS}"
+        LINK_FLAGS "${ARG_LINK_FLAGS}")
+  target_link_libraries(${target} benchmark ${ARG_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
-macro(compile_output_test name)
-  add_executable(${name} "${name}.cc" output_test.h)
-  target_link_libraries(${name} output_test_helper benchmark
-          ${BENCHMARK_CXX_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-endmacro(compile_output_test)
+  # Handle specifics for each different type of test. ex. output tests, gtests, ect.
+  if (ARG_OUTPUT_TEST)
+    target_link_libraries(${target} output_test_helper ${BENCHMARK_CXX_LIBRARIES})
+  elseif (ARG_GTEST_TEST)
+    if (TARGET googletest)
+      add_dependencies(${target} googletest)
+    endif()
+    if (GTEST_INCLUDE_DIRS)
+      target_include_directories(${target} PRIVATE ${GTEST_INCLUDE_DIRS})
+    endif()
+    target_link_libraries(${target} ${GTEST_BOTH_LIBRARIES})
+  endif()
 
-# Demonstration executable
-compile_benchmark_test(benchmark_test)
-add_test(benchmark benchmark_test --benchmark_min_time=0.01)
+  # Unless otherwise specified, supply default arguments to each benchmark test.
+  if (NOT ARG_TEST_ARGS AND NOT ARG_GTEST_TEST)
+    set(ARG_TEST_ARGS --benchmark_min_time=0.01)
+  endif()
 
-compile_benchmark_test(filter_test)
+  if (NOT ARG_EXCLUDE_FROM_TEST)
+    add_test(${target} ${target} ${ARG_TEST_ARGS})
+  endif()
+endfunction(add_benchmark_test)
+
+function(add_benchmark_tests)
+  cmake_parse_arguments(ARG "" "" "OPTIONS" ${ARGN})
+  set(TEST_TARGETS ${ARG_UNPARSED_ARGUMENTS})
+  foreach(target ${TEST_TARGETS})
+    add_benchmark_test(${target}
+        ${ARG_OPTIONS})
+  endforeach()
+endfunction()
+
+###############################################################################
+# Filter Tests
+###############################################################################
+add_benchmark_test(filter_test EXCLUDE_FROM_TEST)
 macro(add_filter_test name filter expect)
   add_test(${name} filter_test --benchmark_min_time=0.01 --benchmark_filter=${filter} ${expect})
   add_test(${name}_list_only filter_test --benchmark_list_tests --benchmark_filter=${filter} ${expect})
 endmacro(add_filter_test)
-
 add_filter_test(filter_simple "Foo" 3)
 add_filter_test(filter_suffix "BM_.*" 4)
 add_filter_test(filter_regex_all ".*" 5)
@@ -68,68 +107,59 @@ add_filter_test(filter_regex_begin "^BM_.*" 4)
 add_filter_test(filter_regex_begin2 "^N" 1)
 add_filter_test(filter_regex_end ".*Ba$" 1)
 
-compile_benchmark_test(options_test)
-add_test(options_benchmarks options_test --benchmark_min_time=0.01)
-
-compile_benchmark_test(basic_test)
-add_test(basic_benchmark basic_test --benchmark_min_time=0.01)
-
-compile_benchmark_test(diagnostics_test)
-add_test(diagnostics_test diagnostics_test --benchmark_min_time=0.01)
-
-compile_benchmark_test(skip_with_error_test)
-add_test(skip_with_error_test skip_with_error_test --benchmark_min_time=0.01)
-
-compile_benchmark_test(donotoptimize_test)
-# Some of the issues with DoNotOptimize only occur when optimization is enabled
+###############################################################################
+# Basic Benchmark Tests
+###############################################################################
+add_benchmark_tests(
+    benchmark_test
+    options_test
+    diagnostics_test
+    skip_with_error_test
+    donotoptimize_test
+    fixture_test
+    register_benchmark_test
+    map_test
+    multiple_ranges_test
+)
+add_benchmark_test(basic_benchmark SOURCE basic_test.cc)
+# Some of the issues with DoNotOptimize only occur when optimization is enabled.
+# Others only occur when they are disabled. Test both.
 check_cxx_compiler_flag(-O3 BENCHMARK_HAS_O3_FLAG)
-if (BENCHMARK_HAS_O3_FLAG)
-  set_target_properties(donotoptimize_test PROPERTIES COMPILE_FLAGS "-O3")
+add_benchmark_test(donotoptimize_test_O3
+      REQUIRES BENCHMARK_HAS_O3_FLAG
+      SOURCE donotoptimize_test.cc
+      COMPILE_FLAGS "-O3")
+check_cxx_compiler_flag(-O0 BENCHMARK_HAS_O0_FLAG)
+add_benchmark_test(donotoptimize_test_O0
+      REQUIRES BENCHMARK_HAS_O0_FLAG
+      SOURCE donotoptimize_test.cc
+      COMPILE_FLAGS "-O0")
+add_benchmark_tests(
+    reporter_output_test 
+    templated_fixture_test 
+    user_counters_test
+  OPTIONS
+    OUTPUT_TEST
+)
+add_benchmark_test(
+    user_counters_tabular_test
+    OUTPUT_TEST
+    TEST_ARGS --benchmark_counters_tabular=true --benchmark_min_time=0.01
+)
+
+# libstdc++ provides different definitions within <map> between dialects. When
+# LTO is enabled and -Werror is specified GCC diagnoses this ODR violation
+# causing the test to fail to compile. To prevent this we explicitly disable
+# the warning.
+check_cxx_compiler_flag(-Wno-odr BENCHMARK_HAS_WNO_ODR)
+if (BENCHMARK_ENABLE_LTO AND BENCHMARK_HAS_WNO_ODR)
+  set(LINK_FLAGS "-Wno-odr")
 endif()
-add_test(donotoptimize_test donotoptimize_test --benchmark_min_time=0.01)
-
-compile_benchmark_test(fixture_test)
-add_test(fixture_test fixture_test --benchmark_min_time=0.01)
-
-compile_benchmark_test(register_benchmark_test)
-add_test(register_benchmark_test register_benchmark_test --benchmark_min_time=0.01)
-
-compile_benchmark_test(map_test)
-add_test(map_test map_test --benchmark_min_time=0.01)
-
-compile_benchmark_test(multiple_ranges_test)
-add_test(multiple_ranges_test multiple_ranges_test --benchmark_min_time=0.01)
-
-compile_output_test(reporter_output_test)
-add_test(reporter_output_test reporter_output_test --benchmark_min_time=0.01)
-
-compile_output_test(templated_fixture_test)
-add_test(templated_fixture_test templated_fixture_test --benchmark_min_time=0.01)
-
-compile_output_test(user_counters_test)
-add_test(user_counters_test user_counters_test --benchmark_min_time=0.01)
-
-compile_output_test(user_counters_tabular_test)
-add_test(user_counters_tabular_test user_counters_tabular_test --benchmark_counters_tabular=true --benchmark_min_time=0.01)
-
 check_cxx_compiler_flag(-std=c++03 BENCHMARK_HAS_CXX03_FLAG)
-if (BENCHMARK_HAS_CXX03_FLAG)
-  compile_benchmark_test(cxx03_test)
-  set_target_properties(cxx03_test
-      PROPERTIES
-      COMPILE_FLAGS "-std=c++03")
-  # libstdc++ provides different definitions within <map> between dialects. When
-  # LTO is enabled and -Werror is specified GCC diagnoses this ODR violation
-  # causing the test to fail to compile. To prevent this we explicitly disable
-  # the warning.
-  check_cxx_compiler_flag(-Wno-odr BENCHMARK_HAS_WNO_ODR)
-  if (BENCHMARK_ENABLE_LTO AND BENCHMARK_HAS_WNO_ODR)
-    set_target_properties(cxx03_test
-        PROPERTIES
-        LINK_FLAGS "-Wno-odr")
-  endif()
-  add_test(cxx03 cxx03_test --benchmark_min_time=0.01)
-endif()
+add_benchmark_test(cxx03_test
+    REQUIRES BENCHMARK_HAS_CXX03_FLAG
+    COMPILE_FLAGS "-std=c++03"
+    LINK_FLAGS "${LINK_FLAGS}")
 
 # Attempt to work around flaky test failures when running on Appveyor servers.
 if (DEFINED ENV{APPVEYOR})
@@ -137,38 +167,22 @@ if (DEFINED ENV{APPVEYOR})
 else()
   set(COMPLEXITY_MIN_TIME "0.01")
 endif()
-compile_output_test(complexity_test)
-add_test(complexity_benchmark complexity_test --benchmark_min_time=${COMPLEXITY_MIN_TIME})
+add_benchmark_test(complexity_test OUTPUT_TEST
+    TEST_ARGS --benchmark_min_time=${COMPLEXITY_MIN_TIME})
+
 
 ###############################################################################
-# GoogleTest Unit Tests
+# GTEST Unit Tests
 ###############################################################################
-
-if (BENCHMARK_ENABLE_GTEST_TESTS)
-  macro(compile_gtest name)
-    add_executable(${name} "${name}.cc")
-    if (TARGET googletest)
-      add_dependencies(${name} googletest)
-    endif()
-    if (GTEST_INCLUDE_DIRS)
-      target_include_directories(${name} PRIVATE ${GTEST_INCLUDE_DIRS})
-    endif()
-    target_link_libraries(${name} benchmark
-        ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-  endmacro(compile_gtest)
-
-  macro(add_gtest name)
-    compile_gtest(${name})
-    add_test(${name} ${name})
-  endmacro()
-
-  add_gtest(statistics_test)
-endif(BENCHMARK_ENABLE_GTEST_TESTS)
+add_benchmark_tests(
+    statistics_test
+  OPTIONS
+    GTEST_TEST
+)
 
 ###############################################################################
 # Assembly Unit Tests
 ###############################################################################
-
 if (BENCHMARK_ENABLE_ASSEMBLY_TESTS)
   if (NOT LLVM_FILECHECK_EXE)
     message(FATAL_ERROR "LLVM FileCheck is required when including this file")
@@ -178,8 +192,6 @@ if (BENCHMARK_ENABLE_ASSEMBLY_TESTS)
   add_filecheck_test(state_assembly_test)
   add_filecheck_test(clobber_memory_assembly_test)
 endif()
-
-
 
 ###############################################################################
 # Code Coverage Configuration


### PR DESCRIPTION
This patch attempts to cleanup and reduce duplication in the CMake
which builds and registers the tests.

The patch adds a `add_benchmark_test` CMake function with a number
of options; allowing almost all tests to use it directly.