### PR TITLE
Fix bazel config to link against pthread.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,13 @@
 licenses(["notice"])
 
+config_setting(
+    name = "windows",
+    values = {
+        "cpu": "x64_windows",
+    },
+    visibility = [":__subpackages__"],
+)
+
 cc_library(
     name = "benchmark",
     srcs = glob([
@@ -7,6 +15,10 @@ cc_library(
         "src/*.h",
     ]),
     hdrs = ["include/benchmark/benchmark.h"],
+    linkopts = select({
+        ":windows": [],
+        "//conditions:default": ["-pthread"],
+    }),
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The benchmarks in the test/ currently build with bazel because they all include a dep on gtest, which brings in pthread when needed.

This snippet of BUILD file is taken from 
https://github.com/abseil/abseil-cpp/blob/master/absl/BUILD.bazel#L38
and
https://github.com/abseil/abseil-cpp/blob/master/absl/synchronization/BUILD.bazel#L197