### PR TITLE
Counter(): add 'one thousand' param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,8 +660,9 @@ the resulting sum is the value which will be shown for the benchmark.
 The `Counter` constructor accepts three parameters: the value as a `double`
 ; a bit flag which allows you to show counters as rates, and/or as per-thread
 iteration, and/or as per-thread averages, and/or iteration invariants;
-and a 'thousand' multiplier (`std::pair<int /*Num*/, int /*Denom*/> `) -
-i.e. what should be counted as 1k - 1000 (default) or 1024?
+and a flag specifying the 'unit' - i.e. is 1k a 1000 (default,
+`benchmark::Counter::One_K::kIs1000`), or 1024
+(`benchmark::Counter::One_K::kIs1024`)?
 
 ```c++
   // sets a simple counter
@@ -679,7 +680,7 @@ i.e. what should be counted as 1k - 1000 (default) or 1024?
   state.counters["FooAvgRate"] = Counter(numFoos,benchmark::Counter::kAvgThreadsRate);
 
   // This says that we process with the rate of state.range(0) bytes every iteration:
-  state.counters["BytesProcessed"] = Counter(state.range(0), benchmark::Counter::kIsIterationInvariantRate, {1024, 1});
+  state.counters["BytesProcessed"] = Counter(state.range(0), benchmark::Counter::kIsIterationInvariantRate, benchmark::Counter::One_K::kIs1024);
 ```
 
 When you're compiling in C++11 mode or later you can use `insert()` with

--- a/README.md
+++ b/README.md
@@ -661,8 +661,8 @@ The `Counter` constructor accepts three parameters: the value as a `double`
 ; a bit flag which allows you to show counters as rates, and/or as per-thread
 iteration, and/or as per-thread averages, and/or iteration invariants;
 and a flag specifying the 'unit' - i.e. is 1k a 1000 (default,
-`benchmark::Counter::One_K::kIs1000`), or 1024
-(`benchmark::Counter::One_K::kIs1024`)?
+`benchmark::Counter::OneK::kIs1000`), or 1024
+(`benchmark::Counter::OneK::kIs1024`)?
 
 ```c++
   // sets a simple counter
@@ -680,7 +680,7 @@ and a flag specifying the 'unit' - i.e. is 1k a 1000 (default,
   state.counters["FooAvgRate"] = Counter(numFoos,benchmark::Counter::kAvgThreadsRate);
 
   // This says that we process with the rate of state.range(0) bytes every iteration:
-  state.counters["BytesProcessed"] = Counter(state.range(0), benchmark::Counter::kIsIterationInvariantRate, benchmark::Counter::One_K::kIs1024);
+  state.counters["BytesProcessed"] = Counter(state.range(0), benchmark::Counter::kIsIterationInvariantRate, benchmark::Counter::OneK::kIs1024);
 ```
 
 When you're compiling in C++11 mode or later you can use `insert()` with

--- a/README.md
+++ b/README.md
@@ -657,9 +657,10 @@ In multithreaded benchmarks, each counter is set on the calling thread only.
 When the benchmark finishes, the counters from each thread will be summed;
 the resulting sum is the value which will be shown for the benchmark.
 
-The `Counter` constructor accepts two parameters: the value as a `double`
-and a bit flag which allows you to show counters as rates and/or as
-per-thread averages:
+The `Counter` constructor accepts three parameters: the value as a `double`
+; a bit flag which allows you to show counters as rates, and/or as per-thread
+iteration, and/or as per-thread averages, and/or iteration invariants;
+and a 'thousand' multiplier - i.e. what should be counted as 1k - 1000 (default) or 1024?
 
 ```c++
   // sets a simple counter
@@ -675,6 +676,9 @@ per-thread averages:
 
   // There's also a combined flag:
   state.counters["FooAvgRate"] = Counter(numFoos,benchmark::Counter::kAvgThreadsRate);
+
+  // This says that we process with the rate of state.range(0) bytes every iteration:
+  state.counters["BytesProcessed"] = Counter(state.range(0), benchmark::Counter::kIsIterationInvariantRate, 1024);
 ```
 
 When you're compiling in C++11 mode or later you can use `insert()` with

--- a/README.md
+++ b/README.md
@@ -660,7 +660,8 @@ the resulting sum is the value which will be shown for the benchmark.
 The `Counter` constructor accepts three parameters: the value as a `double`
 ; a bit flag which allows you to show counters as rates, and/or as per-thread
 iteration, and/or as per-thread averages, and/or iteration invariants;
-and a 'thousand' multiplier - i.e. what should be counted as 1k - 1000 (default) or 1024?
+and a 'thousand' multiplier (`std::pair<int /*Num*/, int /*Denom*/> `) -
+i.e. what should be counted as 1k - 1000 (default) or 1024?
 
 ```c++
   // sets a simple counter
@@ -678,7 +679,7 @@ and a 'thousand' multiplier - i.e. what should be counted as 1k - 1000 (default)
   state.counters["FooAvgRate"] = Counter(numFoos,benchmark::Counter::kAvgThreadsRate);
 
   // This says that we process with the rate of state.range(0) bytes every iteration:
-  state.counters["BytesProcessed"] = Counter(state.range(0), benchmark::Counter::kIsIterationInvariantRate, 1024);
+  state.counters["BytesProcessed"] = Counter(state.range(0), benchmark::Counter::kIsIterationInvariantRate, {1024, 1});
 ```
 
 When you're compiling in C++11 mode or later you can use `insert()` with

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -373,7 +373,7 @@ class Counter {
     kAvgIterationsRate = kIsRate | kAvgIterations
   };
 
