### PR TITLE
benchmark_color: fix auto option

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -312,13 +312,18 @@ bool IsZero(double n) {
 
 ConsoleReporter::OutputOptions GetOutputOptions(bool force_no_color) {
   int output_opts = ConsoleReporter::OO_Defaults;
-  if ((FLAGS_benchmark_color == "auto" && IsColorTerminal()) ||
-      IsTruthyFlagValue(FLAGS_benchmark_color)) {
+  auto is_benchmark_color = [force_no_color] () -> bool {
+    if (force_no_color) {
+      return false;
+    }
+    if (FLAGS_benchmark_color == "auto") {
+      return IsColorTerminal();
+    }
+    return IsTruthyFlagValue(FLAGS_benchmark_color);
+  };
+  if (is_benchmark_color()) {
     output_opts |= ConsoleReporter::OO_Color;
   } else {
-    output_opts &= ~ConsoleReporter::OO_Color;
-  }
-  if (force_no_color) {
     output_opts &= ~ConsoleReporter::OO_Color;
   }
   if (FLAGS_benchmark_counters_tabular) {


### PR DESCRIPTION
As prevously written, "--benchmark_color=auto" was treated as true,
because IsTruthyFlagValue("auto") returned true.  The fix is to
rely on IsColorTerminal test only if the flag value is "auto",
and fall back to IsTruthyFlagValue otherwise.  I also integrated
force_no_color check into the same block.

(Aside for @dominichamon: I noticed that you mentioned in the ticket that a PR was in progress, but I couldn't locate it.)

Fixes #559.