### PR TITLE
Memory management and reporting hooks

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -268,8 +268,8 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* console_reporter);
 size_t RunSpecifiedBenchmarks(BenchmarkReporter* console_reporter,
                               BenchmarkReporter* file_reporter);
 
-// Register a MemoryManager instance that will be used to report on allocation
-// data for benchmark runs.
+// Register a MemoryManager instance that will be used to collect and report
+// allocation measurements for benchmark runs.
 void RegisterMemoryManager(MemoryManager* memory_manager);
 
 namespace internal {
@@ -1424,23 +1424,21 @@ class BENCHMARK_DEPRECATED_MSG("The CSV Reporter will be removed in a future rel
   std::set<std::string> user_counter_names_;
 };
 
-// If a MemoryManager is registered, it can be used to report memory statistics
-// for a run of the benchmark.
+// If a MemoryManager is registered, it can be used to collect and report
+// allocation metrics for a run of the benchmark.
 class MemoryManager {
  public:
   struct Result {
-    explicit Result(int64_t iters)
-        : num_allocs(0), max_bytes_used(0), iterations(iters) {}
+    Result() : num_allocs(0), max_bytes_used(0) {}
 
     // The number of allocations made in total between Start and Stop.
     int64_t num_allocs;
 
     // The peak memory use between Start and Stop.
     int64_t max_bytes_used;
-
-    // The number of iterations run for the memory test.
-    const int64_t iterations;
   };
+
+  virtual ~MemoryManager() {}
 
   // Implement this to start recording allocation information.
   virtual void Start() = 0;

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1259,6 +1259,7 @@ class BenchmarkReporter {
           report_big_o(false),
           report_rms(false),
           counters(),
+          has_memory_result(false),
           allocs_per_iter(0.0),
           max_bytes_used(0) {}
 
@@ -1306,6 +1307,7 @@ class BenchmarkReporter {
     UserCounters counters;
 
     // Memory metrics.
+    bool has_memory_result;
     double allocs_per_iter;
     int64_t max_bytes_used;
   };
@@ -1427,10 +1429,11 @@ class BENCHMARK_DEPRECATED_MSG("The CSV Reporter will be removed in a future rel
 class MemoryManager {
  public:
   struct Result {
-    Result() : num_allocs(0), max_bytes_used(0), iterations(0) {}
+    explicit Result(int64_t iters)
+        : num_allocs(0), max_bytes_used(0), iterations(iters) {}
     int64_t num_allocs;
     int64_t max_bytes_used;
-    int64_t iterations;
+    const int64_t iterations;
   };
 
   // Implement this to start recording allocation information.

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1431,8 +1431,14 @@ class MemoryManager {
   struct Result {
     explicit Result(int64_t iters)
         : num_allocs(0), max_bytes_used(0), iterations(iters) {}
+
+    // The number of allocations made in total between Start and Stop.
     int64_t num_allocs;
+
+    // The peak memory use between Start and Stop.
     int64_t max_bytes_used;
+
+    // The number of iterations run for the memory test.
     const int64_t iterations;
   };
 

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -104,7 +104,7 @@ DEFINE_int32(v, 0, "The level of verbose logging to output");
 namespace benchmark {
 
 namespace {
-static const int64_t kMaxIterations = 1000000000;
+static const size_t kMaxIterations = 1000000000;
 
 static MemoryManager* memory_manager = nullptr;
 }  // end namespace
@@ -117,7 +117,7 @@ namespace {
 
 BenchmarkReporter::Run CreateRunReport(
     const benchmark::internal::Benchmark::Instance& b,
-    const internal::ThreadManager::Result& results, int64_t memory_iterations,
+    const internal::ThreadManager::Result& results, size_t memory_iterations,
     const MemoryManager::Result& memory_result, double seconds) {
   // Create report about this benchmark run.
   BenchmarkReporter::Run report;
@@ -171,7 +171,7 @@ BenchmarkReporter::Run CreateRunReport(
 // Execute one thread of benchmark b for the specified number of iterations.
 // Adds the stats collected for the thread into *total.
 void RunInThread(const benchmark::internal::Benchmark::Instance* b,
-                 int64_t iters, int thread_id,
+                 size_t iters, int thread_id,
                  internal::ThreadManager* manager) {
   internal::ThreadTimer timer;
   State st(iters, b->arg, thread_id, b->threads, &timer, manager);
@@ -199,7 +199,7 @@ std::vector<BenchmarkReporter::Run> RunBenchmark(
   std::vector<BenchmarkReporter::Run> reports;  // return value
 
   const bool has_explicit_iteration_count = b.iterations != 0;
-  int64_t iters = has_explicit_iteration_count ? b.iterations : 1;
+  size_t iters = has_explicit_iteration_count ? b.iterations : 1;
   std::unique_ptr<internal::ThreadManager> manager;
   std::vector<std::thread> pool(b.threads - 1);
   const int repeats =
@@ -263,11 +263,11 @@ std::vector<BenchmarkReporter::Run> RunBenchmark(
 
       if (should_report) {
         MemoryManager::Result memory_result;
-        int64_t memory_iterations = 0;
+        size_t memory_iterations = 0;
         if (memory_manager != nullptr) {
           // Only run a few iterations to reduce the impact of one-time
           // allocations in benchmarks that are not properly managed.
-          memory_iterations = std::min<int64_t>(16, iters);
+          memory_iterations = std::min<size_t>(16, iters);
           memory_manager->Start();
           manager.reset(new internal::ThreadManager(1));
           RunInThread(&b, memory_iterations, 0, manager.get());

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -104,7 +104,7 @@ DEFINE_int32(v, 0, "The level of verbose logging to output");
 namespace benchmark {
 
 namespace {
-static const size_t kMaxIterations = 1000000000;
+static const int64_t kMaxIterations = 1000000000;
 
 static MemoryManager* memory_manager = nullptr;
 }  // end namespace
@@ -171,7 +171,7 @@ BenchmarkReporter::Run CreateRunReport(
 // Execute one thread of benchmark b for the specified number of iterations.
 // Adds the stats collected for the thread into *total.
 void RunInThread(const benchmark::internal::Benchmark::Instance* b,
-                 size_t iters, int thread_id,
+                 int64_t iters, int thread_id,
                  internal::ThreadManager* manager) {
   internal::ThreadTimer timer;
   State st(iters, b->arg, thread_id, b->threads, &timer, manager);
@@ -199,7 +199,7 @@ std::vector<BenchmarkReporter::Run> RunBenchmark(
   std::vector<BenchmarkReporter::Run> reports;  // return value
 
   const bool has_explicit_iteration_count = b.iterations != 0;
-  size_t iters = has_explicit_iteration_count ? b.iterations : 1;
+  int64_t iters = has_explicit_iteration_count ? b.iterations : 1;
   std::unique_ptr<internal::ThreadManager> manager;
   std::vector<std::thread> pool(b.threads - 1);
   const int repeats =

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -29,7 +29,7 @@ struct Benchmark::Instance {
   bool last_benchmark_instance;
   int repetitions;
   double min_time;
-  size_t iterations;
+  int64_t iterations;
   int threads;  // Number of concurrent threads to us
 };
 

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -29,7 +29,7 @@ struct Benchmark::Instance {
   bool last_benchmark_instance;
   int repetitions;
   double min_time;
-  int64_t iterations;
+  size_t iterations;
   int threads;  // Number of concurrent threads to us
 };
 

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -186,6 +186,12 @@ void JSONReporter::PrintRunData(Run const& run) {
   for (auto& c : run.counters) {
     out << ",\n" << indent << FormatKV(c.first, c.second);
   }
+
+  if (run.has_memory_result) {
+    out << ",\n" << indent << FormatKV("allocs_per_iter", run.allocs_per_iter);
+    out << ",\n" << indent << FormatKV("max_bytes_used", run.max_bytes_used);
+  }
+
   if (!run.report_label.empty()) {
     out << ",\n" << indent << FormatKV("label", run.report_label);
   }

--- a/test/memory_manager_test.cc
+++ b/test/memory_manager_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "../src/check.h"
 #include "benchmark/benchmark.h"
 #include "output_test.h"
@@ -22,15 +24,17 @@ ADD_CASES(TC_JSONOut, {{"\"name\": \"BM_empty\",$"},
                        {"\"iterations\": %int,$", MR_Next},
                        {"\"real_time\": %float,$", MR_Next},
                        {"\"cpu_time\": %float,$", MR_Next},
-                       {"\"time_unit\": \"ns\"$", MR_Next},
+                       {"\"time_unit\": \"ns\",$", MR_Next},
                        {"\"allocs_per_iter\": %float,$", MR_Next},
-                       {"\"max_bytes_used\": %int,$", MR_Next},
+                       {"\"max_bytes_used\": 42000$", MR_Next},
                        {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_empty\",%csv_report$"}});
 
 
 int main(int argc, char *argv[]) {
-  benchmark::Initialize(&argc, argv);
-  benchmark::RegisterMemoryManager(new TestMemoryManager());
-  benchmark::RunSpecifiedBenchmarks();
+  std::unique_ptr<benchmark::MemoryManager> mm(new TestMemoryManager());
+
+  benchmark::RegisterMemoryManager(mm.get());
+  RunOutputTests(argc, argv);
+  benchmark::RegisterMemoryManager(nullptr);
 }

--- a/test/memory_manager_test.cc
+++ b/test/memory_manager_test.cc
@@ -1,0 +1,36 @@
+#include "../src/check.h"
+#include "benchmark/benchmark.h"
+#include "output_test.h"
+
+class TestMemoryManager : public benchmark::MemoryManager {
+  void Start() {}
+  void Stop(Result* result) {
+    result->num_allocs = 42;
+    result->max_bytes_used = 42000;
+  }
+};
+
+void BM_empty(benchmark::State& state) {
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(state.iterations());
+  }
+}
+BENCHMARK(BM_empty);
+
+ADD_CASES(TC_ConsoleOut, {{"^BM_empty %console_report$"}});
+ADD_CASES(TC_JSONOut, {{"\"name\": \"BM_empty\",$"},
+                       {"\"iterations\": %int,$", MR_Next},
+                       {"\"real_time\": %float,$", MR_Next},
+                       {"\"cpu_time\": %float,$", MR_Next},
+                       {"\"time_unit\": \"ns\"$", MR_Next},
+                       {"\"allocs_per_iter\": %float,$", MR_Next},
+                       {"\"max_bytes_used\": %float,$", MR_Next},
+                       {"}", MR_Next}});
+ADD_CASES(TC_CSVOut, {{"^\"BM_empty\",%csv_report$"}});
+
+
+int main(int argc, char *argv[]) {
+  benchmark::Initialize(&argc, argv);
+  benchmark::RegisterMemoryManager(new TestMemoryManager());
+  benchmark::RunSpecifiedBenchmarks();
+}

--- a/test/memory_manager_test.cc
+++ b/test/memory_manager_test.cc
@@ -24,7 +24,7 @@ ADD_CASES(TC_JSONOut, {{"\"name\": \"BM_empty\",$"},
                        {"\"cpu_time\": %float,$", MR_Next},
                        {"\"time_unit\": \"ns\"$", MR_Next},
                        {"\"allocs_per_iter\": %float,$", MR_Next},
-                       {"\"max_bytes_used\": %float,$", MR_Next},
+                       {"\"max_bytes_used\": %int,$", MR_Next},
                        {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_empty\",%csv_report$"}});
 


### PR DESCRIPTION
This PR allows one to register a memory management object that can track allocation counts and heap usage, and then inject them into the benchmark report.