### PR TITLE
Add Conan support

### DIFF
--- a/conan/CMakeLists.txt
+++ b/conan/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+include(${CMAKE_SOURCE_DIR}/CMakeListsOriginal.txt)

--- a/conan/test_package/CMakeLists.txt
+++ b/conan/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(test_package)
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/conan/test_package/conanfile.py
+++ b/conan/test_package/conanfile.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans import ConanFile, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        bin_path = os.path.join("bin", "test_package")
+        self.run(bin_path, run_environment=True)

--- a/conan/test_package/test_package.cpp
+++ b/conan/test_package/test_package.cpp
@@ -1,0 +1,18 @@
+#include "benchmark/benchmark.h"
+
+void BM_StringCreation(benchmark::State& state) {
+    while (state.KeepRunning())
+        std::string empty_string;
+}
+
+BENCHMARK(BM_StringCreation);
+
+void BM_StringCopy(benchmark::State& state) {
+    std::string x = "hello";
+    while (state.KeepRunning())
+        std::string copy(x);
+}
+
+BENCHMARK(BM_StringCopy);
+
+BENCHMARK_MAIN();

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,79 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import shutil
+import os
+
+
+class GoogleBenchmarkConan(ConanFile):
+    name = "benchmark"
+    description = "A microbenchmark support library."
+    topics = ("conan", "benchmark", "google", "microbenchmark")
+    url = "https://github.com/google/benchmark"
+    homepage = "https://github.com/google/benchmark"
+    author = "Google Inc."
+    license = "Apache-2.0"
+    exports_sources = ["*"]
+    generators = "cmake"
+
+    settings = "arch", "build_type", "compiler", "os"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "enable_lto": [True, False],
+        "enable_exceptions": [True, False]
+    }
+    default_options = {"shared": False, "fPIC": True, "enable_lto": False, "enable_exceptions": True}
+
+    _build_subfolder = "."
+
+    def source(self):
+        # Wrap the original CMake file to call conan_basic_setup
+        shutil.move("CMakeLists.txt", "CMakeListsOriginal.txt")
+        shutil.move(os.path.join("conan", "CMakeLists.txt"), "CMakeLists.txt")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            if self.settings.compiler == "Visual Studio" and float(self.settings.compiler.version.value) <= 12:
+                raise ConanInvalidConfiguration("{} {} does not support Visual Studio <= 12".format(self.name, self.version))
+            del self.options.fPIC
+
+    def configure(self):
+        if self.settings.os == "Windows" and self.options.shared:
+            raise ConanInvalidConfiguration("Windows shared builds are not supported right now, see issue #639")
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+
+        cmake.definitions["BENCHMARK_ENABLE_TESTING"] = "OFF"
+        cmake.definitions["BENCHMARK_ENABLE_GTEST_TESTS"] = "OFF"
+        cmake.definitions["BENCHMARK_ENABLE_LTO"] = "ON" if self.options.enable_lto else "OFF"
+        cmake.definitions["BENCHMARK_ENABLE_EXCEPTIONS"] = "ON" if self.options.enable_exceptions else "OFF"
+
+        # See https://github.com/google/benchmark/pull/638 for Windows 32 build explanation
+        if self.settings.os != "Windows":
+            cmake.definitions["BENCHMARK_BUILD_32_BITS"] = "ON" if "64" not in str(self.settings.arch) else "OFF"
+            cmake.definitions["BENCHMARK_USE_LIBCXX"] = "ON" if (str(self.settings.compiler.libcxx) == "libc++") else "OFF"
+        else:
+            cmake.definitions["BENCHMARK_USE_LIBCXX"] = "OFF"
+
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        cmake = self._configure_cmake()
+        cmake.install()
+
+        self.copy(pattern="LICENSE", dst="licenses")
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        if self.settings.os == "Linux":
+            self.cpp_info.libs.extend(["pthread", "rt"])
+        elif self.settings.os == "Windows":
+            self.cpp_info.libs.append("shlwapi")
+        elif self.settings.os == "SunOS":
+            self.cpp_info.libs.append("kstat")


### PR DESCRIPTION
This is split from #647 

It only contains the minimum changes to get initial Conan support.

With this changes you can create a Conan package by executing

`conan create . benchmark/<version-number>@google/stable`

or better: to actual test if the package works, the test_package should be executed with it:

`conan create . benchmark/<version-number>@google/stable -tf conan/test_package`

(the parameter `tf` stands for test folder).

If no error appears the created Benchmark Conan package can be consumed by projects **locally**.

_____

This does NOT contain any kind of publishing/uploading mechanism with mass building for different configurations/operating systems etc. this should be eventually done via #647 

_____

cc @memsharded @dominichamon