### PR TITLE
Use __EMSCRIPTEN__ (rather then EMSCRIPTEN) to check for emscripten

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -292,7 +292,7 @@ BENCHMARK_UNUSED static int stream_init_anchor = InitializeStreams();
 
 
 #if (!defined(__GNUC__) && !defined(__clang__)) || defined(__pnacl__) || \
-    defined(EMSCRIPTN)
+    defined(__EMSCRIPTEN__)
 # define BENCHMARK_HAS_NO_INLINE_ASSEMBLY
 #endif
 

--- a/src/internal_macros.h
+++ b/src/internal_macros.h
@@ -57,7 +57,7 @@
   #define BENCHMARK_OS_LINUX 1
 #elif defined(__native_client__)
   #define BENCHMARK_OS_NACL 1
-#elif defined(EMSCRIPTEN)
+#elif defined(__EMSCRIPTEN__)
   #define BENCHMARK_OS_EMSCRIPTEN 1
 #elif defined(__rtems__)
   #define BENCHMARK_OS_RTEMS 1


### PR DESCRIPTION
The old EMSCRIPTEN macro is deprecated and not enabled when
EMCC_STRICT is set.

Also fix a typo in EMSCRIPTN (not sure how this ever worked).