### PR TITLE
Return 0 from State::iterations() when not yet started.

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -575,7 +575,7 @@ class State {
 
   BENCHMARK_ALWAYS_INLINE
   size_t iterations() const {
-    if (!started_) {
+    if (BENCHMARK_BUILTIN_EXPECT(!started_, false)) {
       return 0;
     }
     return max_iterations - total_iterations_ + batch_leftover_;

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -575,7 +575,10 @@ class State {
 
   BENCHMARK_ALWAYS_INLINE
   size_t iterations() const {
-    return (max_iterations - total_iterations_ + batch_leftover_);
+    if (!started_) {
+      return 0;
+    }
+    return max_iterations - total_iterations_ + batch_leftover_;
   }
 
 private: // items we expect on the first cache line (ie 64 bytes of the struct)

--- a/test/basic_test.cc
+++ b/test/basic_test.cc
@@ -99,6 +99,7 @@ BENCHMARK(BM_empty_stop_start)->ThreadPerCpu();
 
 void BM_KeepRunning(benchmark::State& state) {
   size_t iter_count = 0;
+  assert(iter_count == state.iterations());
   while (state.KeepRunning()) {
     ++iter_count;
   }


### PR DESCRIPTION
Previously, State::iterations() returned some unexpected value (typically max_iterations). State::iterations() will now return 0 until KeepRunning() or KeepRunningBatch() is called.