### PR TITLE
Fix parsing of cpuinfo for s390 platform.

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -405,7 +405,9 @@ int GetNumCPUs() {
     size_t SplitIdx = ln.find(':');
     std::string value;
 #if defined(__s390__)
-    if (SplitIdx != std::string::npos) value = ln.substr(SplitIdx - 1, 2);
+    // s390 has another format in /proc/cpuinfo
+    // it needs to be parsed differently
+    if (SplitIdx != std::string::npos) value = ln.substr(Key.size()+1,SplitIdx-Key.size()-1);
 #else
     if (SplitIdx != std::string::npos) value = ln.substr(SplitIdx + 1);
 #endif

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -404,7 +404,11 @@ int GetNumCPUs() {
     if (ln.empty()) continue;
     size_t SplitIdx = ln.find(':');
     std::string value;
+#if defined(__s390__)
+    if (SplitIdx != std::string::npos) value = ln.substr(SplitIdx - 1, 2);
+#else
     if (SplitIdx != std::string::npos) value = ln.substr(SplitIdx + 1);
+#endif
     if (ln.size() >= Key.size() && ln.compare(0, Key.size(), Key) == 0) {
       NumCPUs++;
       if (!value.empty()) {


### PR DESCRIPTION
s390 has another line structure for processor-field.
It should be differently parsed.

Should fix #711 