### PR TITLE
[NFC] BenchmarkRunner: always populate *_report_aggregates_only bools.

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -267,8 +267,8 @@ void RunBenchmarks(const std::vector<BenchmarkInstance>& benchmarks,
       auto report = [&run_results](BenchmarkReporter* reporter,
                                    bool report_aggregates_only) {
         assert(reporter);
-        assert(
-            !(report_aggregates_only && run_results.aggregates_only.empty()));
+        // If there are no aggregates, do output non-aggregates.
+        report_aggregates_only &= !run_results.aggregates_only.empty();
         if (!report_aggregates_only)
           reporter->ReportRuns(run_results.non_aggregates);
         if (!run_results.aggregates_only.empty())

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -136,20 +136,17 @@ class BenchmarkRunner {
         has_explicit_iteration_count(b.iterations != 0),
         pool(b.threads - 1),
         iters(has_explicit_iteration_count ? b.iterations : 1) {
-    if (repeats != 1) {
+    run_results.display_report_aggregates_only =
+        (FLAGS_benchmark_report_aggregates_only ||
+         FLAGS_benchmark_display_aggregates_only);
+    run_results.file_report_aggregates_only =
+        FLAGS_benchmark_report_aggregates_only;
+    if (b.aggregation_report_mode != internal::ARM_Unspecified) {
       run_results.display_report_aggregates_only =
-          (FLAGS_benchmark_report_aggregates_only ||
-           FLAGS_benchmark_display_aggregates_only);
+          (b.aggregation_report_mode &
+           internal::ARM_DisplayReportAggregatesOnly);
       run_results.file_report_aggregates_only =
-          FLAGS_benchmark_report_aggregates_only;
-      if (b.aggregation_report_mode != internal::ARM_Unspecified) {
-        run_results.display_report_aggregates_only =
-            (b.aggregation_report_mode &
-             internal::ARM_DisplayReportAggregatesOnly);
-        run_results.file_report_aggregates_only =
-            (b.aggregation_report_mode &
-             internal::ARM_FileReportAggregatesOnly);
-      }
+          (b.aggregation_report_mode & internal::ARM_FileReportAggregatesOnly);
     }
 
     for (int repetition_num = 0; repetition_num < repeats; repetition_num++) {


### PR DESCRIPTION
It is better to let the RunBenchmarks(), report() decide
whether to actually *only* output aggregates or not,
depending on whether there are actually aggregates.