### PR TITLE
Added default case in switch to avoid warning

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1518,6 +1518,7 @@ inline const char* GetTimeUnitString(TimeUnit unit) {
     case kMicrosecond:
       return "us";
     case kNanosecond:
+    default:	
       return "ns";
   }
   BENCHMARK_UNREACHABLE();
@@ -1530,6 +1531,7 @@ inline double GetTimeUnitMultiplier(TimeUnit unit) {
     case kMicrosecond:
       return 1e6;
     case kNanosecond:
+    default:	
       return 1e9;
   }
   BENCHMARK_UNREACHABLE();

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1518,10 +1518,10 @@ inline const char* GetTimeUnitString(TimeUnit unit) {
     case kMicrosecond:
       return "us";
     case kNanosecond:
-    default:	
       return "ns";
   }
   BENCHMARK_UNREACHABLE();
+  return "ns";
 }
 
 inline double GetTimeUnitMultiplier(TimeUnit unit) {
@@ -1531,10 +1531,10 @@ inline double GetTimeUnitMultiplier(TimeUnit unit) {
     case kMicrosecond:
       return 1e6;
     case kNanosecond:
-    default:	
       return 1e9;
   }
   BENCHMARK_UNREACHABLE();
+  return 1e9;
 }
 
 }  // namespace benchmark


### PR DESCRIPTION
```
warning: missing return statement at end of non-void function "benchmark::GetTimeUnitString"
warning: missing return statement at end of non-void function "benchmark::GetTimeUnitMultiplier"
```
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2016 NVIDIA Corporation
Built on Tue_Jan_10_13:22:03_CST_2017
Cuda compilation tools, release 8.0, V8.0.61