### PR TITLE
Make tests pass on 1-core VMs

### DIFF
--- a/test/reporter_output_test.cc
+++ b/test/reporter_output_test.cc
@@ -17,7 +17,7 @@ static int AddContextCases() {
            {
                {"%int[-/]%int[-/]%int %int:%int:%int$", MR_Default},
                {"Running .*/reporter_output_test(\\.exe)?$", MR_Next},
-               {"Run on \\(%int X %float MHz CPU s\\)", MR_Next},
+               {"Run on \\(%int X %float MHz CPU s?\\)", MR_Next},
            });
   AddCases(TC_JSONOut,
            {{"^\\{", MR_Default},


### PR DESCRIPTION
found while working on reproducible builds for openSUSE

To reproduce there
osc checkout openSUSE:Factory/benchmark && cd $_
osc build -j1 --vm-type=kvm