### PR TITLE
Remove redundant default which causes failures

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1476,7 +1476,7 @@ inline const char* GetTimeUnitString(TimeUnit unit) {
     case kNanosecond:
       return "ns";
   }
-  return "ns";
+  __builtin_unreachable();
 }
 
 inline double GetTimeUnitMultiplier(TimeUnit unit) {
@@ -1488,7 +1488,7 @@ inline double GetTimeUnitMultiplier(TimeUnit unit) {
     case kNanosecond:
       return 1e9;
   }
-  return 1e9;
+  __builtin_unreachable();
 }
 
 }  // namespace benchmark

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -241,6 +241,10 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #define BENCHMARK_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #endif
 
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
 #if defined(COMPILER_GCC) || __has_builtin(__builtin_unreachable)
   #define BENCHMARK_UNREACHABLE() __builtin_unreachable()
 #elif defined(COMPILER_MSVC)

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1474,7 +1474,6 @@ inline const char* GetTimeUnitString(TimeUnit unit) {
     case kMicrosecond:
       return "us";
     case kNanosecond:
-    default:
       return "ns";
   }
 }
@@ -1486,7 +1485,6 @@ inline double GetTimeUnitMultiplier(TimeUnit unit) {
     case kMicrosecond:
       return 1e6;
     case kNanosecond:
-    default:
       return 1e9;
   }
 }

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1476,6 +1476,7 @@ inline const char* GetTimeUnitString(TimeUnit unit) {
     case kNanosecond:
       return "ns";
   }
+  return "ns";
 }
 
 inline double GetTimeUnitMultiplier(TimeUnit unit) {
@@ -1487,6 +1488,7 @@ inline double GetTimeUnitMultiplier(TimeUnit unit) {
     case kNanosecond:
       return 1e9;
   }
+  return 1e9;
 }
 
 }  // namespace benchmark

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -241,27 +241,13 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #define BENCHMARK_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #endif
 
-#if defined(__clang__)
-  #if !defined(COMPILER_CLANG)
-    #define COMPILER_CLANG
-  #endif
-#elif defined(_MSC_VER)
-  #if !defined(COMPILER_MSVC)
-    #define COMPILER_MSVC
-  #endif
-#elif defined(__GNUC__)
-  #if !defined(COMPILER_GCC)
-    #define COMPILER_GCC
-  #endif
-#endif
-
 #ifndef __has_builtin
 #define __has_builtin(x) 0
 #endif
 
-#if defined(COMPILER_GCC) || __has_builtin(__builtin_unreachable)
+#if defined(__GNUC__) || __has_builtin(__builtin_unreachable)
   #define BENCHMARK_UNREACHABLE() __builtin_unreachable()
-#elif defined(COMPILER_MSVC)
+#elif defined(_MSC_VER)
   #define BENCHMARK_UNREACHABLE() __assume(false)
 #else
   #define BENCHMARK_UNREACHABLE() ((void)0)

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -241,6 +241,14 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #define BENCHMARK_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #endif
 
+#if defined(COMPILER_GCC) || __has_builtin(__builtin_unreachable)
+  #define BENCHMARK_UNREACHABLE() __builtin_unreachable()
+#elif defined(COMPILER_MSVC)
+  #define BENCHMARK_UNREACHABLE() __assume(false)
+#else
+  #define BENCHMARK_UNREACHABLE() ((void)0)
+#endif
+
 namespace benchmark {
 class BenchmarkReporter;
 class MemoryManager;
@@ -1476,7 +1484,7 @@ inline const char* GetTimeUnitString(TimeUnit unit) {
     case kNanosecond:
       return "ns";
   }
-  __builtin_unreachable();
+  BENCHMARK_UNREACHABLE();
 }
 
 inline double GetTimeUnitMultiplier(TimeUnit unit) {
@@ -1488,7 +1496,7 @@ inline double GetTimeUnitMultiplier(TimeUnit unit) {
     case kNanosecond:
       return 1e9;
   }
-  __builtin_unreachable();
+  BENCHMARK_UNREACHABLE();
 }
 
 }  // namespace benchmark

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -241,6 +241,20 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #define BENCHMARK_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #endif
 
