### PR TITLE
Include sys/time.h for cycleclock.h when building on MinGW

### DIFF
--- a/src/cycleclock.h
+++ b/src/cycleclock.h
@@ -41,7 +41,7 @@ extern "C" uint64_t __rdtsc();
 #pragma intrinsic(__rdtsc)
 #endif
 
-#ifndef BENCHMARK_OS_WINDOWS
+#if !defined(BENCHMARK_OS_WINDOWS) || defined(BENCHMARK_OS_MINGW)
 #include <sys/time.h>
 #include <time.h>
 #endif

--- a/src/internal_macros.h
+++ b/src/internal_macros.h
@@ -40,6 +40,9 @@
   #define BENCHMARK_OS_CYGWIN 1
 #elif defined(_WIN32)
   #define BENCHMARK_OS_WINDOWS 1
+  #if defined(__MINGW32__)
+    #define BENCHMARK_OS_MINGW 1
+  #endif
 #elif defined(__APPLE__)
   #define BENCHMARK_OS_APPLE 1
   #include "TargetConditionals.h"


### PR DESCRIPTION
When building for ARM, there is a fallback codepath that uses
gettimeofday, which requires sys/time.h.

The Windows SDK doesn't have this header, but MinGW does have it.
Thus, this fixes building for Windows on ARM with MinGW
headers/libraries, while Windows on ARM with the Windows SDK still
is broken.