-  enum One_K {
+  enum OneK {
     // 1'000 items per 1k
     kIs1000 = 1000,
     // 1'024 items per 1k
@@ -382,10 +382,10 @@ class Counter {
 
   double value;
   Flags flags;
-  One_K oneK;
+  OneK oneK;
 
   BENCHMARK_ALWAYS_INLINE
-  Counter(double v = 0., Flags f = kDefaults, One_K k = kIs1000)
+  Counter(double v = 0., Flags f = kDefaults, OneK k = kIs1000)
       : value(v), flags(f), oneK(k) {}
 
   BENCHMARK_ALWAYS_INLINE operator double const&() const { return value; }

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -375,10 +375,11 @@ class Counter {
 
   double value;
   Flags flags;
-  int thousand;
+  std::pair<int /*Num*/, int /*Denom*/> thousand;
 
   BENCHMARK_ALWAYS_INLINE
-  Counter(double v = 0., Flags f = kDefaults, int t = 1000)
+  Counter(double v = 0., Flags f = kDefaults,
+          std::pair<int /*Num*/, int /*Denom*/> t = std::make_pair(1000, 1))
       : value(v), flags(f), thousand(t) {}
 
   BENCHMARK_ALWAYS_INLINE operator double const&() const { return value; }

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -375,9 +375,11 @@ class Counter {
 
   double value;
   Flags flags;
+  int thousand;
 
   BENCHMARK_ALWAYS_INLINE
-  Counter(double v = 0., Flags f = kDefaults) : value(v), flags(f) {}
+  Counter(double v = 0., Flags f = kDefaults, int t = 1000)
+      : value(v), flags(f), thousand(t) {}
 
   BENCHMARK_ALWAYS_INLINE operator double const&() const { return value; }
   BENCHMARK_ALWAYS_INLINE operator double&() { return value; }

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -373,14 +373,20 @@ class Counter {
     kAvgIterationsRate = kIsRate | kAvgIterations
   };
 
+  enum One_K {
+    // 1'000 items per 1k
+    kIs1000,
+    // 1'024 items per 1k
+    kIs1024
+  };
+
   double value;
   Flags flags;
-  std::pair<int /*Num*/, int /*Denom*/> thousand;
+  One_K oneK;
 
   BENCHMARK_ALWAYS_INLINE
-  Counter(double v = 0., Flags f = kDefaults,
-          std::pair<int /*Num*/, int /*Denom*/> t = std::make_pair(1000, 1))
-      : value(v), flags(f), thousand(t) {}
+  Counter(double v = 0., Flags f = kDefaults, One_K k = kIs1000)
+      : value(v), flags(f), oneK(k) {}
 
   BENCHMARK_ALWAYS_INLINE operator double const&() const { return value; }
   BENCHMARK_ALWAYS_INLINE operator double&() { return value; }

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -375,9 +375,9 @@ class Counter {
 
   enum One_K {
     // 1'000 items per 1k
-    kIs1000,
+    kIs1000 = 1000,
     // 1'024 items per 1k
-    kIs1024
+    kIs1024 = 1024
   };
 
   double value;

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -150,7 +150,9 @@ void ConsoleReporter::PrintRunData(const Run& result) {
   for (auto& c : result.counters) {
     const std::size_t cNameLen = std::max(std::string::size_type(10),
                                           c.first.length());
-    auto const& s = HumanReadableNumber(c.second.value, c.second.thousand);
+    const double one_k =
+        double(c.second.thousand.first) / double(c.second.thousand.second);
+    auto const& s = HumanReadableNumber(c.second.value, one_k);
     if (output_options_ & OO_Tabular) {
       if (c.second.flags & Counter::kIsRate) {
         printer(Out, COLOR_DEFAULT, " %*s/s", cNameLen - 2, s.c_str());

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -150,7 +150,7 @@ void ConsoleReporter::PrintRunData(const Run& result) {
   for (auto& c : result.counters) {
     const std::size_t cNameLen = std::max(std::string::size_type(10),
                                           c.first.length());
-    auto const& s = HumanReadableNumber(c.second.value, 1000);
+    auto const& s = HumanReadableNumber(c.second.value, c.second.thousand);
     if (output_options_ & OO_Tabular) {
       if (c.second.flags & Counter::kIsRate) {
         printer(Out, COLOR_DEFAULT, " %*s/s", cNameLen - 2, s.c_str());

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -150,8 +150,15 @@ void ConsoleReporter::PrintRunData(const Run& result) {
   for (auto& c : result.counters) {
     const std::size_t cNameLen = std::max(std::string::size_type(10),
                                           c.first.length());
-    const double one_k =
-        double(c.second.thousand.first) / double(c.second.thousand.second);
+    const double one_k = [](benchmark::Counter::One_K k) -> double {
+      switch (k) {
+        case benchmark::Counter::One_K::kIs1000:
+          return 1000.0;
+        case benchmark::Counter::One_K::kIs1024:
+          return 1024.0;
+      }
+      BENCHMARK_UNREACHABLE();
+    }(c.second.oneK);
     auto const& s = HumanReadableNumber(c.second.value, one_k);
     if (output_options_ & OO_Tabular) {
       if (c.second.flags & Counter::kIsRate) {

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -150,16 +150,7 @@ void ConsoleReporter::PrintRunData(const Run& result) {
   for (auto& c : result.counters) {
     const std::size_t cNameLen = std::max(std::string::size_type(10),
                                           c.first.length());
-    const double one_k = [](benchmark::Counter::One_K k) -> double {
-      switch (k) {
-        case benchmark::Counter::One_K::kIs1000:
-          return 1000.0;
-        case benchmark::Counter::One_K::kIs1024:
-          return 1024.0;
-      }
-      BENCHMARK_UNREACHABLE();
-    }(c.second.oneK);
-    auto const& s = HumanReadableNumber(c.second.value, one_k);
+    auto const& s = HumanReadableNumber(c.second.value, c.second.oneK);
     if (output_options_ & OO_Tabular) {
       if (c.second.flags & Counter::kIsRate) {
         printer(Out, COLOR_DEFAULT, " %*s/s", cNameLen - 2, s.c_str());

--- a/src/statistics.cc
+++ b/src/statistics.cc
@@ -165,7 +165,8 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
     // user counters
     for (auto const& kv : counter_stats) {
       const auto uc_stat = Stat.compute_(kv.second.s);
-      auto c = Counter(uc_stat, counter_stats[kv.first].c.flags);
+      auto c = Counter(uc_stat, counter_stats[kv.first].c.flags,
+                       counter_stats[kv.first].c.thousand);
       data.counters[kv.first] = c;
     }
 

--- a/src/statistics.cc
+++ b/src/statistics.cc
@@ -166,7 +166,7 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
     for (auto const& kv : counter_stats) {
       const auto uc_stat = Stat.compute_(kv.second.s);
       auto c = Counter(uc_stat, counter_stats[kv.first].c.flags,
-                       counter_stats[kv.first].c.thousand);
+                       counter_stats[kv.first].c.oneK);
       data.counters[kv.first] = c;
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -128,6 +128,9 @@ add_test(user_counters_test user_counters_test --benchmark_min_time=0.01)
 compile_output_test(user_counters_tabular_test)
 add_test(user_counters_tabular_test user_counters_tabular_test --benchmark_counters_tabular=true --benchmark_min_time=0.01)
 
+compile_output_test(user_counters_thousands_test)
+add_test(user_counters_thousands_test user_counters_thousands_test --benchmark_min_time=0.01)
+
 check_cxx_compiler_flag(-std=c++03 BENCHMARK_HAS_CXX03_FLAG)
 if (BENCHMARK_HAS_CXX03_FLAG)
   compile_benchmark_test(cxx03_test)

--- a/test/user_counters_thousands_test.cc
+++ b/test/user_counters_thousands_test.cc
@@ -16,13 +16,16 @@ void BM_Counters_Thousands(benchmark::State& state) {
       {{"t0_1000000DefaultBase",
         bm::Counter(1000 * 1000, bm::Counter::kDefaults)},
        {"t1_1000000Base1000",
-        bm::Counter(1000 * 1000, bm::Counter::kDefaults, 1000)},
+        bm::Counter(1000 * 1000, bm::Counter::kDefaults, {1000, 1})},
        {"t2_1000000Base1024",
-        bm::Counter(1000 * 1000, bm::Counter::kDefaults, 1024)},
+        bm::Counter(1000 * 1000, bm::Counter::kDefaults, {1024, 1})},
        {"t3_1048576Base1000",
-        bm::Counter(1024 * 1024, bm::Counter::kDefaults, 1000)},
+        bm::Counter(1024 * 1024, bm::Counter::kDefaults, {1000, 1})},
        {"t4_1048576Base1024",
-        bm::Counter(1024 * 1024, bm::Counter::kDefaults, 1024)}});
+        bm::Counter(1024 * 1024, bm::Counter::kDefaults, {1024, 1})},
+       {"t5_1000000Base1000by1024over1024",
+        bm::Counter(1000 * 1000, bm::Counter::kDefaults,
+                    {1024 * 1000, 1024})}});
 }
 BENCHMARK(BM_Counters_Thousands)->Repetitions(2);
 ADD_CASES(
@@ -31,22 +34,25 @@ ADD_CASES(
         {"^BM_Counters_Thousands/repeats:2 %console_report "
          "t0_1000000DefaultBase=1000k "
          "t1_1000000Base1000=1000k t2_1000000Base1024=976.56[23]k "
-         "t3_1048576Base1000=1048.58k t4_1048576Base1024=1024k$"},
+         "t3_1048576Base1000=1048.58k t4_1048576Base1024=1024k "
+         "t5_1000000Base1000by1024over1024=1000k$"},
         {"^BM_Counters_Thousands/repeats:2 %console_report "
          "t0_1000000DefaultBase=1000k "
          "t1_1000000Base1000=1000k t2_1000000Base1024=976.56[23]k "
-         "t3_1048576Base1000=1048.58k t4_1048576Base1024=1024k$"},
+         "t3_1048576Base1000=1048.58k t4_1048576Base1024=1024k "
+         "t5_1000000Base1000by1024over1024=1000k$"},
         {"^BM_Counters_Thousands/repeats:2_mean %console_report "
          "t0_1000000DefaultBase=1000k t1_1000000Base1000=1000k "
          "t2_1000000Base1024=976.56[23]k t3_1048576Base1000=1048.58k "
-         "t4_1048576Base1024=1024k$"},
+         "t4_1048576Base1024=1024k t5_1000000Base1000by1024over1024=1000k$"},
         {"^BM_Counters_Thousands/repeats:2_median %console_report "
          "t0_1000000DefaultBase=1000k t1_1000000Base1000=1000k "
          "t2_1000000Base1024=976.56[23]k t3_1048576Base1000=1048.58k "
-         "t4_1048576Base1024=1024k$"},
+         "t4_1048576Base1024=1024k t5_1000000Base1000by1024over1024=1000k$"},
         {"^BM_Counters_Thousands/repeats:2_stddev %console_report "
          "t0_1000000DefaultBase=0 t1_1000000Base1000=0 t2_1000000Base1024=0 "
-         "t3_1048576Base1000=0 t4_1048576Base1024=0$"},
+         "t3_1048576Base1000=0 t4_1048576Base1024=0 "
+         "t5_1000000Base1000by1024over1024=0$"},
     });
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_Counters_Thousands/repeats:2\",$"},
@@ -59,7 +65,9 @@ ADD_CASES(TC_JSONOut,
            {"\"t1_1000000Base1000\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t2_1000000Base1024\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t3_1048576Base1000\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
-           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6$", MR_Next},
+           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t5_1000000Base1000by1024over1024\": 1\\.(0)*e\\+(0)*6$",
+            MR_Next},
            {"}", MR_Next}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_Counters_Thousands/repeats:2\",$"},
@@ -72,7 +80,9 @@ ADD_CASES(TC_JSONOut,
            {"\"t1_1000000Base1000\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t2_1000000Base1024\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t3_1048576Base1000\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
-           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6$", MR_Next},
+           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t5_1000000Base1000by1024over1024\": 1\\.(0)*e\\+(0)*6$",
+            MR_Next},
            {"}", MR_Next}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_Counters_Thousands/repeats:2_mean\",$"},
@@ -85,7 +95,9 @@ ADD_CASES(TC_JSONOut,
            {"\"t1_1000000Base1000\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t2_1000000Base1024\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t3_1048576Base1000\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
-           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6$", MR_Next},
+           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t5_1000000Base1000by1024over1024\": 1\\.(0)*e\\+(0)*6$",
+            MR_Next},
            {"}", MR_Next}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_Counters_Thousands/repeats:2_median\",$"},
@@ -98,7 +110,9 @@ ADD_CASES(TC_JSONOut,
            {"\"t1_1000000Base1000\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t2_1000000Base1024\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t3_1048576Base1000\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
-           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6$", MR_Next},
+           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t5_1000000Base1000by1024over1024\": 1\\.(0)*e\\+(0)*6$",
+            MR_Next},
            {"}", MR_Next}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_Counters_Thousands/repeats:2_stddev\",$"},
@@ -111,24 +125,25 @@ ADD_CASES(TC_JSONOut,
            {"\"t1_1000000Base1000\": 0\\.(0)*e\\+(0)*,$", MR_Next},
            {"\"t2_1000000Base1024\": 0\\.(0)*e\\+(0)*,$", MR_Next},
            {"\"t3_1048576Base1000\": 0\\.(0)*e\\+(0)*,$", MR_Next},
-           {"\"t4_1048576Base1024\": 0\\.(0)*e\\+(0)*$", MR_Next},
+           {"\"t4_1048576Base1024\": 0\\.(0)*e\\+(0)*,$", MR_Next},
+           {"\"t5_1000000Base1000by1024over1024\": 0\\.(0)*e\\+(0)*$", MR_Next},
            {"}", MR_Next}});
 
 ADD_CASES(
     TC_CSVOut,
     {{"^\"BM_Counters_Thousands/"
       "repeats:2\",%csv_report,1e\\+(0)*6,1e\\+(0)*6,1e\\+(0)*6,1\\.04858e\\+("
-      "0)*6,1\\.04858e\\+(0)*6$"},
+      "0)*6,1\\.04858e\\+(0)*6,1e\\+(0)*6$"},
      {"^\"BM_Counters_Thousands/"
       "repeats:2\",%csv_report,1e\\+(0)*6,1e\\+(0)*6,1e\\+(0)*6,1\\.04858e\\+("
-      "0)*6,1\\.04858e\\+(0)*6$"},
+      "0)*6,1\\.04858e\\+(0)*6,1e\\+(0)*6$"},
      {"^\"BM_Counters_Thousands/"
       "repeats:2_mean\",%csv_report,1e\\+(0)*6,1e\\+(0)*6,1e\\+(0)*6,1\\."
-      "04858e\\+(0)*6,1\\.04858e\\+(0)*6$"},
+      "04858e\\+(0)*6,1\\.04858e\\+(0)*6,1e\\+(0)*6$"},
      {"^\"BM_Counters_Thousands/"
       "repeats:2_median\",%csv_report,1e\\+(0)*6,1e\\+(0)*6,1e\\+(0)*6,1\\."
-      "04858e\\+(0)*6,1\\.04858e\\+(0)*6$"},
-     {"^\"BM_Counters_Thousands/repeats:2_stddev\",%csv_report,0,0,0,0,0$"}});
+      "04858e\\+(0)*6,1\\.04858e\\+(0)*6,1e\\+(0)*6$"},
+     {"^\"BM_Counters_Thousands/repeats:2_stddev\",%csv_report,0,0,0,0,0,0$"}});
 // VS2013 does not allow this function to be passed as a lambda argument
 // to CHECK_BENCHMARK_RESULTS()
 void CheckThousands(Results const& e) {
@@ -142,6 +157,8 @@ void CheckThousands(Results const& e) {
   CHECK_FLOAT_COUNTER_VALUE(e, "t2_1000000Base1024", EQ, 1000 * 1000, 0.0001);
   CHECK_FLOAT_COUNTER_VALUE(e, "t3_1048576Base1000", EQ, 1024 * 1024, 0.0001);
   CHECK_FLOAT_COUNTER_VALUE(e, "t4_1048576Base1024", EQ, 1024 * 1024, 0.0001);
+  CHECK_FLOAT_COUNTER_VALUE(e, "t5_1000000Base1000by1024over1024", EQ,
+                            1000 * 1000, 0.0001);
 }
 CHECK_BENCHMARK_RESULTS("BM_Counters_Thousands", &CheckThousands);
 

--- a/test/user_counters_thousands_test.cc
+++ b/test/user_counters_thousands_test.cc
@@ -16,13 +16,13 @@ void BM_Counters_Thousands(benchmark::State& state) {
       {"t0_1000000DefaultBase",
        bm::Counter(1000 * 1000, bm::Counter::kDefaults)},
       {"t1_1000000Base1000", bm::Counter(1000 * 1000, bm::Counter::kDefaults,
-                                         benchmark::Counter::One_K::kIs1000)},
+                                         benchmark::Counter::OneK::kIs1000)},
       {"t2_1000000Base1024", bm::Counter(1000 * 1000, bm::Counter::kDefaults,
-                                         benchmark::Counter::One_K::kIs1024)},
+                                         benchmark::Counter::OneK::kIs1024)},
       {"t3_1048576Base1000", bm::Counter(1024 * 1024, bm::Counter::kDefaults,
-                                         benchmark::Counter::One_K::kIs1000)},
+                                         benchmark::Counter::OneK::kIs1000)},
       {"t4_1048576Base1024", bm::Counter(1024 * 1024, bm::Counter::kDefaults,
-                                         benchmark::Counter::One_K::kIs1024)},
+                                         benchmark::Counter::OneK::kIs1024)},
   });
 }
 BENCHMARK(BM_Counters_Thousands)->Repetitions(2);

