### PR TITLE
Update bazel WORKSPACE and BUILD files to work better on Windows.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,7 +16,7 @@ cc_library(
     ]),
     hdrs = ["include/benchmark/benchmark.h"],
     linkopts = select({
-        ":windows": [],
+        ":windows": ["-DEFAULTLIB:shlwapi.lib"],
         "//conditions:default": ["-pthread"],
     }),
     strip_include_prefix = "include",

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ We need to install the library globally now
 sudo make install
 ```
 
-Now you have google/benchmark installed in your machine 
+Now you have google/benchmark installed in your machine
 Note: Don't forget to link to pthread library while building
 
 ## Stable and Experimental Library Versions
@@ -933,7 +933,7 @@ sudo cpupower frequency-set --governor powersave
 
 # Known Issues
 
-### Windows
+### Windows with CMake
 
 * Users must manually link `shlwapi.lib`. Failure to do so may result
 in unresolved symbols.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,9 +1,7 @@
 workspace(name = "com_github_google_benchmark")
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
-    name = "com_google_googletest",
-    commit = "3f0cf6b62ad1eb50d8736538363d3580dd640c3e",  # HEAD
-    remote = "https://github.com/google/googletest",
+http_archive(
+     name = "com_google_googletest",
+     urls = ["https://github.com/google/googletest/archive/3f0cf6b62ad1eb50d8736538363d3580dd640c3e.zip"],
+     strip_prefix = "googletest-3f0cf6b62ad1eb50d8736538363d3580dd640c3e",
 )


### PR DESCRIPTION
Note, bazel only supports MSVC on Windows, and not MinGW, so linking against shlwapi.lib only needs to follow MSVC conventions.

Tested this on local Windows 10 machine with Visual Studio 2017. Bazel did not work correctly with git_repository(), so switched it out with http_archive() in the workspace file as found in
https://github.com/abseil/abseil-cpp/blob/master/WORKSPACE#L14
except it is modified to fetch a particular commit of gtest.

This PR is an alternative to https://github.com/google/benchmark/pull/580 which tried to solve this issue for CMake as well and ran into MinGW issues