### PR TITLE
clang-format run on the benchmark header

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -164,7 +164,6 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #ifndef BENCHMARK_BENCHMARK_H_
 #define BENCHMARK_BENCHMARK_H_
 
-
 // The _MSVC_LANG check should detect Visual Studio 2015 Update 3 and newer.
 #if __cplusplus >= 201103L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201103L)
 #define BENCHMARK_HAS_CXX11
@@ -176,19 +175,19 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #include <cassert>
 #include <cstddef>
 #include <iosfwd>
-#include <string>
-#include <vector>
 #include <map>
 #include <set>
+#include <string>
+#include <vector>
 
 #if defined(BENCHMARK_HAS_CXX11)
-#include <type_traits>
 #include <initializer_list>
+#include <type_traits>
 #include <utility>
 #endif
 
 #if defined(_MSC_VER)
-#include <intrin.h> // for _ReadWriteBarrier
+#include <intrin.h>  // for _ReadWriteBarrier
 #endif
 
 #ifndef BENCHMARK_HAS_CXX11
@@ -233,7 +232,9 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #else
 #define BENCHMARK_BUILTIN_EXPECT(x, y) x
 #define BENCHMARK_DEPRECATED_MSG(msg)
-#define BENCHMARK_WARNING_MSG(msg) __pragma(message(__FILE__ "(" BENCHMARK_INTERNAL_TOSTRING(__LINE__) ") : warning note: " msg))
+#define BENCHMARK_WARNING_MSG(msg)                           \
+  __pragma(message(__FILE__ "(" BENCHMARK_INTERNAL_TOSTRING( \
+      __LINE__) ") : warning note: " msg))
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__)
@@ -290,12 +291,10 @@ BENCHMARK_UNUSED static int stream_init_anchor = InitializeStreams();
 
 }  // namespace internal
 
-
 #if (!defined(__GNUC__) && !defined(__clang__)) || defined(__pnacl__) || \
     defined(__EMSCRIPTEN__)
-# define BENCHMARK_HAS_NO_INLINE_ASSEMBLY
+#define BENCHMARK_HAS_NO_INLINE_ASSEMBLY
 #endif
-
 
 // The DoNotOptimize(...) function can be used to prevent a value or
 // expression from being optimized away by the compiler. This function is
@@ -303,9 +302,8 @@ BENCHMARK_UNUSED static int stream_init_anchor = InitializeStreams();
 // See: https://youtu.be/nXaxk27zwlk?t=2441
 #ifndef BENCHMARK_HAS_NO_INLINE_ASSEMBLY
 template <class Tp>
-inline BENCHMARK_ALWAYS_INLINE
-void DoNotOptimize(Tp const& value) {
-    asm volatile("" : : "r,m"(value) : "memory");
+inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
+  asm volatile("" : : "r,m"(value) : "memory");
 }
 
 template <class Tp>
@@ -329,9 +327,7 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   _ReadWriteBarrier();
 }
 
-inline BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
-  _ReadWriteBarrier();
-}
+inline BENCHMARK_ALWAYS_INLINE void ClobberMemory() { _ReadWriteBarrier(); }
 #else
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
@@ -340,38 +336,33 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
 // FIXME Add ClobberMemory() for non-gnu and non-msvc compilers
 #endif
 
-
-
 // This class is used for user-defined counters.
 class Counter {
-public:
-
+ public:
   enum Flags {
-    kDefaults   = 0,
+    kDefaults = 0,
     // Mark the counter as a rate. It will be presented divided
     // by the duration of the benchmark.
-    kIsRate     = 1,
+    kIsRate = 1,
     // Mark the counter as a thread-average quantity. It will be
     // presented divided by the number of threads.
     kAvgThreads = 2,
     // Mark the counter as a thread-average rate. See above.
-    kAvgThreadsRate = kIsRate|kAvgThreads
+    kAvgThreadsRate = kIsRate | kAvgThreads
   };
 
   double value;
-  Flags  flags;
+  Flags flags;
 
   BENCHMARK_ALWAYS_INLINE
   Counter(double v = 0., Flags f = kDefaults) : value(v), flags(f) {}
 
-  BENCHMARK_ALWAYS_INLINE operator double const& () const { return value; }
-  BENCHMARK_ALWAYS_INLINE operator double      & ()       { return value; }
-
+  BENCHMARK_ALWAYS_INLINE operator double const&() const { return value; }
+  BENCHMARK_ALWAYS_INLINE operator double&() { return value; }
 };
 
 // This is the container for the user-defined counters.
 typedef std::map<std::string, Counter> UserCounters;