--- a/test/user_counters_thousands_test.cc
+++ b/test/user_counters_thousands_test.cc
@@ -1,0 +1,152 @@
+
+#undef NDEBUG
+
+#include "benchmark/benchmark.h"
+#include "output_test.h"
+
+// ========================================================================= //
+// ------------------------ Thousands Customisation ------------------------ //
+// ========================================================================= //
+
+void BM_Counters_Thousands(benchmark::State& state) {
+  for (auto _ : state) {
+  }
+  namespace bm = benchmark;
+  state.counters.insert(
+      {{"t0_1000000DefaultBase",
+        bm::Counter(1000 * 1000, bm::Counter::kDefaults)},
+       {"t1_1000000Base1000",
+        bm::Counter(1000 * 1000, bm::Counter::kDefaults, 1000)},
+       {"t2_1000000Base1024",
+        bm::Counter(1000 * 1000, bm::Counter::kDefaults, 1024)},
+       {"t3_1048576Base1000",
+        bm::Counter(1024 * 1024, bm::Counter::kDefaults, 1000)},
+       {"t4_1048576Base1024",
+        bm::Counter(1024 * 1024, bm::Counter::kDefaults, 1024)}});
+}
+BENCHMARK(BM_Counters_Thousands)->Repetitions(2);
+ADD_CASES(
+    TC_ConsoleOut,
+    {
+        {"^BM_Counters_Thousands/repeats:2 %console_report "
+         "t0_1000000DefaultBase=1000k "
+         "t1_1000000Base1000=1000k t2_1000000Base1024=976.56[23]k "
+         "t3_1048576Base1000=1048.58k t4_1048576Base1024=1024k$"},
+        {"^BM_Counters_Thousands/repeats:2 %console_report "
+         "t0_1000000DefaultBase=1000k "
+         "t1_1000000Base1000=1000k t2_1000000Base1024=976.56[23]k "
+         "t3_1048576Base1000=1048.58k t4_1048576Base1024=1024k$"},
+        {"^BM_Counters_Thousands/repeats:2_mean %console_report "
+         "t0_1000000DefaultBase=1000k t1_1000000Base1000=1000k "
+         "t2_1000000Base1024=976.56[23]k t3_1048576Base1000=1048.58k "
+         "t4_1048576Base1024=1024k$"},
+        {"^BM_Counters_Thousands/repeats:2_median %console_report "
+         "t0_1000000DefaultBase=1000k t1_1000000Base1000=1000k "
+         "t2_1000000Base1024=976.56[23]k t3_1048576Base1000=1048.58k "
+         "t4_1048576Base1024=1024k$"},
+        {"^BM_Counters_Thousands/repeats:2_stddev %console_report "
+         "t0_1000000DefaultBase=0 t1_1000000Base1000=0 t2_1000000Base1024=0 "
+         "t3_1048576Base1000=0 t4_1048576Base1024=0$"},
+    });
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_Counters_Thousands/repeats:2\",$"},
+           {"\"run_type\": \"iteration\",$", MR_Next},
+           {"\"iterations\": %int,$", MR_Next},
+           {"\"real_time\": %float,$", MR_Next},
+           {"\"cpu_time\": %float,$", MR_Next},
+           {"\"time_unit\": \"ns\",$", MR_Next},
+           {"\"t0_1000000DefaultBase\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t1_1000000Base1000\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t2_1000000Base1024\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t3_1048576Base1000\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6$", MR_Next},
+           {"}", MR_Next}});
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_Counters_Thousands/repeats:2\",$"},
+           {"\"run_type\": \"iteration\",$", MR_Next},
+           {"\"iterations\": %int,$", MR_Next},
+           {"\"real_time\": %float,$", MR_Next},
+           {"\"cpu_time\": %float,$", MR_Next},
+           {"\"time_unit\": \"ns\",$", MR_Next},
+           {"\"t0_1000000DefaultBase\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t1_1000000Base1000\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t2_1000000Base1024\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t3_1048576Base1000\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6$", MR_Next},
+           {"}", MR_Next}});
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_Counters_Thousands/repeats:2_mean\",$"},
+           {"\"run_type\": \"aggregate\",$", MR_Next},
+           {"\"iterations\": %int,$", MR_Next},
+           {"\"real_time\": %float,$", MR_Next},
+           {"\"cpu_time\": %float,$", MR_Next},
+           {"\"time_unit\": \"ns\",$", MR_Next},
+           {"\"t0_1000000DefaultBase\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t1_1000000Base1000\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t2_1000000Base1024\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t3_1048576Base1000\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6$", MR_Next},
+           {"}", MR_Next}});
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_Counters_Thousands/repeats:2_median\",$"},
+           {"\"run_type\": \"aggregate\",$", MR_Next},
+           {"\"iterations\": %int,$", MR_Next},
+           {"\"real_time\": %float,$", MR_Next},
+           {"\"cpu_time\": %float,$", MR_Next},
+           {"\"time_unit\": \"ns\",$", MR_Next},
+           {"\"t0_1000000DefaultBase\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t1_1000000Base1000\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t2_1000000Base1024\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t3_1048576Base1000\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
+           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6$", MR_Next},
+           {"}", MR_Next}});
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_Counters_Thousands/repeats:2_stddev\",$"},
+           {"\"run_type\": \"aggregate\",$", MR_Next},
+           {"\"iterations\": %int,$", MR_Next},
+           {"\"real_time\": %float,$", MR_Next},
+           {"\"cpu_time\": %float,$", MR_Next},
+           {"\"time_unit\": \"ns\",$", MR_Next},
+           {"\"t0_1000000DefaultBase\": 0\\.(0)*e\\+(0)*,$", MR_Next},
+           {"\"t1_1000000Base1000\": 0\\.(0)*e\\+(0)*,$", MR_Next},
+           {"\"t2_1000000Base1024\": 0\\.(0)*e\\+(0)*,$", MR_Next},
+           {"\"t3_1048576Base1000\": 0\\.(0)*e\\+(0)*,$", MR_Next},
+           {"\"t4_1048576Base1024\": 0\\.(0)*e\\+(0)*$", MR_Next},
+           {"}", MR_Next}});
+
+ADD_CASES(
+    TC_CSVOut,
+    {{"^\"BM_Counters_Thousands/"
+      "repeats:2\",%csv_report,1e\\+(0)*6,1e\\+(0)*6,1e\\+(0)*6,1\\.04858e\\+("
+      "0)*6,1\\.04858e\\+(0)*6$"},
+     {"^\"BM_Counters_Thousands/"
+      "repeats:2\",%csv_report,1e\\+(0)*6,1e\\+(0)*6,1e\\+(0)*6,1\\.04858e\\+("
+      "0)*6,1\\.04858e\\+(0)*6$"},
+     {"^\"BM_Counters_Thousands/"
+      "repeats:2_mean\",%csv_report,1e\\+(0)*6,1e\\+(0)*6,1e\\+(0)*6,1\\."
+      "04858e\\+(0)*6,1\\.04858e\\+(0)*6$"},
+     {"^\"BM_Counters_Thousands/"
+      "repeats:2_median\",%csv_report,1e\\+(0)*6,1e\\+(0)*6,1e\\+(0)*6,1\\."
+      "04858e\\+(0)*6,1\\.04858e\\+(0)*6$"},
+     {"^\"BM_Counters_Thousands/repeats:2_stddev\",%csv_report,0,0,0,0,0$"}});
+// VS2013 does not allow this function to be passed as a lambda argument
+// to CHECK_BENCHMARK_RESULTS()
+void CheckThousands(Results const& e) {
+  if (e.name != "BM_Counters_Thousands/repeats:2")
+    return;  // Do not check the aggregates!
+
+  // check that the values are within 0.01% of the expected values
+  CHECK_FLOAT_COUNTER_VALUE(e, "t0_1000000DefaultBase", EQ, 1000 * 1000,
+                            0.0001);
+  CHECK_FLOAT_COUNTER_VALUE(e, "t1_1000000Base1000", EQ, 1000 * 1000, 0.0001);
+  CHECK_FLOAT_COUNTER_VALUE(e, "t2_1000000Base1024", EQ, 1000 * 1000, 0.0001);
+  CHECK_FLOAT_COUNTER_VALUE(e, "t3_1048576Base1000", EQ, 1024 * 1024, 0.0001);
+  CHECK_FLOAT_COUNTER_VALUE(e, "t4_1048576Base1024", EQ, 1024 * 1024, 0.0001);
+}
+CHECK_BENCHMARK_RESULTS("BM_Counters_Thousands", &CheckThousands);
+
+// ========================================================================= //
+// --------------------------- TEST CASES END ------------------------------ //
+// ========================================================================= //
+
+int main(int argc, char* argv[]) { RunOutputTests(argc, argv); }

