### PR TITLE
Fix build with Intel compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,13 @@ else()
   add_cxx_compiler_flag(-fstrict-aliasing)
   # Disable warnings regarding deprecated parts of the library while building
   # and testing those parts of the library.
-  add_cxx_compiler_flag(-Wno-deprecated-declarations)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+    # Intel silently ignores '-Wno-deprecated-declarations',
+    # warning no. 1786 must be explicitly disabled.
+    add_cxx_compiler_flag(-wd1786)
+  else()
+    add_cxx_compiler_flag(-Wno-deprecated-declarations)
+  endif()
   # Disable deprecation warnings for release builds (when -Werror is enabled).
   add_cxx_compiler_flag(-Wno-deprecated RELEASE)
   add_cxx_compiler_flag(-Wno-deprecated RELWITHDEBINFO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,12 +141,12 @@ else()
   add_cxx_compiler_flag(-fstrict-aliasing)
   # Disable warnings regarding deprecated parts of the library while building
   # and testing those parts of the library.
+  add_cxx_compiler_flag(-Wno-deprecated-declarations)
   if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
     # Intel silently ignores '-Wno-deprecated-declarations',
     # warning no. 1786 must be explicitly disabled.
+    # See #631 for rationale.
     add_cxx_compiler_flag(-wd1786)
-  else()
-    add_cxx_compiler_flag(-Wno-deprecated-declarations)
   endif()
   # Disable deprecation warnings for release builds (when -Werror is enabled).
   add_cxx_compiler_flag(-Wno-deprecated RELEASE)

--- a/src/complexity.cc
+++ b/src/complexity.cc
@@ -36,10 +36,10 @@ BigOFunc* FittingCurve(BigO complexity) {
       return [](int64_t n) -> double { return std::pow(n, 3); };
     case oLogN:
       /* Note: can't use log2 because Android's GNU STL lacks it */
-      return [](int64_t n) { return kLog2E * log(n); };
+      return [](int64_t n) { return kLog2E * log(static_cast<double>(n)); };
     case oNLogN:
       /* Note: can't use log2 because Android's GNU STL lacks it */
-      return [](int64_t n) { return kLog2E * n * log(n); };
+      return [](int64_t n) { return kLog2E * n * log(static_cast<double>(n)); };
     case o1:
     default:
       return [](int64_t) { return 1.0; };

--- a/test/complexity_test.cc
+++ b/test/complexity_test.cc
@@ -85,7 +85,7 @@ std::vector<int> ConstructRandomVector(int64_t size) {
   std::vector<int> v;
   v.reserve(static_cast<int>(size));
   for (int i = 0; i < size; ++i) {
-    v.push_back(std::rand() % size);
+    v.push_back(static_cast<int>(std::rand() % size));
   }
   return v;
 }

--- a/test/complexity_test.cc
+++ b/test/complexity_test.cc
@@ -106,7 +106,7 @@ BENCHMARK(BM_Complexity_O_N)
 BENCHMARK(BM_Complexity_O_N)
     ->RangeMultiplier(2)
     ->Range(1 << 10, 1 << 16)
-    ->Complexity([](int64_t n) -> double { return n; });
+    ->Complexity([](int64_t n) -> double { return static_cast<double>(n); });
 BENCHMARK(BM_Complexity_O_N)
     ->RangeMultiplier(2)
     ->Range(1 << 10, 1 << 16)
@@ -142,7 +142,7 @@ BENCHMARK(BM_Complexity_O_N_log_N)
 BENCHMARK(BM_Complexity_O_N_log_N)
     ->RangeMultiplier(2)
     ->Range(1 << 10, 1 << 16)
-    ->Complexity([](int64_t n) { return kLog2E * n * log(n); });
+    ->Complexity([](int64_t n) { return kLog2E * n * log(static_cast<double>(n)); });
 BENCHMARK(BM_Complexity_O_N_log_N)
     ->RangeMultiplier(2)
     ->Range(1 << 10, 1 << 16)


### PR DESCRIPTION
This PR fixes some quirks that prevent the build with the Intel compiler when `-DCMAKE_BUILD_TYPE=Release` is set that in turn adds `-Werror` to build flags. Should fix #630 (and should fix #568 as well) for the following Intel versions:

* 2016 (`16.0.3`)
* 2017 (`17.0.4`)
* 2018 (`18.0.3`)
* 2019-beta (`19.0.0.046`, not yet released)