### PR TITLE
Add documentation on Running Your First Benchmark

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,7 +14,7 @@ Carto
 Christopher Seymour <chris.j.seymour@hotmail.com>
 David Coeurjolly <david.coeurjolly@liris.cnrs.fr>
 Deniz Evrenci <denizevrenci@gmail.com>
-Dirac Research 
+Dirac Research
 Dominik Czarnota <dominik.b.czarnota@gmail.com>
 Eric Fiselier <eric@efcs.ca>
 Eugene Zhuk <eugene.zhuk@gmail.com>
@@ -28,6 +28,7 @@ JianXiong Zhou <zhoujianxiong2@gmail.com>
 Joao Paulo Magalhaes <joaoppmagalhaes@gmail.com>
 Jussi Knuuttila <jussi.knuuttila@gmail.com>
 Kaito Udagawa <umireon@gmail.com>
+Kanak Kshetri <kanakkshetri@fastmail.fm>
 Kishan Kumar <kumar.kishan@outlook.com>
 Lei Xu <eddyxu@gmail.com>
 Matt Clarkson <mattyclarkson@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -42,6 +42,7 @@ Joao Paulo Magalhaes <joaoppmagalhaes@gmail.com>
 John Millikin <jmillikin@stripe.com>
 Jussi Knuuttila <jussi.knuuttila@gmail.com>
 Kai Wolf <kai.wolf@gmail.com>
+Kanak Kshetri <kanakkshetri@fastmail.fm>
 Kishan Kumar <kumar.kishan@outlook.com>
 Kaito Udagawa <umireon@gmail.com>
 Lei Xu <eddyxu@gmail.com>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ IRC channel: https://freenode.net #googlebenchmark
 
 [Known issues and common problems](#known-issues)
 
+[Running Your First Benchmark Documentation](docs/RunningFirstBenchmark.md)
+
 [Additional Tooling Documentation](docs/tools.md)
 
 [Assembly Testing Documentation](docs/AssemblyTests.md)
@@ -118,9 +120,9 @@ BENCHMARK(BM_StringCopy);
 BENCHMARK_MAIN();
 ```
 
-Don't forget to inform your linker to add benchmark library e.g. through 
-`-lbenchmark` compilation flag. Alternatively, you may leave out the 
-`BENCHMARK_MAIN();` at the end of the source file and link against 
+Don't forget to inform your linker to add benchmark library e.g. through
+`-lbenchmark` compilation flag. Alternatively, you may leave out the
+`BENCHMARK_MAIN();` at the end of the source file and link against
 `-lbenchmark_main` to get the same default behavior.
 
 The benchmark library will reporting the timing for the code within the `for(...)` loop.
@@ -334,7 +336,7 @@ Compared to an empty `KeepRunning` loop, which looks like:
 ```
 
 Unless C++03 compatibility is required, the ranged-for variant of writing
-the benchmark loop should be preferred.  
+the benchmark loop should be preferred.
 
 ## Passing arbitrary arguments to a benchmark
 In C++11 it is possible to define a benchmark that takes an arbitrary number

--- a/docs/RunningFirstBenchmark.md
+++ b/docs/RunningFirstBenchmark.md
@@ -1,0 +1,114 @@
+# Running Your First Benchmark
+
+This tutorial is aimed at people new to the library and shows you how to run benchmarks with the Google Benchmark library.
+
+# Install the prerequisites
+
+We need the following programs:
+
+* git : to clone google benchmark and gtest libraries
+* cmake : to build google benchmark
+* make : to build google benchmark. Advanced users can use an alternative cmake backend like ninja.
+* g++ : to compile your c++ code. Advanced users can use other compilers like clang instead.
+
+On Fedora 28, the following command installs the requirements:
+
+```
+sudo dnf install --assumeyes wget git-core cmake make gcc-c++
+```
+
+At the time of writing, the versions were as follows:
+* g++ : 8.1.1 20180502
+* cmake : 3.11.2
+* gnu make: 4.2.1
+* git: 2.17.1
+
+# Build and install Google Benchmark
+
+Follow the instructions elsewhere to build and install the google-benchmark library.
+
+On Fedora 28, these commands were sufficient:
+
+```
+git clone https://github.com/google/benchmark.git
+cd benchmark
+git clone https://github.com/google/googletest.git
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=RELEASE
+make -j
+sudo make install
+```
+
+`make install` should result in lines that look like:
+
+```
+-- Install configuration: "RELEASE"
+-- Installing: /usr/local/lib/libbenchmark.a
+-- Installing: /usr/local/lib/libbenchmark_main.a
+-- Installing: /usr/local/include/benchmark
+-- Installing: /usr/local/include/benchmark/benchmark.h
+-- Installing: /usr/local/lib/cmake/benchmark/benchmarkConfig.cmake
+-- Installing: /usr/local/lib/cmake/benchmark/benchmarkConfigVersion.cmake
+-- Installing: /usr/local/lib/pkgconfig/benchmark.pc
+-- Installing: /usr/local/lib/cmake/benchmark/benchmarkTargets.cmake
+-- Installing: /usr/local/lib/cmake/benchmark/benchmarkTargets-release.cmake
+```
+
+Note the locations of the header file (`benchmark.h`) and the static library (`libbenchmark.a`); you might have to tell your compiler to look for libraries in those paths. Things worked out of the box in Fedora 28.
+
+
+# Build your first benchmark
+
+Save this file as `BenchmarkMain.cpp`:
+
+```
+#include <benchmark/benchmark.h>
+#include <string>
+
+static void BM_StringCopy(benchmark::State& state) {
+    std::string x = "hello";
+    for (auto _ : state)
+        std::string copy(x);
+}
+
+BENCHMARK(BM_StringCopy);
+BENCHMARK_MAIN();
+```
+
+Use this command to build the library:
+
+```
+g++ BenchMain.cpp -std=c++11 -lbenchmark -lpthread -O2 -o BenchMain
+```
+
+Notes:
+* We use `-std=c++11` because the code sample uses range based for. You can specify `c++14` or `c++17` instead.
+* We use `-lbenchmark` and `-lpthread` to use the benchmark library in our code. It is important to have `BenchMain.cpp` specified before you specify the `-lbenchmark` and `-lpthread` flags; otherwise you will get very confusing `undefined reference` type errors when building.
+* We use `-O2` to compile the code with optimizations enabled. You want the code being benchmarked to be close to the code you will use in production, so you should specify any flags, including optimization flags that you compile your code with.
+* Finally, we use `-o BenchMain` to tell the compiler to build an executable called `BenchMain`
+
+Use this to run the created benchmark:
+
+```
+./BenchMain
+```
+
+This will produce an output that looks like:
+
+```
+2018-06-19 11:08:35
+Running ./BenchMain
+Run on (4 X 3000 MHz CPU s)
+CPU Caches:
+  L1 Data 32K (x2)
+  L1 Instruction 32K (x2)
+  L2 Unified 256K (x2)
+  L3 Unified 3072K (x1)
+-----------------------------------------------------
+Benchmark              Time           CPU Iterations
+-----------------------------------------------------
+BM_StringCopy          5 ns          5 ns  127850761
+```
+
+Congratulations. You have just run your first benchmark.


### PR DESCRIPTION
In https://github.com/google/benchmark/issues/619 , the need for
documentation aimed at rank beginners was mentioned. Specifically, the
need for exact command line incantations and expected outputs.

This commit adds a new file inside docs that contains this
beginner-friendly documentation. The documentation was verified
against Fedora 28, but can be extended to add ubuntu and other os
information.