### PR TITLE
Unbreak -Wthread-safety for -DCMAKE_BUILD_TYPE=Release on platforms that annotate <pthread.h>

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -179,7 +179,7 @@ if (BENCHMARK_ENABLE_GTEST_TESTS)
       add_dependencies(${name} googletest)
     endif()
     if (GTEST_INCLUDE_DIRS)
-      target_include_directories(${name} PRIVATE ${GTEST_INCLUDE_DIRS})
+      target_include_directories(${name} SYSTEM PRIVATE ${GTEST_INCLUDE_DIRS})
     endif()
     target_link_libraries(${name} benchmark
         ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
Fixes #655. `-Werror` shouldn't be forced for release builds, anyway.