-
 
 // TimeUnit is passed to a benchmark in order to specify the order of magnitude
 // for the measured time.
@@ -396,7 +387,7 @@ struct Statistics {
   StatisticsFunc* compute_;
 
   Statistics(std::string name, StatisticsFunc* compute)
-    : name_(name), compute_(compute) {}
+      : name_(name), compute_(compute) {}
 };
 
 namespace internal {
@@ -405,14 +396,12 @@ class ThreadManager;
 
 enum ReportMode
 #if defined(BENCHMARK_HAS_CXX11)
-  : unsigned
+    : unsigned
 #else
 #endif
-  {
-  RM_Unspecified,  // The mode has not been manually specified
+{ RM_Unspecified,  // The mode has not been manually specified
   RM_Default,      // The mode is user-specified as default.
-  RM_ReportAggregatesOnly
-};
+  RM_ReportAggregatesOnly };
 }  // namespace internal
 
 // State is passed to a running Benchmark and contains state for the
@@ -581,8 +570,8 @@ class State {
     return max_iterations - total_iterations_ + batch_leftover_;
   }
 
-private: // items we expect on the first cache line (ie 64 bytes of the struct)
-
+ private
+     :  // items we expect on the first cache line (ie 64 bytes of the struct)
   // When total_iterations_ is 0, KeepRunning() and friends will return false.
   // May be larger than max_iterations.
   size_t total_iterations_;
@@ -592,15 +581,15 @@ private: // items we expect on the first cache line (ie 64 bytes of the struct)
   // completed_iterations_ accurately.
   size_t batch_leftover_;
 
-public:
+ public:
   const size_t max_iterations;
 
-private:
+ private:
   bool started_;
   bool finished_;
   bool error_occurred_;
 
-private: // items we don't need on the first cache line
+ private:  // items we don't need on the first cache line
   std::vector<int64_t> range_;
 
   int64_t bytes_processed_;
@@ -615,7 +604,6 @@ private: // items we don't need on the first cache line
   const int thread_index;
   // Number of threads concurrently executing the benchmark.
   const int threads;
-
 
   // TODO(EricWF) make me private
   State(size_t max_iters, const std::vector<int64_t>& ranges, int thread_i,
@@ -633,18 +621,16 @@ private: // items we don't need on the first cache line
   BENCHMARK_DISALLOW_COPY_AND_ASSIGN(State);
 };
 
