### PR TITLE
Mark CMake project as C++-only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ foreach(p
   endif()
 endforeach()
 
-project (benchmark)
+project (benchmark CXX)
 
 option(BENCHMARK_ENABLE_TESTING "Enable testing of the benchmark library." ON)
 option(BENCHMARK_ENABLE_EXCEPTIONS "Enable the use of exceptions in the benchmark library." ON)


### PR DESCRIPTION
This will make CMake skip all the checks for C compiler