### PR TITLE
Add variables for specifying deployment destinations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,12 @@ foreach(p
   endif()
 endforeach()
 
+set(BENCHMARK_INSTALL_BINDIR "bin" CACHE STRING "Installation directory for executables")
+set(BENCHMARK_INSTALL_INCLUDEDIR "include" CACHE STRING "Installation directory for headers")
+set(BENCHMARK_INSTALL_LIBDIR "lib" CACHE STRING "Installation directory for libraries")
+set(BENCHMARK_INSTALL_CMAKEDIR "lib/cmake/${PACKAGE_NAME}" CACHE STRING "Installation directory for cmake config files")
+set(BENCHMARK_INSTALL_PKGCONFIG "lib/pkgconfig" CACHE STRING "Installation directory for pkgconfig config files")
+
 option(BENCHMARK_ENABLE_TESTING "Enable testing of the benchmark library." ON)
 option(BENCHMARK_ENABLE_EXCEPTIONS "Enable the use of exceptions in the benchmark library." ON)
 option(BENCHMARK_ENABLE_LTO "Enable link time optimisation of the benchmark library." OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,12 +55,6 @@ target_include_directories(benchmark PUBLIC
     )
 target_link_libraries(benchmark_main benchmark)
 
-set(include_install_dir "include")
-set(lib_install_dir "lib/")
-set(bin_install_dir "bin/")
-set(config_install_dir "lib/cmake/${PROJECT_NAME}")
-set(pkgconfig_install_dir "lib/pkgconfig")
-
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
 set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
@@ -83,26 +77,26 @@ if (BENCHMARK_ENABLE_INSTALL)
   install(
     TARGETS benchmark benchmark_main
     EXPORT ${targets_export_name}
-    ARCHIVE DESTINATION ${lib_install_dir}
-    LIBRARY DESTINATION ${lib_install_dir}
-    RUNTIME DESTINATION ${bin_install_dir}
-    INCLUDES DESTINATION ${include_install_dir})
+    ARCHIVE DESTINATION ${BENCHMARK_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${BENCHMARK_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${BENCHMARK_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${BENCHMARK_INSTALL_INCLUDEDIR})
 
   install(
     DIRECTORY "${PROJECT_SOURCE_DIR}/include/benchmark"
-    DESTINATION ${include_install_dir}
+    DESTINATION ${BENCHMARK_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN "*.*h")
 
   install(
       FILES "${project_config}" "${version_config}"
-      DESTINATION "${config_install_dir}")
+      DESTINATION "${BENCHMARK_INSTALL_CMAKEDIR}")
 
   install(
       FILES "${pkg_config}"
-      DESTINATION "${pkgconfig_install_dir}")
+      DESTINATION "${BENCHMARK_INSTALL_PKGCONFIG}")
 
   install(
       EXPORT "${targets_export_name}"
       NAMESPACE "${namespace}"
-      DESTINATION "${config_install_dir}")
+      DESTINATION "${BENCHMARK_INSTALL_CMAKEDIR}")
 endif()


### PR DESCRIPTION
Signed-off-by: Dmitri Toubelis <dmitri.toubelis@litmusautomation.com>

We are building `benchmark` using yocto build system. Our target deployment destinations are `/usr/lib64` for 64-bit libraries and `/usr/lib` for 32-bit ones. Currently, all deployment destinations are hardcoded. The proposed patch makes them configurable leaving defaults unchanged.