### PR TITLE
cmake: use numeric version in package config

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,7 +69,7 @@ set(namespace "${PROJECT_NAME}::")
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-    "${version_config}" VERSION ${GIT_VERSION} COMPATIBILITY SameMajorVersion
+  "${version_config}" VERSION ${GENERIC_LIB_VERSION} COMPATIBILITY SameMajorVersion
 )
 
 configure_file("${PROJECT_SOURCE_DIR}/cmake/Config.cmake.in" "${project_config}" @ONLY)


### PR DESCRIPTION
Currently, it is not possible pass a specific version to `find_package (benchmark)` because the version string contains both digits and letters, e.g., `v1.4.0-12345abc-dirty`. Such a version string does not seem to be recognized by `CMakePackageConfigHelpers`. As a result,  `find_package (benchmark 1.4)` fails due to the unexpected version format.

This PR fixes the issue.