--- a/test/user_counters_thousands_test.cc
+++ b/test/user_counters_thousands_test.cc
@@ -12,20 +12,18 @@ void BM_Counters_Thousands(benchmark::State& state) {
   for (auto _ : state) {
   }
   namespace bm = benchmark;
-  state.counters.insert(
-      {{"t0_1000000DefaultBase",
-        bm::Counter(1000 * 1000, bm::Counter::kDefaults)},
-       {"t1_1000000Base1000",
-        bm::Counter(1000 * 1000, bm::Counter::kDefaults, {1000, 1})},
-       {"t2_1000000Base1024",
-        bm::Counter(1000 * 1000, bm::Counter::kDefaults, {1024, 1})},
-       {"t3_1048576Base1000",
-        bm::Counter(1024 * 1024, bm::Counter::kDefaults, {1000, 1})},
-       {"t4_1048576Base1024",
-        bm::Counter(1024 * 1024, bm::Counter::kDefaults, {1024, 1})},
-       {"t5_1000000Base1000by1024over1024",
-        bm::Counter(1000 * 1000, bm::Counter::kDefaults,
-                    {1024 * 1000, 1024})}});
+  state.counters.insert({
+      {"t0_1000000DefaultBase",
+       bm::Counter(1000 * 1000, bm::Counter::kDefaults)},
+      {"t1_1000000Base1000", bm::Counter(1000 * 1000, bm::Counter::kDefaults,
+                                         benchmark::Counter::One_K::kIs1000)},
+      {"t2_1000000Base1024", bm::Counter(1000 * 1000, bm::Counter::kDefaults,
+                                         benchmark::Counter::One_K::kIs1024)},
+      {"t3_1048576Base1000", bm::Counter(1024 * 1024, bm::Counter::kDefaults,
+                                         benchmark::Counter::One_K::kIs1000)},
+      {"t4_1048576Base1024", bm::Counter(1024 * 1024, bm::Counter::kDefaults,
+                                         benchmark::Counter::One_K::kIs1024)},
+  });
 }
 BENCHMARK(BM_Counters_Thousands)->Repetitions(2);
 ADD_CASES(
@@ -34,25 +32,22 @@ ADD_CASES(
         {"^BM_Counters_Thousands/repeats:2 %console_report "
          "t0_1000000DefaultBase=1000k "
          "t1_1000000Base1000=1000k t2_1000000Base1024=976.56[23]k "
-         "t3_1048576Base1000=1048.58k t4_1048576Base1024=1024k "
-         "t5_1000000Base1000by1024over1024=1000k$"},
+         "t3_1048576Base1000=1048.58k t4_1048576Base1024=1024k$"},
         {"^BM_Counters_Thousands/repeats:2 %console_report "
          "t0_1000000DefaultBase=1000k "
          "t1_1000000Base1000=1000k t2_1000000Base1024=976.56[23]k "
-         "t3_1048576Base1000=1048.58k t4_1048576Base1024=1024k "
-         "t5_1000000Base1000by1024over1024=1000k$"},
+         "t3_1048576Base1000=1048.58k t4_1048576Base1024=1024k$"},
         {"^BM_Counters_Thousands/repeats:2_mean %console_report "
          "t0_1000000DefaultBase=1000k t1_1000000Base1000=1000k "
          "t2_1000000Base1024=976.56[23]k t3_1048576Base1000=1048.58k "
-         "t4_1048576Base1024=1024k t5_1000000Base1000by1024over1024=1000k$"},
+         "t4_1048576Base1024=1024k$"},
         {"^BM_Counters_Thousands/repeats:2_median %console_report "
          "t0_1000000DefaultBase=1000k t1_1000000Base1000=1000k "
          "t2_1000000Base1024=976.56[23]k t3_1048576Base1000=1048.58k "
-         "t4_1048576Base1024=1024k t5_1000000Base1000by1024over1024=1000k$"},
+         "t4_1048576Base1024=1024k$"},
         {"^BM_Counters_Thousands/repeats:2_stddev %console_report "
          "t0_1000000DefaultBase=0 t1_1000000Base1000=0 t2_1000000Base1024=0 "
-         "t3_1048576Base1000=0 t4_1048576Base1024=0 "
-         "t5_1000000Base1000by1024over1024=0$"},
+         "t3_1048576Base1000=0 t4_1048576Base1024=0$"},
     });
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_Counters_Thousands/repeats:2\",$"},
@@ -65,9 +60,7 @@ ADD_CASES(TC_JSONOut,
            {"\"t1_1000000Base1000\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t2_1000000Base1024\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t3_1048576Base1000\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
-           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
-           {"\"t5_1000000Base1000by1024over1024\": 1\\.(0)*e\\+(0)*6$",
-            MR_Next},
+           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6$", MR_Next},
            {"}", MR_Next}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_Counters_Thousands/repeats:2\",$"},
@@ -80,9 +73,7 @@ ADD_CASES(TC_JSONOut,
            {"\"t1_1000000Base1000\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t2_1000000Base1024\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t3_1048576Base1000\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
-           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
-           {"\"t5_1000000Base1000by1024over1024\": 1\\.(0)*e\\+(0)*6$",
-            MR_Next},
+           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6$", MR_Next},
            {"}", MR_Next}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_Counters_Thousands/repeats:2_mean\",$"},
@@ -95,9 +86,7 @@ ADD_CASES(TC_JSONOut,
            {"\"t1_1000000Base1000\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t2_1000000Base1024\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t3_1048576Base1000\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
-           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
-           {"\"t5_1000000Base1000by1024over1024\": 1\\.(0)*e\\+(0)*6$",
-            MR_Next},
+           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6$", MR_Next},
            {"}", MR_Next}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_Counters_Thousands/repeats:2_median\",$"},
@@ -110,9 +99,7 @@ ADD_CASES(TC_JSONOut,
            {"\"t1_1000000Base1000\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t2_1000000Base1024\": 1\\.(0)*e\\+(0)*6,$", MR_Next},
            {"\"t3_1048576Base1000\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
-           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6,$", MR_Next},
-           {"\"t5_1000000Base1000by1024over1024\": 1\\.(0)*e\\+(0)*6$",
-            MR_Next},
+           {"\"t4_1048576Base1024\": 1\\.048576(0)*e\\+(0)*6$", MR_Next},
            {"}", MR_Next}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_Counters_Thousands/repeats:2_stddev\",$"},
@@ -125,25 +112,24 @@ ADD_CASES(TC_JSONOut,
            {"\"t1_1000000Base1000\": 0\\.(0)*e\\+(0)*,$", MR_Next},
            {"\"t2_1000000Base1024\": 0\\.(0)*e\\+(0)*,$", MR_Next},
            {"\"t3_1048576Base1000\": 0\\.(0)*e\\+(0)*,$", MR_Next},
-           {"\"t4_1048576Base1024\": 0\\.(0)*e\\+(0)*,$", MR_Next},
-           {"\"t5_1000000Base1000by1024over1024\": 0\\.(0)*e\\+(0)*$", MR_Next},
+           {"\"t4_1048576Base1024\": 0\\.(0)*e\\+(0)*$", MR_Next},
            {"}", MR_Next}});
 
 ADD_CASES(
     TC_CSVOut,
     {{"^\"BM_Counters_Thousands/"
       "repeats:2\",%csv_report,1e\\+(0)*6,1e\\+(0)*6,1e\\+(0)*6,1\\.04858e\\+("
-      "0)*6,1\\.04858e\\+(0)*6,1e\\+(0)*6$"},
+      "0)*6,1\\.04858e\\+(0)*6$"},
      {"^\"BM_Counters_Thousands/"
       "repeats:2\",%csv_report,1e\\+(0)*6,1e\\+(0)*6,1e\\+(0)*6,1\\.04858e\\+("
-      "0)*6,1\\.04858e\\+(0)*6,1e\\+(0)*6$"},
+      "0)*6,1\\.04858e\\+(0)*6$"},
      {"^\"BM_Counters_Thousands/"
       "repeats:2_mean\",%csv_report,1e\\+(0)*6,1e\\+(0)*6,1e\\+(0)*6,1\\."
-      "04858e\\+(0)*6,1\\.04858e\\+(0)*6,1e\\+(0)*6$"},
+      "04858e\\+(0)*6,1\\.04858e\\+(0)*6$"},
      {"^\"BM_Counters_Thousands/"
       "repeats:2_median\",%csv_report,1e\\+(0)*6,1e\\+(0)*6,1e\\+(0)*6,1\\."
-      "04858e\\+(0)*6,1\\.04858e\\+(0)*6,1e\\+(0)*6$"},
-     {"^\"BM_Counters_Thousands/repeats:2_stddev\",%csv_report,0,0,0,0,0,0$"}});
+      "04858e\\+(0)*6,1\\.04858e\\+(0)*6$"},
+     {"^\"BM_Counters_Thousands/repeats:2_stddev\",%csv_report,0,0,0,0,0$"}});
 // VS2013 does not allow this function to be passed as a lambda argument
 // to CHECK_BENCHMARK_RESULTS()
 void CheckThousands(Results const& e) {
@@ -157,8 +143,6 @@ void CheckThousands(Results const& e) {
   CHECK_FLOAT_COUNTER_VALUE(e, "t2_1000000Base1024", EQ, 1000 * 1000, 0.0001);
   CHECK_FLOAT_COUNTER_VALUE(e, "t3_1048576Base1000", EQ, 1024 * 1024, 0.0001);
   CHECK_FLOAT_COUNTER_VALUE(e, "t4_1048576Base1024", EQ, 1024 * 1024, 0.0001);
-  CHECK_FLOAT_COUNTER_VALUE(e, "t5_1000000Base1000by1024over1024", EQ,
-                            1000 * 1000, 0.0001);
 }
 CHECK_BENCHMARK_RESULTS("BM_Counters_Thousands", &CheckThousands);
 


### PR DESCRIPTION
Needed for https://github.com/google/benchmark/pull/654

Custom user counters are quite custom. It is not guaranteed
that the user *always* expects for these to have 1k == 1000.
If the counter represents bytes/memory/etc, 1k should be 1024.

Some bikeshedding points:
1. Is this sufficient, or do we really want to go full on
   into custom types with names?
   I think just the '1000' is sufficient for now.
2. Should there be a helper benchmark::Counter::Counter{1000,1024}()
   static 'constructor' functions, since these two, by far,
   will be the most used?
3. In the future, we should be somehow encoding this info into JSON.