### PR TITLE
Apply the `real_time_used >= 5 * min_time` check to manual time as well.

### DIFF
--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -273,10 +273,8 @@ class BenchmarkRunner {
     return i.results.has_error_ ||
            i.iters >= kMaxIterations ||  // Too many iterations already.
            i.seconds >= min_time ||      // The elapsed time is large enough.
-           // CPU time is specified but the elapsed real time greatly exceeds
-           // the minimum time.
-           // Note that user provided timers are except from this sanity check.
-           ((i.results.real_time_used >= 5 * min_time) && !b.use_manual_time);
+           // The elapsed real time greatly exceeds the minimum time.
+           i.results.real_time_used >= 5 * min_time;
   }
 
   void DoOneRepetition(bool is_the_first_repetition) {


### PR DESCRIPTION
In the commit message of 46afd8e6, I found out the following:
> However when a benchmark uses a manual timer this heuristic isn't helpful
> and likely isn't correct since we don't know what the manual timer actually
> measures.

I think the heuristic is helpful in exactly the same way for manual timer.

In my particular use case with the manual timer, the benchmarks are GPU
benchmarks, and the manual timer reports GPU time. In a certain benchmark,
the real time elapsed 257x more than the manual time. As a result,
ShouldReportIterationResults takes 257x of time to return true.

I think it's reasonable to assume that all users want a benchmark to finish
in a fixed amount of real time for good user experience, regardless of the
real_time / manual_time ratio.