### PR TITLE
Add -lpthread to pkg-config Libs.private

### DIFF
--- a/cmake/benchmark.pc.in
+++ b/cmake/benchmark.pc.in
@@ -8,4 +8,5 @@ Description: Google microbenchmark framework
 Version: @VERSION@
 
 Libs: -L${libdir} -lbenchmark
+Libs.private: -lpthread
 Cflags: -I${includedir}


### PR DESCRIPTION
Since pthread is required at least for GCC (according to the documentation), this should be reflected by the `pkg-config` file.

The same is, for instance, also done by the gflags library:  https://github.com/gflags/gflags/blob/1005485222e8b0feff822c5723ddcaa5abadc01a/cmake/package.pc.in#L13