### PR TITLE
appveyor ci: drop Visual Studio 12 2013 - unsupported by Google Test master branch.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,12 +20,6 @@ environment:
     - compiler: msvc-14-seh
       generator: "Visual Studio 14 2015 Win64"
 
-    - compiler: msvc-12-seh
-      generator: "Visual Studio 12 2013"
-
-    - compiler: msvc-12-seh
-      generator: "Visual Studio 12 2013 Win64"
-
     - compiler: gcc-5.3.0-posix
       generator: "MinGW Makefiles"
       cxx_path: 'C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin'


### PR DESCRIPTION
See https://github.com/google/googletest/pull/1815

Fixes #689.