### PR TITLE
Porting into OpenBSD

### DIFF
--- a/src/internal_macros.h
+++ b/src/internal_macros.h
@@ -51,6 +51,8 @@
   #define BENCHMARK_OS_FREEBSD 1
 #elif defined(__NetBSD__)
   #define BENCHMARK_OS_NETBSD 1
+#elif defined(__OpenBSD__)
+  #define BENCHMARK_OS_OPENBSD 1
 #elif defined(__linux__)
   #define BENCHMARK_OS_LINUX 1
 #elif defined(__native_client__)


### PR DESCRIPTION
Porting `benchmark` into `OpenBSD`. Before porting:  

```
# make test

......

91% tests passed, 5 tests failed out of 54

Total Test time (real) =  40.18 sec

The following tests FAILED:
          1 - benchmark (Child aborted)
         38 - options_benchmarks (Child aborted)
         39 - basic_benchmark (Child aborted)
         43 - fixture_test (Child aborted)
         47 - reporter_output_test (Child aborted)
Errors while running CTest
*** Error 8 in /root/Project/benchmark/build (Makefile:130 'test': /usr/local/bin/ctest --force-new-ctest-process --exclude-regex "CMake.Fil...)

```

After porting, all tests passed:  

```
# make test

......

100% tests passed, 0 tests failed out of 54

Total Test time (real) =  17.54 sec
```
