### PR TITLE
CI: Add Conan testing, mass building and publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,49 @@ matrix:
         - LIBCXX_BUILD=1 LIBCXX_SANITIZER=Thread
         - ENABLE_SANITIZER=1
         - EXTRA_FLAGS="-stdlib=libc++ -g -O2 -fno-omit-frame-pointer -fsanitize=thread -fno-sanitize-recover=all"
+    # Conan testing and uploading
+    - compiler: gcc
+      env: CONAN=True
+      language: python
+      python: "3.6"
+      before_script:
+        - pip install -U pip
+      before_install:
+        - pip --version
+      install:
+        - pip install conan
+      script:
+        - conan create . benchmark/master@google/testing --build
+      after_success:
+        # If this build is NOT triggered by a pull request; AND got triggered by either a tag OR push to master
+        # and the following environment variables are set:
+        #   CONAN_UPLOAD - a reference to the Conan repository e.g. https://bintray.com/google/conan
+        #   CONAN_LOGIN_USERNAME - user for the upload e.g. upload_bot_username
+        #   CONAN_PASSWORD - password for the CONAN_LOGIN_USERNAME; for Bintray this is the API key
+        # then upload the new recipe version to the Conan repository.
+        #
+        # For the tag pushes we are using for the
+        #   version the tag name, removing the "v"
+        #   channel "stable"
+        # For master pushes we are using for the
+        #   version simply "master"
+        #   channel "testing"
+        - if [[ "${TRAVIS_PULL_REQUEST}" == "false" && ( -n "${TRAVIS_TAG}" || "${TRAVIS_BRANCH}" == "master" ) && -n "${CONAN_UPLOAD}" && -n "${CONAN_LOGIN_USERNAME}" && -n "${CONAN_PASSWORD}" ]]; then
+            conan remote add benchmark ${CONAN_UPLOAD} --insert;
+            conan remote list;
+
+            if [ -n "${TRAVIS_TAG}" ]; then
+              CONANVERSION=${TRAVIS_TAG//v};
+              CONANREFERENCE=benchmark/${CONANVERSION}@google/stable;
+              conan export . ${CONANREFERENCE};
+            else
+              CONANVERSION="master";
+              CONANREFERENCE=benchmark/${CONANVERSION}@google/testing;
+            fi;
+
+            conan user -p "${CONAN_PASSWORD}" -r benchmark "${CONAN_LOGIN_USERNAME}";
+            conan upload --force -r benchmark --retry 3 --retry-wait 10 --confirm "${CONANREFERENCE}";
+          fi;
     - os: osx
       osx_image: xcode8.3
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,38 @@ language: cpp
 env:
   global:
     - /usr/local/bin:$PATH
+    - CONAN_USERNAME="google"
+    - CONAN_PACKAGE_NAME="benchmark"
+
+conan-buildsteps: &conan-buildsteps
+  before_install:
+    # use this step if you desire to manipulate CONAN variables programmatically
+    # dummy to overwrite default build steps
+    - true
+  install:
+    - chmod +x ./conan/ci/install.sh
+    - ./conan/ci/install.sh
+  script:
+    - chmod +x ./conan/ci/build.sh
+    - ./conan/ci/build.sh
+   # the following are dummies to overwrite default build steps
+  before_script:
+    - true
+  after_success:
+    - true
+  if: tag IS present
+conan-linux: &conan-linux
+  os: linux
+  dist: xenial
+  language: python
+  python: "3.7"
+  services:
+    - docker
+  <<: *conan-buildsteps
+conan-osx: &conan-osx
+  os: osx
+  language: generic
+  <<: *conan-buildsteps
 
 matrix:
   include:
@@ -117,49 +149,6 @@ matrix:
         - LIBCXX_BUILD=1 LIBCXX_SANITIZER=Thread
         - ENABLE_SANITIZER=1
         - EXTRA_FLAGS="-stdlib=libc++ -g -O2 -fno-omit-frame-pointer -fsanitize=thread -fno-sanitize-recover=all"
-    # Conan testing and uploading
-    - compiler: gcc
-      env: CONAN=True
-      language: python
-      python: "3.6"
-      before_script:
-        - pip install -U pip
-      before_install:
-        - pip --version
-      install:
-        - pip install conan
-      script:
-        - conan create . benchmark/master@google/testing --build
-      after_success:
-        # If this build is NOT triggered by a pull request; AND got triggered by either a tag OR push to master
-        # and the following environment variables are set:
-        #   CONAN_UPLOAD - a reference to the Conan repository e.g. https://bintray.com/google/conan
-        #   CONAN_LOGIN_USERNAME - user for the upload e.g. upload_bot_username
-        #   CONAN_PASSWORD - password for the CONAN_LOGIN_USERNAME; for Bintray this is the API key
-        # then upload the new recipe version to the Conan repository.
-        #
-        # For the tag pushes we are using for the
-        #   version the tag name, removing the "v"
-        #   channel "stable"
-        # For master pushes we are using for the
-        #   version simply "master"
-        #   channel "testing"
-        - if [[ "${TRAVIS_PULL_REQUEST}" == "false" && ( -n "${TRAVIS_TAG}" || "${TRAVIS_BRANCH}" == "master" ) && -n "${CONAN_UPLOAD}" && -n "${CONAN_LOGIN_USERNAME}" && -n "${CONAN_PASSWORD}" ]]; then
-            conan remote add benchmark ${CONAN_UPLOAD} --insert;
-            conan remote list;
-
-            if [ -n "${TRAVIS_TAG}" ]; then
-              CONANVERSION=${TRAVIS_TAG//v};
-              CONANREFERENCE=benchmark/${CONANVERSION}@google/stable;
-              conan export . ${CONANREFERENCE};
-            else
-              CONANVERSION="master";
-              CONANREFERENCE=benchmark/${CONANVERSION}@google/testing;
-            fi;
-
-            conan user -p "${CONAN_PASSWORD}" -r benchmark "${CONAN_LOGIN_USERNAME}";
-            conan upload --force -r benchmark --retry 3 --retry-wait 10 --confirm "${CONANREFERENCE}";
-          fi;
     - os: osx
       osx_image: xcode8.3
       compiler: clang
@@ -180,6 +169,80 @@ matrix:
       compiler: gcc
       env:
         - COMPILER=g++-7 C_COMPILER=gcc-7  BUILD_TYPE=Debug
+    # Conan testing and uploading
+    - compiler: gcc
+      env: CONAN=True
+      language: python
+      dist: xenial
+      python: "3.7"
+      before_install:
+        - pip install -U pip
+      install:
+        - pip install conan
+      before_script:
+        - pip --version
+        - conan --version
+      script:
+        - CONAN_FULL_REFERENCE=${CONAN_PACKAGE_NAME}/master@${CONAN_USERNAME}/testing
+        - conan create . ${CONAN_FULL_REFERENCE} --build --test-folder "conan/test_package"
+      after_success:
+        # If this build is NOT triggered by a pull request; AND got triggered by either a tag OR push to master
+        # and the following environment variables are set:
+        #   CONAN_UPLOAD - a reference to the Conan repository e.g. https://api.bintray.com/google/conan
+        #   CONAN_LOGIN_USERNAME - user for the upload e.g. upload_bot_username
+        #   CONAN_PASSWORD - password for the CONAN_LOGIN_USERNAME; for Bintray this is the API key
+        # then upload the new recipe version to the Conan repository.
+        # For tag pushes we are also building and uploading packages for common configurations.
+        #
+        # For the tag pushes we are using for the
+        #   version the tag name, removing the "v"
+        #   channel "stable"
+        # For master pushes we are using for the
+        #   version simply "master"
+        #   channel "testing"
+        - if [[ "${TRAVIS_PULL_REQUEST}" == "false" && "${TRAVIS_BRANCH}" == "master" && -n "${CONAN_UPLOAD}" && -n "${CONAN_LOGIN_USERNAME}" && -n "${CONAN_PASSWORD}" ]]; then
+            conan remote add ${CONAN_PACKAGE_NAME} ${CONAN_UPLOAD} --insert;
+            conan remote list;
+
+            conan user -p "${CONAN_PASSWORD}" -r benchmark "${CONAN_LOGIN_USERNAME}";
+            conan upload --force -r ${CONAN_PACKAGE_NAME} --retry 3 --retry-wait 10 --confirm "${CONAN_FULL_REFERENCE}";
+          fi;
+      if: NOT tag IS present
+    - <<: *conan-linux
+      env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=conanio/gcc49
+    - <<: *conan-linux
+      env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=conanio/gcc5
+    - <<: *conan-linux
+      env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=conanio/gcc6
+    - <<: *conan-linux
+      env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7
+    - <<: *conan-linux
+      env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8
+    - <<: *conan-linux
+      env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=conanio/clang39
+    - <<: *conan-linux
+      env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=conanio/clang40
+    - <<: *conan-linux
+      env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=conanio/clang50
+    - <<: *conan-linux
+      env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=conanio/clang60
+    - <<: *conan-linux
+      env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7
+    - <<: *conan-osx
+      osx_image: xcode7.3
+      env: CONAN_APPLE_CLANG_VERSIONS=7.3
+    - <<: *conan-osx
+      osx_image: xcode8.3
+      env: CONAN_APPLE_CLANG_VERSIONS=8.1
+    - <<: *conan-osx
+      osx_image: xcode9
+      env: CONAN_APPLE_CLANG_VERSIONS=9.0
+    - <<: *conan-osx
+      osx_image: xcode9.4
+      env: CONAN_APPLE_CLANG_VERSIONS=9.1
+    - <<: *conan-osx
+      osx_image: xcode10.1
+      env: CONAN_APPLE_CLANG_VERSIONS=10.0
 
 before_script:
   - if [ -n "${LIBCXX_BUILD}" ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ configuration:
   - Release
 
 environment:
+  global:
+    CONAN_USERNAME: "google"
+    CONAN_PACKAGE_NAME: "benchmark"
+    CONAN_DISABLE_SHARED_BUILD: "True" # Remove this line altogether when shared Win builds are fixed
   matrix:
     - compiler: msvc-15-seh
       generator: "Visual Studio 15 2017"
@@ -25,26 +29,65 @@ environment:
       cxx_path: 'C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin'
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      CONAN_VISUAL_VERSIONS: 14
+      CONAN_BUILD_TYPES: Release
+      CONAN: true
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      CONAN_VISUAL_VERSIONS: 14
+      CONAN_BUILD_TYPES: Debug
+      CONAN: true
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CONAN_VISUAL_VERSIONS: 15
+      CONAN_BUILD_TYPES: Release
+      CONAN: true
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CONAN_VISUAL_VERSIONS: 15
+      CONAN_BUILD_TYPES: Debug
+      CONAN: true
+
 matrix:
+  exclude:
+    # We only need one time all Conan jobs, so exclude all but one configuration from matrix expanding
+    - CONAN: true
+      configuration: Debug
   fast_finish: true
 
-install:
-  # git bash conflicts with MinGW makefiles
-  - if "%generator%"=="MinGW Makefiles" (set "PATH=%PATH:C:\Program Files\Git\usr\bin;=%")
-  - if not "%cxx_path%"=="" (set "PATH=%PATH%;%cxx_path%")
+for:
+-
+  matrix:
+    except:
+      - CONAN: true
 
-build_script:
-  - md _build -Force
-  - cd _build
-  - echo %configuration%
-  - cmake -G "%generator%" "-DCMAKE_BUILD_TYPE=%configuration%" -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON ..
-  - cmake --build . --config %configuration%
+  install:
+    # git bash conflicts with MinGW makefiles
+    - if "%generator%"=="MinGW Makefiles" (set "PATH=%PATH:C:\Program Files\Git\usr\bin;=%")
+    - if not "%cxx_path%"=="" (set "PATH=%PATH%;%cxx_path%")
 
-test_script:
-  - ctest -c %configuration% --timeout 300 --output-on-failure
+  build_script:
+    - md _build -Force
+    - cd _build
+    - echo %configuration%
+    - cmake -G "%generator%" "-DCMAKE_BUILD_TYPE=%configuration%" -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON ..
+    - cmake --build . --config %configuration%
 
-artifacts:
-  - path: '_build/CMakeFiles/*.log'
-    name: logs
-  - path: '_build/Testing/**/*.xml'
-    name: test_results
+  test_script:
+    - ctest -c %configuration% --timeout 300 --output-on-failure
+
+  artifacts:
+    - path: '_build/CMakeFiles/*.log'
+      name: logs
+    - path: '_build/Testing/**/*.xml'
+      name: test_results
+
+-
+  matrix:
+    only:
+      - CONAN: true
+  skip_non_tags: true
+
+  install:
+    - python conan/appveyor/install.py
+
+  build_script:
+    - python conan/appveyor/build.py

--- a/conan/appveyor/build.py
+++ b/conan/appveyor/build.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+
+if os.getenv("APPVEYOR_REPO_TAG") != "true":
+    print("Skip build step. It's not TAG")
+else:
+    os.system("python conan/build.py")

--- a/conan/appveyor/install.py
+++ b/conan/appveyor/install.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+
+if os.getenv("APPVEYOR_REPO_TAG") != "true":
+    print("Skip step. It's not TAG")
+else:
+    os.system("pip install conan conan-package-tools")

--- a/conan/build.py
+++ b/conan/build.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from cpt.packager import ConanMultiPackager
+import os
+
+def set_appveyor_environment():
+    if os.getenv("APPVEYOR") is not None:
+        os.environ["CONAN_STABLE_BRANCH_PATTERN"] = os.getenv("CONAN_STABLE_BRANCH_PATTERN", "master")
+        os.environ["CONAN_ARCHS"] = os.getenv("CONAN_ARCHS", "x86,x86_64")
+        os.environ["CONAN_BUILD_TYPES"] = os.getenv("CONAN_BUILD_TYPES", "Release,Debug").replace('"', '')
+        os.environ["CONAN_PACKAGE_VERSION"] = os.getenv("CONAN_PACKAGE_VERSION", os.getenv("APPVEYOR_REPO_TAG_NAME"))
+
+if __name__ == "__main__":
+    set_appveyor_environment()
+    login_username = os.getenv("CONAN_LOGIN_USERNAME")
+    username = os.getenv("CONAN_USERNAME")
+    tag_version = os.getenv("CONAN_PACKAGE_VERSION", os.getenv("TRAVIS_TAG"))
+    package_version = tag_version.replace("v", "")
+    package_name_unset = "SET-CONAN_PACKAGE_NAME-OR-CONAN_REFERENCE"
+    package_name = os.getenv("CONAN_PACKAGE_NAME", package_name_unset)
+    reference = "{}/{}".format(package_name, package_version)
+    channel = os.getenv("CONAN_CHANNEL", "stable")
+    upload = os.getenv("CONAN_UPLOAD")
+    stable_branch_pattern = os.getenv("CONAN_STABLE_BRANCH_PATTERN", r"v\d+\.\d+\.\d+.*")
+    test_folder = os.getenv("CPT_TEST_FOLDER", os.path.join("conan", "test_package"))
+    upload_only_when_stable = os.getenv("CONAN_UPLOAD_ONLY_WHEN_STABLE", True)
+
+    disable_shared = os.getenv("CONAN_DISABLE_SHARED_BUILD", "False")
+    if disable_shared == "True" and package_name == package_name_unset:
+        raise Exception("CONAN_DISABLE_SHARED_BUILD: True is only supported when you define CONAN_PACKAGE_NAME")
+
+    builder = ConanMultiPackager(username=username,
+                                 reference=reference,
+                                 channel=channel,
+                                 login_username=login_username,
+                                 upload=upload,
+                                 stable_branch_pattern=stable_branch_pattern,
+                                 upload_only_when_stable=upload_only_when_stable,
+                                 test_folder=test_folder)
+    builder.add_common_builds(pure_c=False)
+
+    filtered_builds = []
+    for settings, options, env_vars, build_requires, reference in builder.items:
+        if disable_shared == "False" or not options["{}:shared".format(package_name)]:
+             filtered_builds.append([settings, options, env_vars, build_requires])
+    builder.builds = filtered_builds
+
+    builder.run()

--- a/conan/ci/build.sh
+++ b/conan/ci/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+    pyenv activate conan
+fi
+
+conan user
+python conan/build.py

--- a/conan/ci/install.sh
+++ b/conan/ci/install.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew update || brew update
+    brew outdated pyenv || brew upgrade pyenv
+    brew install pyenv-virtualenv
+    brew install cmake || true
+
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+
+    pyenv install 3.7.1
+    pyenv virtualenv 3.7.1 conan
+    pyenv rehash
+    pyenv activate conan
+fi
+
+pip install -U conan_package_tools conan

--- a/conan/test_package/CMakeLists.txt
+++ b/conan/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.12)
 project(test_package)
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE)


### PR DESCRIPTION
This
  * is adding a recipe for the Conan package manager
  * also adds a small test to the CI if Conan package creation is working 
  * updated: also adds a upload script to the CI for the Conan recipe to a Conan repository

~~Please note that for future releases of benchmark the version string needs to be updated in conanfile.py~~ (not anymore, see discussion)

_______
~~**Future work** could include~~
**Remaining to do list:**
  * [x] setting up a free repository on Bintray: https://bintray.com/dominichamon/benchmark
  * [ ] including the package in the official Conan repository [conan-center](https://bintray.com/conan/conan-center) 
   * [x] and extending the CI to upload new versions of the recipe and built packages to the Bintray repository automatically

To use the recipe after this pull request is merged it requires to clone this git repository first; when the recipe is included in conan-center every Conan client would be able to use it via one single install command.
_______

Please let me know if you have any further questions regarding supporting Conan 😄 

Fixes #635 

//cc @raulbocanegra @p-groarke @danimtb @Mikayex @mpusz @iblis-ms