### PR TITLE
Do not combine inline with BENCHMARK_ALWAYS_INLINE

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -203,7 +203,7 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 
 #if defined(__GNUC__)
 #define BENCHMARK_UNUSED __attribute__((unused))
-#define BENCHMARK_ALWAYS_INLINE __attribute__((always_inline))
+#define BENCHMARK_ALWAYS_INLINE inline __attribute__((always_inline))
 #define BENCHMARK_NOEXCEPT noexcept
 #define BENCHMARK_NOEXCEPT_OP(x) noexcept(x)
 #elif defined(_MSC_VER) && !defined(__clang__)
@@ -219,7 +219,7 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #define __func__ __FUNCTION__
 #else
 #define BENCHMARK_UNUSED
-#define BENCHMARK_ALWAYS_INLINE
+#define BENCHMARK_ALWAYS_INLINE inline
 #define BENCHMARK_NOEXCEPT
 #define BENCHMARK_NOEXCEPT_OP(x)
 #endif
@@ -303,13 +303,13 @@ BENCHMARK_UNUSED static int stream_init_anchor = InitializeStreams();
 // See: https://youtu.be/nXaxk27zwlk?t=2441
 #ifndef BENCHMARK_HAS_NO_INLINE_ASSEMBLY
 template <class Tp>
-inline BENCHMARK_ALWAYS_INLINE
+BENCHMARK_ALWAYS_INLINE
 void DoNotOptimize(Tp const& value) {
     asm volatile("" : : "r,m"(value) : "memory");
 }
 
 template <class Tp>
-inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
+BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
 #if defined(__clang__)
   asm volatile("" : "+r,m"(value) : : "memory");
 #else
@@ -319,22 +319,22 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
 
 // Force the compiler to flush pending writes to global memory. Acts as an
 // effective read/write barrier
-inline BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
+BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
   asm volatile("" : : : "memory");
 }
 #elif defined(_MSC_VER)
 template <class Tp>
-inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
+BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
   _ReadWriteBarrier();
 }
 
-inline BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
+BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
   _ReadWriteBarrier();
 }
 #else
 template <class Tp>
-inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
+BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
 }
 // FIXME Add ClobberMemory() for non-gnu and non-msvc compilers
@@ -630,17 +630,17 @@ private: // items we don't need on the first cache line
   BENCHMARK_DISALLOW_COPY_AND_ASSIGN(State);
 };
 
-inline BENCHMARK_ALWAYS_INLINE
+BENCHMARK_ALWAYS_INLINE
 bool State::KeepRunning() {
   return KeepRunningInternal(1, /*is_batch=*/ false);
 }
 
-inline BENCHMARK_ALWAYS_INLINE
+BENCHMARK_ALWAYS_INLINE
 bool State::KeepRunningBatch(size_t n) {
   return KeepRunningInternal(n, /*is_batch=*/ true);
 }
 
-inline BENCHMARK_ALWAYS_INLINE
+BENCHMARK_ALWAYS_INLINE
 bool State::KeepRunningInternal(size_t n, bool is_batch) {
   // total_iterations_ is set to 0 by the constructor, and always set to a
   // nonzero value by StartKepRunning().
@@ -708,10 +708,10 @@ struct State::StateIterator {
   State* const parent_;
 };
 
-inline BENCHMARK_ALWAYS_INLINE State::StateIterator State::begin() {
+BENCHMARK_ALWAYS_INLINE State::StateIterator State::begin() {
   return StateIterator(this);
 }
-inline BENCHMARK_ALWAYS_INLINE State::StateIterator State::end() {
+BENCHMARK_ALWAYS_INLINE State::StateIterator State::end() {
   StartKeepRunning();
   return StateIterator();
 }

--- a/src/cycleclock.h
+++ b/src/cycleclock.h
@@ -58,7 +58,7 @@ namespace benchmark {
 //    https://setisvn.ssl.berkeley.edu/svn/lib/fftw-3.0.1/kernel/cycle.h
 namespace cycleclock {
 // This should return the number of cycles since power-on.  Thread-safe.
-inline BENCHMARK_ALWAYS_INLINE int64_t Now() {
+BENCHMARK_ALWAYS_INLINE int64_t Now() {
 #if defined(BENCHMARK_OS_MACOSX)
   // this goes at the top because we need ALL Macs, regardless of
   // architecture, to return the number of "mach time units" that


### PR DESCRIPTION
MSVC does not like functions with both inline and __forceinline keywords. This change makes BENCHMARK_ALWAYS_INLINE to decay to inline if "always inline"-like attribute is not supported. So you should not use both inline and BENCHMARK_ALWAYS_INLINE together.