### PR TITLE
Use EXPECT_DOUBLE_EQ when comparing doubles in tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,6 @@ else()
   add_cxx_compiler_flag(-pedantic)
   add_cxx_compiler_flag(-pedantic-errors)
   add_cxx_compiler_flag(-Wshorten-64-to-32)
-  add_cxx_compiler_flag(-Wfloat-equal)
   add_cxx_compiler_flag(-fstrict-aliasing)
   # Disable warnings regarding deprecated parts of the library while building
   # and testing those parts of the library.

--- a/test/string_util_gtest.cc
+++ b/test/string_util_gtest.cc
@@ -114,28 +114,28 @@ TEST(StringUtilTest, stoi) {
 TEST(StringUtilTest, stod) {
   {
     size_t pos = 0;
-    EXPECT_EQ(0.0, benchmark::stod("0", &pos));
+    EXPECT_DOUBLE_EQ(0.0, benchmark::stod("0", &pos));
     EXPECT_EQ(1, pos);
   }
   {
     size_t pos = 0;
-    EXPECT_EQ(-84.0, benchmark::stod("-84", &pos));
+    EXPECT_DOUBLE_EQ(-84.0, benchmark::stod("-84", &pos));
     EXPECT_EQ(3, pos);
   }
   {
     size_t pos = 0;
-    EXPECT_EQ(1234.0, benchmark::stod("1234", &pos));
+    EXPECT_DOUBLE_EQ(1234.0, benchmark::stod("1234", &pos));
     EXPECT_EQ(4, pos);
   }
   {
     size_t pos = 0;
-    EXPECT_EQ(1.5, benchmark::stod("1.5", &pos));
+    EXPECT_DOUBLE_EQ(1.5, benchmark::stod("1.5", &pos));
     EXPECT_EQ(3, pos);
   }
   {
     size_t pos = 0;
     /* Note: exactly representable as double */
-    EXPECT_EQ(-1.25e+9, benchmark::stod("-1.25e+9", &pos));
+    EXPECT_DOUBLE_EQ(-1.25e+9, benchmark::stod("-1.25e+9", &pos));
     EXPECT_EQ(8, pos);
   }
   {

--- a/test/string_util_gtest.cc
+++ b/test/string_util_gtest.cc
@@ -114,28 +114,28 @@ TEST(StringUtilTest, stoi) {
 TEST(StringUtilTest, stod) {
   {
     size_t pos = 0;
-    EXPECT_DOUBLE_EQ(0.0, benchmark::stod("0", &pos));
+    EXPECT_EQ(0.0, benchmark::stod("0", &pos));
     EXPECT_EQ(1, pos);
   }
   {
     size_t pos = 0;
-    EXPECT_DOUBLE_EQ(-84.0, benchmark::stod("-84", &pos));
+    EXPECT_EQ(-84.0, benchmark::stod("-84", &pos));
     EXPECT_EQ(3, pos);
   }
   {
     size_t pos = 0;
-    EXPECT_DOUBLE_EQ(1234.0, benchmark::stod("1234", &pos));
+    EXPECT_EQ(1234.0, benchmark::stod("1234", &pos));
     EXPECT_EQ(4, pos);
   }
   {
     size_t pos = 0;
-    EXPECT_DOUBLE_EQ(1.5, benchmark::stod("1.5", &pos));
+    EXPECT_EQ(1.5, benchmark::stod("1.5", &pos));
     EXPECT_EQ(3, pos);
   }
   {
     size_t pos = 0;
     /* Note: exactly representable as double */
-    EXPECT_DOUBLE_EQ(-1.25e+9, benchmark::stod("-1.25e+9", &pos));
+    EXPECT_EQ(-1.25e+9, benchmark::stod("-1.25e+9", &pos));
     EXPECT_EQ(8, pos);
   }
   {


### PR DESCRIPTION
Fixes #623