### PR TITLE
Add pragma to fix msvc link issue, modify bazel WORKSPACE to work with msvc

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,11 +933,6 @@ sudo cpupower frequency-set --governor powersave
 
 # Known Issues
 
-### Windows
-
-* Users must manually link `shlwapi.lib`. Failure to do so may result
-in unresolved symbols.
-
 ### Solaris
 
 * Users must explicitly link with kstat library (-lkstat compilation flag).

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,9 +1,7 @@
 workspace(name = "com_github_google_benchmark")
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
-    name = "com_google_googletest",
-    commit = "3f0cf6b62ad1eb50d8736538363d3580dd640c3e",  # HEAD
-    remote = "https://github.com/google/googletest",
+http_archive(
+     name = "com_google_googletest",
+     urls = ["https://github.com/google/googletest/archive/master.zip"],
+     strip_prefix = "googletest-master",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,6 @@ workspace(name = "com_github_google_benchmark")
 
 http_archive(
      name = "com_google_googletest",
-     urls = ["https://github.com/google/googletest/archive/master.zip"],
-     strip_prefix = "googletest-master",
+     urls = ["https://github.com/google/googletest/archive/3f0cf6b62ad1eb50d8736538363d3580dd640c3e.zip"],
+     strip_prefix = "googletest-3f0cf6b62ad1eb50d8736538363d3580dd640c3e",
 )

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -501,6 +501,7 @@ double GetCPUCyclesPerSecond() {
   // In NT, read MHz from the registry. If we fail to do so or we're in win9x
   // then make a crude estimate.
   DWORD data, data_size = sizeof(data);
+  #pragma comment(lib, "shlwapi.lib")  // For SHGetValue().
   if (IsWindowsXPOrGreater() &&
       SUCCEEDED(
           SHGetValueA(HKEY_LOCAL_MACHINE,


### PR DESCRIPTION
Pragma for shlwapi.lib is taken from
https://github.com/abseil/abseil-cpp/blob/master/absl/base/internal/sysinfo.cc#L81

Tested this on local Windows 10 machine with Visual Studio 2017. Bazel did not work correctly with git_repository(), so switched it out with http_archive() in the workspace file as found in
https://github.com/abseil/abseil-cpp/blob/master/WORKSPACE#L14