### PR TITLE
Avoid using CMake 3.6 feature list(FILTER ...)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,10 @@ file(GLOB
     *.cc
     ${PROJECT_SOURCE_DIR}/include/benchmark/*.h
     ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
-list(FILTER SOURCE_FILES EXCLUDE REGEX "benchmark_main\\.cc")
+file(GLOB BENCHMARK_MAIN "benchmark_main.cc")
+foreach(item ${BENCHMARK_MAIN})
+  list(REMOVE_ITEM SOURCE_FILES "${item}")
+endforeach()
 
 add_library(benchmark ${SOURCE_FILES})
 set_target_properties(benchmark PROPERTIES


### PR DESCRIPTION
`list(FILTER ...)` is a CMake 3.6 feature, but benchmark targets CMake 2.8.12