### PR TITLE
Backport LLVM's r341717 "Fix flags used to compile benchmark library with clang-cl"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if (BENCHMARK_BUILD_32_BITS)
   add_required_cxx_compiler_flag(-m32)
 endif()
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+if (MSVC)
   # Turn compiler warnings up to 11
   string(REGEX REPLACE "[-/]W[1-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")


### PR DESCRIPTION
> `MSVC` is true for clang-cl, but `"${CMAKE_CXX_COMPILER_ID}" STREQUAL
> "MSVC"` is false, so we would enable -Wall, which means -Weverything
> with clang-cl, and we get tons of undesired warnings.
> 
> Use the simpler condition to fix things.

Patch by: Reid Kleckner @rnk
https://reviews.llvm.org/rL341717
https://github.com/llvm-mirror/llvm/commit/a8ea812648fd051aa6e847735ddab5f84a1ba5f8