+#if defined(__clang__)
+  #if !defined(COMPILER_CLANG)
+    #define COMPILER_CLANG
+  #endif
+#elif defined(_MSC_VER)
+  #if !defined(COMPILER_MSVC)
+    #define COMPILER_MSVC
+  #endif
+#elif defined(__GNUC__)
+  #if !defined(COMPILER_GCC)
+    #define COMPILER_GCC
+  #endif
+#endif
+
 #ifndef __has_builtin
 #define __has_builtin(x) 0
 #endif

--- a/src/internal_macros.h
+++ b/src/internal_macros.h
@@ -12,20 +12,6 @@
 #define __has_feature(x) 0
 #endif
 
-#if defined(__clang__)
-  #if !defined(COMPILER_CLANG)
-    #define COMPILER_CLANG
-  #endif
-#elif defined(_MSC_VER)
-  #if !defined(COMPILER_MSVC)
-    #define COMPILER_MSVC
-  #endif
-#elif defined(__GNUC__)
-  #if !defined(COMPILER_GCC)
-    #define COMPILER_GCC
-  #endif
-#endif
-
 #if __has_feature(cxx_attributes)
   #define BENCHMARK_NORETURN [[noreturn]]
 #elif defined(__GNUC__)

--- a/src/internal_macros.h
+++ b/src/internal_macros.h
@@ -87,14 +87,6 @@
   #define BENCHMARK_MAYBE_UNUSED
 #endif
 
-#if defined(COMPILER_GCC) || __has_builtin(__builtin_unreachable)
-  #define BENCHMARK_UNREACHABLE() __builtin_unreachable()
-#elif defined(COMPILER_MSVC)
-  #define BENCHMARK_UNREACHABLE() __assume(false)
-#else
-  #define BENCHMARK_UNREACHABLE() ((void)0)
-#endif
-
 // clang-format on
 
 #endif  // BENCHMARK_INTERNAL_MACROS_H_

--- a/src/internal_macros.h
+++ b/src/internal_macros.h
@@ -12,6 +12,20 @@
 #define __has_feature(x) 0
 #endif
 
+#if defined(__clang__)
+  #if !defined(COMPILER_CLANG)
+    #define COMPILER_CLANG
+  #endif
+#elif defined(_MSC_VER)
+  #if !defined(COMPILER_MSVC)
+    #define COMPILER_MSVC
+  #endif
+#elif defined(__GNUC__)
+  #if !defined(COMPILER_GCC)
+    #define COMPILER_GCC
+  #endif
+#endif
+
 #if __has_feature(cxx_attributes)
   #define BENCHMARK_NORETURN [[noreturn]]
 #elif defined(__GNUC__)

--- a/src/internal_macros.h
+++ b/src/internal_macros.h
@@ -11,9 +11,6 @@
 #ifndef __has_feature
 #define __has_feature(x) 0
 #endif
-#ifndef __has_builtin
-#define __has_builtin(x) 0
-#endif
 
 #if defined(__clang__)
   #if !defined(COMPILER_CLANG)


### PR DESCRIPTION
I tried to embed Google Benchmark into the LLVM source tree and have encountered an error. Since the Benchmark CMakeLists contains the following lines:

```CMake
  add_cxx_compiler_flag(-Werror RELEASE)
  add_cxx_compiler_flag(-Werror RELWITHDEBINFO)
  add_cxx_compiler_flag(-Werror MINSIZEREL)
```

The compilation fails when all warnings by latest Clang are enabled because of the warnings "error: default label in switch which covers all enumeration values". This totally makes sense, because the `TimeUnit` only contains the cases which are already handled by the `switch` block:

```C++
enum TimeUnit { kNanosecond, kMicrosecond, kMillisecond };
```
Two functions which currently have this kind of behavior look like this:
```C++
inline const char* GetTimeUnitString(TimeUnit unit) {
  switch (unit) {
    case kMillisecond:
      return "ms";
    case kMicrosecond:
      return "us";
    case kNanosecond:
    default:
      return "ns";
  }
}
```

Unfortunately, the latest release (1.4.1) contains this code, I probably have to manually edit those in the LLVM tree.

Clang version which I used to compile the Benchmark Library: clang r335143.