### PR TITLE
Print at least three significant digits for times.

### DIFF
--- a/test/output_test_helper.cc
+++ b/test/output_test_helper.cc
@@ -38,17 +38,18 @@ SubMap& GetSubstitutions() {
   // Don't use 'dec_re' from header because it may not yet be initialized.
   // clang-format off
   static std::string safe_dec_re = "[0-9]*[.]?[0-9]+([eE][-+][0-9]+)?";
+  static std::string time_re = "([0-9]+[.])?[0-9]+";
   static SubMap map = {
       {"%float", "[0-9]*[.]?[0-9]+([eE][-+][0-9]+)?"},
       // human-readable float
       {"%hrfloat", "[0-9]*[.]?[0-9]+([eE][-+][0-9]+)?[kMGTPEZYmunpfazy]?"},
       {"%int", "[ ]*[0-9]+"},
       {" %s ", "[ ]+"},
-      {"%time", "[ ]*[0-9]+ ns"},
-      {"%console_report", "[ ]*[0-9]+ ns [ ]*[0-9]+ ns [ ]*[0-9]+"},
-      {"%console_time_only_report", "[ ]*[0-9]+ ns [ ]*[0-9]+ ns"},
-      {"%console_us_report", "[ ]*[0-9]+ us [ ]*[0-9]+ us [ ]*[0-9]+"},
-      {"%console_us_time_only_report", "[ ]*[0-9]+ us [ ]*[0-9]+ us"},
+      {"%time", "[ ]*" + time_re + "[ ]+ns"},
+      {"%console_report", "[ ]*" + time_re + "[ ]+ns [ ]*" + time_re + "[ ]+ns [ ]*[0-9]+"},
+      {"%console_time_only_report", "[ ]*" + time_re + "[ ]+ns [ ]*" + time_re + "[ ]+ns"},
+      {"%console_us_report", "[ ]*" + time_re + "[ ]+us [ ]*" + time_re + "[ ]+us [ ]*[0-9]+"},
+      {"%console_us_time_only_report", "[ ]*" + time_re + "[ ]+us [ ]*" + time_re + "[ ]+us"},
       {"%csv_header",
        "name,iterations,real_time,cpu_time,time_unit,bytes_per_second,"
        "items_per_second,label,error_occurred,error_message"},

--- a/test/reporter_output_test.cc
+++ b/test/reporter_output_test.cc
@@ -521,7 +521,7 @@ ADD_CASES(TC_ConsoleOut, {{"^BM_UserStats/iterations:5/repeats:3/manual_time [ "
                           {"^BM_UserStats/iterations:5/repeats:3/"
                            "manual_time_median [ ]* 150 ns %time [ ]*3$"},
                           {"^BM_UserStats/iterations:5/repeats:3/"
-                           "manual_time_stddev [ ]* 0 ns %time [ ]*3$"},
+                           "manual_time_stddev [ ]* 0.000 ns %time [ ]*3$"},
                           {"^BM_UserStats/iterations:5/repeats:3/manual_time_ "
                            "[ ]* 150 ns %time [ ]*3$"}});
 ADD_CASES(


### PR DESCRIPTION
Some benchmarks are particularly sensitive and they run in less than
a nanosecond. In order for the console reporter to provide meaningful
output for such benchmarks it needs to be able to display the times
using more resolution than a single nanosecond.

This patch changes the console reporter to print at least three
significant digits for all results.