### PR TITLE
Fix precision loss warning in MSVC

### DIFF
--- a/src/complexity.cc
+++ b/src/complexity.cc
@@ -28,7 +28,7 @@ namespace benchmark {
 BigOFunc* FittingCurve(BigO complexity) {
   switch (complexity) {
     case oN:
-      return [](int64_t n) -> double { return n; };
+      return [](int64_t n) -> double { return static_cast<double>(n); };
     case oNSquared:
       return [](int64_t n) -> double { return std::pow(n, 2); };
     case oNCubed:


### PR DESCRIPTION
Warning text:

c:\projects\berrydb\third_party\benchmark\src\complexity.cc(31): warning C4244: 'return': conversion from 'int64_t' to 'double', possible loss of data

Thank you very much for maintaining google benchmark!