-inline BENCHMARK_ALWAYS_INLINE
-bool State::KeepRunning() {
-  return KeepRunningInternal(1, /*is_batch=*/ false);
+inline BENCHMARK_ALWAYS_INLINE bool State::KeepRunning() {
+  return KeepRunningInternal(1, /*is_batch=*/false);
 }
 
-inline BENCHMARK_ALWAYS_INLINE
-bool State::KeepRunningBatch(size_t n) {
-  return KeepRunningInternal(n, /*is_batch=*/ true);
+inline BENCHMARK_ALWAYS_INLINE bool State::KeepRunningBatch(size_t n) {
+  return KeepRunningInternal(n, /*is_batch=*/true);
 }
 
-inline BENCHMARK_ALWAYS_INLINE
-bool State::KeepRunningInternal(size_t n, bool is_batch) {
+inline BENCHMARK_ALWAYS_INLINE bool State::KeepRunningInternal(size_t n,
+                                                               bool is_batch) {
   // total_iterations_ is set to 0 by the constructor, and always set to a
   // nonzero value by StartKepRunning().
   assert(n > 0);
@@ -657,13 +643,13 @@ bool State::KeepRunningInternal(size_t n, bool is_batch) {
   if (!started_) {
     StartKeepRunning();
     if (!error_occurred_ && total_iterations_ >= n) {
-      total_iterations_-= n;
+      total_iterations_ -= n;
       return true;
     }
   }
   // For non-batch runs, total_iterations_ must be 0 by now.
   if (is_batch && total_iterations_ != 0) {
-    batch_leftover_  = n - total_iterations_;
+    batch_leftover_ = n - total_iterations_;
     total_iterations_ = 0;
     return true;
   }
@@ -897,7 +883,7 @@ class Benchmark {
 
   std::string name_;
   ReportMode report_mode_;
-  std::vector<std::string> arg_names_;   // Args for all benchmark runs
+  std::vector<std::string> arg_names_;       // Args for all benchmark runs
   std::vector<std::vector<int64_t> > args_;  // Args for all benchmark runs
   TimeUnit time_unit_;
   int range_multiplier_;
@@ -1122,7 +1108,7 @@ class Fixture : public internal::Benchmark {
   class BaseClass##_##Method##_Benchmark : public BaseClass<a> {    \
    public:                                                          \
     BaseClass##_##Method##_Benchmark() : BaseClass<a>() {           \
-      this->SetName(#BaseClass"<" #a ">/" #Method);                 \
+      this->SetName(#BaseClass "<" #a ">/" #Method);                \
     }                                                               \
                                                                     \
    protected:                                                       \
@@ -1133,7 +1119,7 @@ class Fixture : public internal::Benchmark {
   class BaseClass##_##Method##_Benchmark : public BaseClass<a, b> {    \
    public:                                                             \
     BaseClass##_##Method##_Benchmark() : BaseClass<a, b>() {           \
-      this->SetName(#BaseClass"<" #a "," #b ">/" #Method);             \
+      this->SetName(#BaseClass "<" #a "," #b ">/" #Method);            \
     }                                                                  \
                                                                        \
    protected:                                                          \
@@ -1145,14 +1131,15 @@ class Fixture : public internal::Benchmark {
   class BaseClass##_##Method##_Benchmark : public BaseClass<__VA_ARGS__> { \
    public:                                                                 \
     BaseClass##_##Method##_Benchmark() : BaseClass<__VA_ARGS__>() {        \
-      this->SetName(#BaseClass"<" #__VA_ARGS__ ">/" #Method);              \
+      this->SetName(#BaseClass "<" #__VA_ARGS__ ">/" #Method);             \
     }                                                                      \
                                                                            \
    protected:                                                              \
     virtual void BenchmarkCase(::benchmark::State&);                       \
   };
 #else
-#define BENCHMARK_TEMPLATE_PRIVATE_DECLARE_F(n, a) BENCHMARK_TEMPLATE1_PRIVATE_DECLARE_F(n, a)
+#define BENCHMARK_TEMPLATE_PRIVATE_DECLARE_F(n, a) \
+  BENCHMARK_TEMPLATE1_PRIVATE_DECLARE_F(n, a)
 #endif
 
 #define BENCHMARK_DEFINE_F(BaseClass, Method)    \
@@ -1172,7 +1159,8 @@ class Fixture : public internal::Benchmark {
   BENCHMARK_TEMPLATE_PRIVATE_DECLARE_F(BaseClass, Method, __VA_ARGS__) \
   void BaseClass##_##Method##_Benchmark::BenchmarkCase
 #else
-#define BENCHMARK_TEMPLATE_DEFINE_F(BaseClass, Method, a) BENCHMARK_TEMPLATE1_DEFINE_F(BaseClass, Method, a)
+#define BENCHMARK_TEMPLATE_DEFINE_F(BaseClass, Method, a) \
+  BENCHMARK_TEMPLATE1_DEFINE_F(BaseClass, Method, a)
 #endif
 
 #define BENCHMARK_REGISTER_F(BaseClass, Method) \
@@ -1199,23 +1187,23 @@ class Fixture : public internal::Benchmark {
   void BaseClass##_##Method##_Benchmark::BenchmarkCase
 
 #ifdef BENCHMARK_HAS_CXX11
-#define BENCHMARK_TEMPLATE_F(BaseClass, Method, ...)           \
+#define BENCHMARK_TEMPLATE_F(BaseClass, Method, ...)                   \
   BENCHMARK_TEMPLATE_PRIVATE_DECLARE_F(BaseClass, Method, __VA_ARGS__) \
-  BENCHMARK_REGISTER_F(BaseClass, Method);                     \
+  BENCHMARK_REGISTER_F(BaseClass, Method);                             \
   void BaseClass##_##Method##_Benchmark::BenchmarkCase
 #else
-#define BENCHMARK_TEMPLATE_F(BaseClass, Method, a) BENCHMARK_TEMPLATE1_F(BaseClass, Method, a)
+#define BENCHMARK_TEMPLATE_F(BaseClass, Method, a) \
+  BENCHMARK_TEMPLATE1_F(BaseClass, Method, a)
 #endif
 
 // Helper macro to create a main routine in a test that runs the benchmarks
-#define BENCHMARK_MAIN()                   \
-  int main(int argc, char** argv) {        \
-    ::benchmark::Initialize(&argc, argv);  \
+#define BENCHMARK_MAIN()                                                \
+  int main(int argc, char** argv) {                                     \
+    ::benchmark::Initialize(&argc, argv);                               \
     if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1; \
-    ::benchmark::RunSpecifiedBenchmarks(); \
-  }                                        \
+    ::benchmark::RunSpecifiedBenchmarks();                              \
+  }                                                                     \
   int main(int, char**)
-
 
 // ------------------------------------------------------
 // Benchmark Reporters
@@ -1253,7 +1241,7 @@ class BenchmarkReporter {
     CPUInfo const& cpu_info;
     // The number of chars in the longest benchmark name.
     size_t name_field_width;
-    static const char *executable_name;
+    static const char* executable_name;
     Context();
   };
 
@@ -1376,17 +1364,19 @@ class BenchmarkReporter {
 // Simple reporter that outputs benchmark data to the console. This is the
 // default reporter used by RunSpecifiedBenchmarks().
 class ConsoleReporter : public BenchmarkReporter {
-public:
+ public:
   enum OutputOptions {
     OO_None = 0,
     OO_Color = 1,
     OO_Tabular = 2,
-    OO_ColorTabular = OO_Color|OO_Tabular,
+    OO_ColorTabular = OO_Color | OO_Tabular,
     OO_Defaults = OO_ColorTabular
   };
   explicit ConsoleReporter(OutputOptions opts_ = OO_Defaults)
-      : output_options_(opts_), name_field_width_(0),
-        prev_counters_(), printed_header_(false) {}
+      : output_options_(opts_),
+        name_field_width_(0),
+        prev_counters_(),
+        printed_header_(false) {}
 
   virtual bool ReportContext(const Context& context);
   virtual void ReportRuns(const std::vector<Run>& reports);
@@ -1424,7 +1414,7 @@ class CSVReporter : public BenchmarkReporter {
   void PrintRunData(const Run& report);
 
   bool printed_header_;
-  std::set< std::string > user_counter_names_;
+  std::set<std::string> user_counter_names_;
 };
 
 inline const char* GetTimeUnitString(TimeUnit unit) {
@@ -1451,6 +1441,6 @@ inline double GetTimeUnitMultiplier(TimeUnit unit) {
   }
 }
 
-} // namespace benchmark
+}  // namespace benchmark
 
 #endif  // BENCHMARK_BENCHMARK_H_


### PR DESCRIPTION
Many PRs include clang-format changes if they touch the header as we never brought it up to date. This PR is only the result of running clang-format on `include/benchmark/benchmark.h`.