### PR TITLE
Report the actual iterations run.

### DIFF
--- a/src/thread_manager.h
+++ b/src/thread_manager.h
@@ -1,6 +1,9 @@
 #ifndef BENCHMARK_THREAD_MANAGER_H
 #define BENCHMARK_THREAD_MANAGER_H
 
+#include <atomic>
+
+#include "benchmark/benchmark.h"
 #include "mutex.h"
 
 namespace benchmark {
@@ -35,6 +38,7 @@ class ThreadManager {
 
  public:
   struct Result {
+    int64_t iterations = 0;
     double real_time_used = 0;
     double cpu_time_used = 0;
     double manual_time_used = 0;


### PR DESCRIPTION
Before this change, we would report the number of requested iterations passed to the state. After, we will report the actual number of iterations run.

As a side-effect, instead of multiplying the expected iterations per thread by the number of threads to get the total number, we can report the actual number of iterations across all threads, which takes into account the situation where some threads might run more iterations than others.