### PR TITLE
removed locked notify_all() call.

### DIFF
--- a/src/thread_manager.h
+++ b/src/thread_manager.h
@@ -22,10 +22,9 @@ class ThreadManager {
     return start_stop_barrier_.wait();
   }
 
-  void NotifyThreadComplete() EXCLUDES(end_cond_mutex_) {
+  void NotifyThreadComplete() {
     start_stop_barrier_.removeThread();
     if (--alive_threads_ == 0) {
-      MutexLock lock(end_cond_mutex_);
       end_condition_.notify_all();
     }
   }


### PR DESCRIPTION
I'm not an expert but as far as i know when conditional variable notify_all() function is called it's discouraged to lock the mutex at the same time.