### PR TITLE
BENCHMARK_CAPTURE() and Complexity() - naming problem

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Andriy Berestovskyy <berestovskyy@gmail.com>
 Arne Beer <arne@twobeer.de>
 Carto
 Christopher Seymour <chris.j.seymour@hotmail.com>
+Daniel Harvey <danielharvey458@gmail.com>
 David Coeurjolly <david.coeurjolly@liris.cnrs.fr>
 Deniz Evrenci <denizevrenci@gmail.com>
 Dirac Research 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,6 +29,7 @@ Billy Robert O'Neal III <billy.oneal@gmail.com> <bion@microsoft.com>
 Chris Kennelly <ckennelly@google.com> <ckennelly@ckennelly.com>
 Christopher Seymour <chris.j.seymour@hotmail.com>
 Cyrille Faucheux <cyrille.faucheux@gmail.com>
+Daniel Harvey <danielharvey458@gmail.com>
 David Coeurjolly <david.coeurjolly@liris.cnrs.fr>
 Deniz Evrenci <denizevrenci@gmail.com>
 Dominic Hamon <dma@stripysock.com> <dominic@google.com>

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1311,22 +1311,22 @@ class BenchmarkName {
   // Different fields of the benchmark's name.
   enum Field {
     // The name of the function being invoked in the benchmark.
-    ROOT = 1u,
+    kRoot = 1U,
     // The arguments supplied to the benchmark, e.g. via Range().
-    ARGS = 1u << 1,
+    kArgs = 1U << 1U,
     // The minimum time specified for a benchmark.
-    MIN_TIME = 1u << 2,
+    kMinTime = 1U << 2U,
     // The number of iterations specified for a benchmark.
-    ITERATIONS = 1u << 3,
+    kIterations = 1U << 3U,
     // The number of repetitions specified for a benchmark.
-    REPETITIONS = 1u << 4,
+    kRepetitions = 1U << 4U,
     // The type of time to measure for a benchmark.
-    TIME_TYPE = 1u << 5,
+    kTimeType = 1U << 5U,
     // The number of concurrent threads for a benchmark.
-    THREADS = 1u << 6,
+    kThreads = 1U << 6U,
     // All fields.
-    ALL =
-        ROOT | ARGS | MIN_TIME | ITERATIONS | REPETITIONS | TIME_TYPE | THREADS
+    kAll =
+        kRoot | kArgs | kMinTime | kIterations | kRepetitions | kTimeType | kThreads
   };
 
   // Construct BenchmarkName with an 'empty' name.
@@ -1345,7 +1345,7 @@ class BenchmarkName {
   std::string get(Field fields) const;
 
   // Conversion to a string, which returns a string equivalent to
-  // get(Field::ALL).
+  // get(Field::kAll).
   operator std::string() const { return name_; }
 
   // Get the size of the full name of the benchmark.
@@ -1416,7 +1416,7 @@ class BenchmarkReporter {
           max_bytes_used(0) {}
 
     std::string benchmark_name(
-        BenchmarkName::Field component = BenchmarkName::ALL) const;
+        BenchmarkName::Field component = BenchmarkName::kAll) const;
     BenchmarkName run_name;
     RunType run_type;          // is this a measurement, or an aggregate?
     std::string aggregate_name;

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1335,11 +1335,11 @@ class BenchmarkName {
   // Construct BenchmarkName with a given 'root'.
   BenchmarkName(std::string root);
 
-  // Append a 'field_name' to a given field of the name.
-  // Each appended field_name for a given field will be
+  // Append a 'field_content' to a given field of the name.
+  // Each appended field_content for a given field will be
   // separated by a '/', and additionally each field will
   // be separated by a '/'.
-  BenchmarkName& append(Field field, const std::string& field_name);
+  BenchmarkName& append(Field field, const std::string& field_content);
 
   // Get the benchmark's name including all the fields set in 'fields'
   std::string get(Field fields) const;

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1335,8 +1335,8 @@ class BenchmarkName {
   // Construct BenchmarkName with a given 'root'.
   BenchmarkName(std::string root);
 
-  // Append a 'field_content' to a given field of the name.
-  // Each appended field_content for a given field will be
+  // Append 'field_content' to a given field of the name.
+  // Each appended element of content for a given field will be
   // separated by a '/', and additionally each field will
   // be separated by a '/'.
   BenchmarkName& append(Field field, const std::string& field_content);
@@ -1344,9 +1344,8 @@ class BenchmarkName {
   // Get the benchmark's name including all the fields set in 'fields'
   std::string get(Field fields) const;
 
-  // Conversion to a string, which returns a string equivalent to
-  // get(Field::kAll).
-  operator std::string() const { return name_; }
+  // Get the full name of the benchmark including all fields.
+  const std::string& str() const { return name_; }
 
   // Get the size of the full name of the benchmark.
   size_t size() const { return name_.size(); }
@@ -1363,9 +1362,6 @@ class BenchmarkName {
   std::string name_;
   uint16_t offsets_[offset_count];
 };
-
-// Insert the full name of a BenchmarkName into a stream.
-std::ostream& operator<<(std::ostream& os, const BenchmarkName& bmn);
 
 // Bitwise-or of BenchmarkName::Field bitfield
 BenchmarkName::Field operator|(BenchmarkName::Field lhs,

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -393,7 +393,8 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
   }
 
   if (FLAGS_benchmark_list_tests) {
-    for (auto const& benchmark : benchmarks) Out << benchmark.name << "\n";
+    for (auto const& benchmark : benchmarks)
+      Out << benchmark.name.str() << "\n";
   } else {
     internal::RunBenchmarks(benchmarks, display_reporter, file_reporter);
   }

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -233,7 +233,7 @@ void RunBenchmarks(const std::vector<BenchmarkInstance>& benchmarks,
   size_t stat_field_width = 0;
   for (const BenchmarkInstance& benchmark : benchmarks) {
     name_field_width =
-        std::max<size_t>(name_field_width, benchmark.name.size());
+        std::max<size_t>(name_field_width, benchmark.name.str().size());
     might_have_aggregates |= benchmark.repetitions > 1;
 
     for (const auto& Stat : *benchmark.statistics)

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -16,7 +16,7 @@ namespace internal {
 
 // Information kept per benchmark we may want to run
 struct BenchmarkInstance {
-  std::string name;
+  BenchmarkName name;
   Benchmark* benchmark;
   AggregationReportMode aggregation_report_mode;
   std::vector<int64_t> arg;

--- a/src/benchmark_name.cc
+++ b/src/benchmark_name.cc
@@ -41,6 +41,7 @@ void join_impl(std::string& s, const char delimiter, const Head& head,
   join_impl(s, delimiter, tail...);
 }
 
+// TODO: use absl::StrJoin
 template <typename... Ts>
 std::string join(char delimiter, const Ts&... ts) {
   std::string s;

--- a/src/benchmark_name.cc
+++ b/src/benchmark_name.cc
@@ -88,10 +88,6 @@ size_t BenchmarkName::end_offset(size_t enumerator_index) const {
                                                   : offsets_[enumerator_index];
 }
 
-std::ostream &operator<<(std::ostream &os, const BenchmarkName &bmn) {
-  return os << static_cast<std::string>(bmn);
-}
-
 BenchmarkName::Field operator|(BenchmarkName::Field lhs,
                                BenchmarkName::Field rhs) {
   using underlying_type =

--- a/src/benchmark_name.cc
+++ b/src/benchmark_name.cc
@@ -114,7 +114,11 @@ BenchmarkName::Field operator~(BenchmarkName::Field component) {
   using underlying_type =
       typename std::underlying_type<BenchmarkName::Field>::type;
 
+  // '&' with kAll to ensure the result is within the enumeration's
+  // range before casting back to the underlying type
+  // [expr.static.cast]p10
   return static_cast<BenchmarkName::Field>(
+      static_cast<underlying_type>(BenchmarkName::Field::kAll) &
       ~static_cast<underlying_type>(component));
 }
 

--- a/src/benchmark_name.cc
+++ b/src/benchmark_name.cc
@@ -1,0 +1,121 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+
+namespace benchmark {
+
+BenchmarkName::BenchmarkName() : offsets_{} {}
+
+BenchmarkName::BenchmarkName(std::string root)
+    : name_(std::move(root)), offsets_{} {
+  std::fill_n(offsets_, offset_count, name_.size());
+}
+
+BenchmarkName &BenchmarkName::append(Field field,
+                                     const std::string &field_name) {
+  for (auto e = 0u; e < enumerator_count; ++e) {
+    if (is_set(field, e)) {
+      // Insert the new name at the end of this field.
+      auto offset = end_offset(e);
+      auto inserted_characters_count = field_name.size();
+
+      // Insert a leading separator unless we are right
+      // at the beginning of the name.
+      if (offset != 0) {
+        name_.insert(offset++, 1, separator);
+        ++inserted_characters_count;
+      }
+
+      name_.insert(offset, field_name);
+
+      // Update all following offsets to account for the inserted characters.
+      for (auto o = e; o < offset_count; ++o) {
+        offsets_[o] += inserted_characters_count;
+      }
+    }
+  }
+  return *this;
+}
+
+std::string BenchmarkName::get(Field fields) const {
+  std::string n;
+  for (auto e = 0u; e < enumerator_count; ++e) {
+    if (is_set(fields, e)) {
+      auto begin = start_offset(e);
+      const auto end = end_offset(e);
+
+      if (begin == end) {
+        continue;
+      }
+
+      // If we're about to start the string, drop the leading '/'.
+      // Note we're iterating the fields in order, so the first
+      // insert will always be at the front of 'n'.
+      if (n.empty() && (name_.at(begin) == separator)) {
+        ++begin;
+      }
+
+      assert(begin <= end);
+
+      n += name_.substr(begin, end - begin);
+    }
+  }
+  return n;
+}
+
+bool BenchmarkName::is_set(Field field, size_t enumerator_index) const {
+  return field & (1u << enumerator_index);
+}
+
+size_t BenchmarkName::start_offset(size_t enumerator_index) const {
+  return enumerator_index == 0 ? 0 : offsets_[enumerator_index - 1];
+}
+
+size_t BenchmarkName::end_offset(size_t enumerator_index) const {
+  return enumerator_index + 1 == enumerator_count ? name_.size()
+                                                  : offsets_[enumerator_index];
+}
+
+std::ostream &operator<<(std::ostream &os, const BenchmarkName &bmn) {
+  return os << static_cast<std::string>(bmn);
+}
+
+BenchmarkName::Field operator|(BenchmarkName::Field lhs,
+                               BenchmarkName::Field rhs) {
+  using underlying_type =
+      typename std::underlying_type<BenchmarkName::Field>::type;
+
+  return static_cast<BenchmarkName::Field>(static_cast<underlying_type>(lhs) |
+                                           static_cast<underlying_type>(rhs));
+}
+
+BenchmarkName::Field operator&(BenchmarkName::Field lhs,
+                               BenchmarkName::Field rhs) {
+  using underlying_type =
+      typename std::underlying_type<BenchmarkName::Field>::type;
+
+  return static_cast<BenchmarkName::Field>(static_cast<underlying_type>(lhs) &
+                                           static_cast<underlying_type>(rhs));
+}
+
+BenchmarkName::Field operator~(BenchmarkName::Field component) {
+  using underlying_type =
+      typename std::underlying_type<BenchmarkName::Field>::type;
+
+  return static_cast<BenchmarkName::Field>(
+      ~static_cast<underlying_type>(component));
+}
+
+}  // namespace benchmark

--- a/src/benchmark_name.cc
+++ b/src/benchmark_name.cc
@@ -27,6 +27,7 @@ size_t size_impl(const Head& head, const Tail&... tail) {
 }
 
 // Join a pack of std::strings using a delimiter
+// TODO: use absl::StrJoin
 void join_impl(std::string&, char) {}
 
 template <typename Head, typename... Tail>
@@ -41,7 +42,6 @@ void join_impl(std::string& s, const char delimiter, const Head& head,
   join_impl(s, delimiter, tail...);
 }
 
-// TODO: use absl::StrJoin
 template <typename... Ts>
 std::string join(char delimiter, const Ts&... ts) {
   std::string s;

--- a/src/benchmark_name.cc
+++ b/src/benchmark_name.cc
@@ -24,12 +24,12 @@ BenchmarkName::BenchmarkName(std::string root)
 }
 
 BenchmarkName &BenchmarkName::append(Field field,
-                                     const std::string &field_name) {
+                                     const std::string &field_content) {
   for (auto e = 0u; e < enumerator_count; ++e) {
     if (is_set(field, e)) {
       // Insert the new name at the end of this field.
       auto offset = end_offset(e);
-      auto inserted_characters_count = field_name.size();
+      auto inserted_characters_count = field_content.size();
 
       // Insert a leading separator unless we are right
       // at the beginning of the name.
@@ -38,7 +38,7 @@ BenchmarkName &BenchmarkName::append(Field field,
         ++inserted_characters_count;
       }
 
-      name_.insert(offset, field_name);
+      name_.insert(offset, field_content);
 
       // Update all following offsets to account for the inserted characters.
       for (auto o = e; o < offset_count; ++o) {

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -172,41 +172,45 @@ bool BenchmarkFamilies::FindBenchmarks(
         // Add arguments to instance name
         size_t arg_i = 0;
         for (auto const& arg : args) {
-          instance.name += "/";
+          std::string args_name;
 
           if (arg_i < family->arg_names_.size()) {
             const auto& arg_name = family->arg_names_[arg_i];
             if (!arg_name.empty()) {
-              instance.name +=
-                  StrFormat("%s:", family->arg_names_[arg_i].c_str());
+              args_name += StrFormat("%s:", family->arg_names_[arg_i].c_str());
             }
           }
 
           // we know that the args are always non-negative (see 'AddRange()'),
           // thus print as 'unsigned'. BUT, do a cast due to the 32-bit builds.
-          instance.name += StrFormat("%lu", static_cast<unsigned long>(arg));
+          args_name += StrFormat("%lu", static_cast<unsigned long>(arg));
+          instance.name.append(BenchmarkName::ARGS, args_name);
           ++arg_i;
         }
 
         if (!IsZero(family->min_time_))
-          instance.name += StrFormat("/min_time:%0.3f", family->min_time_);
+          instance.name.append(BenchmarkName::MIN_TIME,
+                               StrFormat("min_time:%0.3f", family->min_time_));
         if (family->iterations_ != 0) {
-          instance.name +=
-              StrFormat("/iterations:%lu",
-                        static_cast<unsigned long>(family->iterations_));
+          instance.name.append(
+              BenchmarkName::ITERATIONS,
+              StrFormat("iterations:%lu",
+                        static_cast<unsigned long>(family->iterations_)));
         }
         if (family->repetitions_ != 0)
-          instance.name += StrFormat("/repeats:%d", family->repetitions_);
+          instance.name.append(BenchmarkName::REPETITIONS,
+                               StrFormat("repeats:%d", family->repetitions_));
 
         if (family->use_manual_time_) {
-          instance.name += "/manual_time";
+          instance.name.append(BenchmarkName::TIME_TYPE, "manual_time");
         } else if (family->use_real_time_) {
-          instance.name += "/real_time";
+          instance.name.append(BenchmarkName::TIME_TYPE, "real_time");
         }
 
         // Add the number of threads used to the name
         if (!family->thread_counts_.empty()) {
-          instance.name += StrFormat("/threads:%d", instance.threads);
+          instance.name.append(BenchmarkName::THREADS,
+                               StrFormat("threads:%d", instance.threads));
         }
 
         if ((re.Match(instance.name) && !isNegativeFilter) ||

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -153,7 +153,7 @@ bool BenchmarkFamilies::FindBenchmarks(
     for (auto const& args : family->args_) {
       for (int num_threads : *thread_counts) {
         BenchmarkInstance instance;
-        instance.name = family->name_;
+        instance.name.function_name = family->name_;
         instance.benchmark = family.get();
         instance.aggregation_report_mode = family->aggregation_report_mode_;
         instance.arg = args;
@@ -172,49 +172,51 @@ bool BenchmarkFamilies::FindBenchmarks(
         // Add arguments to instance name
         size_t arg_i = 0;
         for (auto const& arg : args) {
-          std::string args_name;
+          if (!instance.name.args.empty()) {
+            instance.name.args += '/';
+          }
 
           if (arg_i < family->arg_names_.size()) {
             const auto& arg_name = family->arg_names_[arg_i];
             if (!arg_name.empty()) {
-              args_name += StrFormat("%s:", family->arg_names_[arg_i].c_str());
+              instance.name.args += StrFormat("%s:", arg_name.c_str());
             }
           }
 
           // we know that the args are always non-negative (see 'AddRange()'),
           // thus print as 'unsigned'. BUT, do a cast due to the 32-bit builds.
-          args_name += StrFormat("%lu", static_cast<unsigned long>(arg));
-          instance.name.append(BenchmarkName::kArgs, args_name);
+          instance.name.args +=
+              StrFormat("%lu", static_cast<unsigned long>(arg));
+
           ++arg_i;
         }
 
         if (!IsZero(family->min_time_))
-          instance.name.append(BenchmarkName::kMinTime,
-                               StrFormat("min_time:%0.3f", family->min_time_));
+          instance.name.min_time =
+              StrFormat("min_time:%0.3f", family->min_time_);
         if (family->iterations_ != 0) {
-          instance.name.append(
-              BenchmarkName::kIterations,
+          instance.name.iterations =
               StrFormat("iterations:%lu",
-                        static_cast<unsigned long>(family->iterations_)));
+                        static_cast<unsigned long>(family->iterations_));
         }
         if (family->repetitions_ != 0)
-          instance.name.append(BenchmarkName::kRepetitions,
-                               StrFormat("repeats:%d", family->repetitions_));
+          instance.name.repetitions =
+              StrFormat("repeats:%d", family->repetitions_);
 
         if (family->use_manual_time_) {
-          instance.name.append(BenchmarkName::kTimeType, "manual_time");
+          instance.name.time_type = "manual_time";
         } else if (family->use_real_time_) {
-          instance.name.append(BenchmarkName::kTimeType, "real_time");
+          instance.name.time_type = "real_time";
         }
 
         // Add the number of threads used to the name
         if (!family->thread_counts_.empty()) {
-          instance.name.append(BenchmarkName::kThreads,
-                               StrFormat("threads:%d", instance.threads));
+          instance.name.threads = StrFormat("threads:%d", instance.threads);
         }
 
-        if ((re.Match(instance.name.str()) && !isNegativeFilter) ||
-            (!re.Match(instance.name.str()) && isNegativeFilter)) {
+        const auto full_name = instance.name.str();
+        if ((re.Match(full_name) && !isNegativeFilter) ||
+            (!re.Match(full_name) && isNegativeFilter)) {
           instance.last_benchmark_instance = (&args == &family->args_.back());
           benchmarks->push_back(std::move(instance));
         }

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -213,8 +213,8 @@ bool BenchmarkFamilies::FindBenchmarks(
                                StrFormat("threads:%d", instance.threads));
         }
 
-        if ((re.Match(instance.name) && !isNegativeFilter) ||
-            (!re.Match(instance.name) && isNegativeFilter)) {
+        if ((re.Match(instance.name.str()) && !isNegativeFilter) ||
+            (!re.Match(instance.name.str()) && isNegativeFilter)) {
           instance.last_benchmark_instance = (&args == &family->args_.back());
           benchmarks->push_back(std::move(instance));
         }

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -184,32 +184,32 @@ bool BenchmarkFamilies::FindBenchmarks(
           // we know that the args are always non-negative (see 'AddRange()'),
           // thus print as 'unsigned'. BUT, do a cast due to the 32-bit builds.
           args_name += StrFormat("%lu", static_cast<unsigned long>(arg));
-          instance.name.append(BenchmarkName::ARGS, args_name);
+          instance.name.append(BenchmarkName::kArgs, args_name);
           ++arg_i;
         }
 
         if (!IsZero(family->min_time_))
-          instance.name.append(BenchmarkName::MIN_TIME,
+          instance.name.append(BenchmarkName::kMinTime,
                                StrFormat("min_time:%0.3f", family->min_time_));
         if (family->iterations_ != 0) {
           instance.name.append(
-              BenchmarkName::ITERATIONS,
+              BenchmarkName::kIterations,
               StrFormat("iterations:%lu",
                         static_cast<unsigned long>(family->iterations_)));
         }
         if (family->repetitions_ != 0)
-          instance.name.append(BenchmarkName::REPETITIONS,
+          instance.name.append(BenchmarkName::kRepetitions,
                                StrFormat("repeats:%d", family->repetitions_));
 
         if (family->use_manual_time_) {
-          instance.name.append(BenchmarkName::TIME_TYPE, "manual_time");
+          instance.name.append(BenchmarkName::kTimeType, "manual_time");
         } else if (family->use_real_time_) {
-          instance.name.append(BenchmarkName::TIME_TYPE, "real_time");
+          instance.name.append(BenchmarkName::kTimeType, "real_time");
         }
 
         // Add the number of threads used to the name
         if (!family->thread_counts_.empty()) {
-          instance.name.append(BenchmarkName::THREADS,
+          instance.name.append(BenchmarkName::kThreads,
                                StrFormat("threads:%d", instance.threads));
         }
 

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -191,7 +191,7 @@ class BenchmarkRunner {
     double seconds;
   };
   IterationResults DoNIterations() {
-    VLOG(2) << "Running " << b.name << " for " << iters << "\n";
+    VLOG(2) << "Running " << b.name.str() << " for " << iters << "\n";
 
     std::unique_ptr<internal::ThreadManager> manager;
     manager.reset(new internal::ThreadManager(b.threads));

--- a/src/complexity.cc
+++ b/src/complexity.cc
@@ -183,8 +183,9 @@ std::vector<BenchmarkReporter::Run> ComputeBigO(
     result_real = MinimalLeastSq(n, real_time, result_cpu.complexity);
   }
 
-  std::string run_name = reports[0].benchmark_name().substr(
-      0, reports[0].benchmark_name().find('/'));
+  // Drop the 'args' when reporting complexity.
+  const auto run_name =
+      reports[0].benchmark_name(BenchmarkName::ALL & ~BenchmarkName::ARGS);
 
   // Get the data from the accumulator to BenchmarkReporter::Run's.
   Run big_o;

--- a/src/complexity.cc
+++ b/src/complexity.cc
@@ -184,8 +184,8 @@ std::vector<BenchmarkReporter::Run> ComputeBigO(
   }
 
   // Drop the 'args' when reporting complexity.
-  const auto run_name =
-      reports[0].benchmark_name(BenchmarkName::kAll & ~BenchmarkName::kArgs);
+  auto run_name = reports[0].run_name;
+  run_name.args.clear();
 
   // Get the data from the accumulator to BenchmarkReporter::Run's.
   Run big_o;

--- a/src/complexity.cc
+++ b/src/complexity.cc
@@ -185,7 +185,7 @@ std::vector<BenchmarkReporter::Run> ComputeBigO(
 
   // Drop the 'args' when reporting complexity.
   const auto run_name =
-      reports[0].benchmark_name(BenchmarkName::ALL & ~BenchmarkName::ARGS);
+      reports[0].benchmark_name(BenchmarkName::kAll & ~BenchmarkName::kArgs);
 
   // Get the data from the accumulator to BenchmarkReporter::Run's.
   Run big_o;

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -168,7 +168,7 @@ void JSONReporter::PrintRunData(Run const& run) {
   std::string indent(6, ' ');
   std::ostream& out = GetOutputStream();
   out << indent << FormatKV("name", run.benchmark_name()) << ",\n";
-  out << indent << FormatKV("run_name", run.run_name) << ",\n";
+  out << indent << FormatKV("run_name", run.run_name.str()) << ",\n";
   out << indent << FormatKV("run_type", [&run]() -> const char* {
     switch (run.run_type) {
       case BenchmarkReporter::Run::RT_Iteration:

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -82,8 +82,8 @@ const char *BenchmarkReporter::Context::executable_name;
 BenchmarkReporter::Context::Context()
     : cpu_info(CPUInfo::Get()), sys_info(SystemInfo::Get()) {}
 
-std::string BenchmarkReporter::Run::benchmark_name() const {
-  std::string name = run_name;
+std::string BenchmarkReporter::Run::benchmark_name(BenchmarkName::Field field) const {
+  std::string name = run_name.get(field);
   if (run_type == RT_Aggregate) {
     name += "_" + aggregate_name;
   }

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -82,8 +82,8 @@ const char *BenchmarkReporter::Context::executable_name;
 BenchmarkReporter::Context::Context()
     : cpu_info(CPUInfo::Get()), sys_info(SystemInfo::Get()) {}
 
-std::string BenchmarkReporter::Run::benchmark_name(BenchmarkName::Field field) const {
-  std::string name = run_name.get(field);
+std::string BenchmarkReporter::Run::benchmark_name() const {
+  std::string name = run_name.str();
   if (run_type == RT_Aggregate) {
     name += "_" + aggregate_name;
   }

--- a/src/statistics.cc
+++ b/src/statistics.cc
@@ -147,7 +147,7 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
   for (const auto& Stat : *reports[0].statistics) {
     // Get the data from the accumulator to BenchmarkReporter::Run's.
     Run data;
-    data.run_name = reports[0].benchmark_name();
+    data.run_name = reports[0].run_name;
     data.run_type = BenchmarkReporter::Run::RT_Aggregate;
     data.aggregate_name = Stat.name_;
     data.report_label = report_label;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -191,6 +191,7 @@ if (BENCHMARK_ENABLE_GTEST_TESTS)
   endmacro()
 
   add_gtest(benchmark_gtest)
+  add_gtest(benchmark_name_gtest)
   add_gtest(statistics_gtest)
   add_gtest(string_util_gtest)
 endif(BENCHMARK_ENABLE_GTEST_TESTS)

--- a/test/benchmark_name_gtest.cc
+++ b/test/benchmark_name_gtest.cc
@@ -6,215 +6,69 @@ namespace {
 using namespace benchmark;
 using namespace benchmark::internal;
 
-#define EXPECT_FIELD(name, field, expected) \
-  EXPECT_EQ((name.get(BenchmarkName::field)), (expected));
-
 TEST(BenchmarkNameTest, Empty) {
   const auto name = BenchmarkName();
-
-  EXPECT_FIELD(name, kAll, std::string{});
-  EXPECT_FIELD(name, kRoot, std::string{});
-  EXPECT_FIELD(name, kArgs, std::string{});
-  EXPECT_FIELD(name, kMinTime, std::string{});
-  EXPECT_FIELD(name, kIterations, std::string{});
-  EXPECT_FIELD(name, kRepetitions, std::string{});
-  EXPECT_FIELD(name, kTimeType, std::string{});
-  EXPECT_FIELD(name, kThreads, std::string{});
+  EXPECT_EQ(name.str(), std::string());
 }
 
-TEST(BenchmarkNameTest, Root) {
-  const auto name = BenchmarkName("root");
-
-  EXPECT_FIELD(name, kAll, "root");
-  EXPECT_FIELD(name, kRoot, "root");
-  EXPECT_FIELD(name, kArgs, std::string{});
-  EXPECT_FIELD(name, kMinTime, std::string{});
-  EXPECT_FIELD(name, kIterations, std::string{});
-  EXPECT_FIELD(name, kRepetitions, std::string{});
-  EXPECT_FIELD(name, kTimeType, std::string{});
-  EXPECT_FIELD(name, kThreads, std::string{});
+TEST(BenchmarkNameTest, FunctionName) {
+  auto name = BenchmarkName();
+  name.function_name = "function_name";
+  EXPECT_EQ(name.str(), "function_name");
 }
 
-TEST(BenchmarkNameTest, AppendToRoot) {
-  const auto name =
-      BenchmarkName("root").append(BenchmarkName::kRoot, "subroot");
-
-  EXPECT_FIELD(name, kAll, "root/subroot");
-  EXPECT_FIELD(name, kRoot, "root/subroot");
-  EXPECT_FIELD(name, kArgs, std::string{});
-  EXPECT_FIELD(name, kMinTime, std::string{});
-  EXPECT_FIELD(name, kIterations, std::string{});
-  EXPECT_FIELD(name, kRepetitions, std::string{});
-  EXPECT_FIELD(name, kTimeType, std::string{});
-  EXPECT_FIELD(name, kThreads, std::string{});
-}
-
-TEST(BenchmarkNameTest, RootAndArgs) {
-  const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::kRoot, "subroot")
-                        .append(BenchmarkName::kArgs, "some_args:3/4/5");
-
-  EXPECT_FIELD(name, kAll, "root/subroot/some_args:3/4/5");
-  EXPECT_FIELD(name, kRoot, "root/subroot");
-  EXPECT_FIELD(name, kArgs, "some_args:3/4/5");
-  EXPECT_FIELD(name, kMinTime, std::string{});
-  EXPECT_FIELD(name, kIterations, std::string{});
-  EXPECT_FIELD(name, kRepetitions, std::string{});
-  EXPECT_FIELD(name, kTimeType, std::string{});
-  EXPECT_FIELD(name, kThreads, std::string{});
-}
-
-TEST(BenchmarkNameTest, MultipleArgs) {
-  const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::kArgs, "some_args:3")
-                        .append(BenchmarkName::kArgs, "4")
-                        .append(BenchmarkName::kArgs, "5");
-
-  EXPECT_FIELD(name, kAll, "root/some_args:3/4/5");
-  EXPECT_FIELD(name, kRoot, "root");
-  EXPECT_FIELD(name, kArgs, "some_args:3/4/5");
-  EXPECT_FIELD(name, kMinTime, std::string{});
-  EXPECT_FIELD(name, kIterations, std::string{});
-  EXPECT_FIELD(name, kRepetitions, std::string{});
-  EXPECT_FIELD(name, kTimeType, std::string{});
-  EXPECT_FIELD(name, kThreads, std::string{});
+TEST(BenchmarkNameTest, FunctionNameAndArgs) {
+  auto name = BenchmarkName();
+  name.function_name = "function_name";
+  name.args = "some_args:3/4/5";
+  EXPECT_EQ(name.str(), "function_name/some_args:3/4/5");
 }
 
 TEST(BenchmarkNameTest, MinTime) {
-  const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::kArgs, "some_args:3/4")
-                        .append(BenchmarkName::kMinTime, "min_time:3.4s");
-
-  EXPECT_FIELD(name, kAll, "root/some_args:3/4/min_time:3.4s");
-  EXPECT_FIELD(name, kRoot, "root");
-  EXPECT_FIELD(name, kArgs, "some_args:3/4");
-  EXPECT_FIELD(name, kMinTime, "min_time:3.4s");
-  EXPECT_FIELD(name, kIterations, std::string{});
-  EXPECT_FIELD(name, kRepetitions, std::string{});
-  EXPECT_FIELD(name, kTimeType, std::string{});
-  EXPECT_FIELD(name, kThreads, std::string{});
+  auto name = BenchmarkName();
+  name.function_name = "function_name";
+  name.args = "some_args:3/4";
+  name.min_time = "min_time:3.4s";
+  EXPECT_EQ(name.str(), "function_name/some_args:3/4/min_time:3.4s");
 }
 
 TEST(BenchmarkNameTest, Iterations) {
-  const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::kMinTime, "min_time:3.4s")
-                        .append(BenchmarkName::kIterations, "iterations:42");
-
-  EXPECT_FIELD(name, kAll, "root/min_time:3.4s/iterations:42");
-  EXPECT_FIELD(name, kRoot, "root");
-  EXPECT_FIELD(name, kArgs, std::string{});
-  EXPECT_FIELD(name, kMinTime, "min_time:3.4s");
-  EXPECT_FIELD(name, kIterations, "iterations:42");
-  EXPECT_FIELD(name, kRepetitions, std::string{});
-  EXPECT_FIELD(name, kTimeType, std::string{});
-  EXPECT_FIELD(name, kThreads, std::string{});
+  auto name = BenchmarkName();
+  name.function_name = "function_name";
+  name.min_time = "min_time:3.4s";
+  name.iterations = "iterations:42";
+  EXPECT_EQ(name.str(), "function_name/min_time:3.4s/iterations:42");
 }
 
 TEST(BenchmarkNameTest, Repetitions) {
-  const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::kIterations, "iterations:42")
-                        .append(BenchmarkName::kRepetitions, "repetitions:24");
-
-  EXPECT_FIELD(name, kAll, "root/iterations:42/repetitions:24");
-  EXPECT_FIELD(name, kRoot, "root");
-  EXPECT_FIELD(name, kArgs, std::string{});
-  EXPECT_FIELD(name, kMinTime, std::string{});
-  EXPECT_FIELD(name, kIterations, "iterations:42");
-  EXPECT_FIELD(name, kRepetitions, "repetitions:24");
-  EXPECT_FIELD(name, kTimeType, std::string{});
-  EXPECT_FIELD(name, kThreads, std::string{});
+  auto name = BenchmarkName();
+  name.function_name = "function_name";
+  name.min_time = "min_time:3.4s";
+  name.repetitions = "repetitions:24";
+  EXPECT_EQ(name.str(), "function_name/min_time:3.4s/repetitions:24");
 }
 
 TEST(BenchmarkNameTest, TimeType) {
-  const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::kRepetitions, "repetitions:24")
-                        .append(BenchmarkName::kTimeType, "hammer_time");
-
-  EXPECT_FIELD(name, kAll, "root/repetitions:24/hammer_time");
-  EXPECT_FIELD(name, kRoot, "root");
-  EXPECT_FIELD(name, kArgs, std::string{});
-  EXPECT_FIELD(name, kMinTime, std::string{});
-  EXPECT_FIELD(name, kIterations, std::string{});
-  EXPECT_FIELD(name, kRepetitions, "repetitions:24");
-  EXPECT_FIELD(name, kTimeType, "hammer_time");
-  EXPECT_FIELD(name, kThreads, std::string{});
+  auto name = BenchmarkName();
+  name.function_name = "function_name";
+  name.min_time = "min_time:3.4s";
+  name.time_type = "hammer_time";
+  EXPECT_EQ(name.str(), "function_name/min_time:3.4s/hammer_time");
 }
 
 TEST(BenchmarkNameTest, Threads) {
-  const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::kTimeType, "hammer_time")
-                        .append(BenchmarkName::kThreads, "threads:256");
-
-  EXPECT_FIELD(name, kAll, "root/hammer_time/threads:256");
-  EXPECT_FIELD(name, kRoot, "root");
-  EXPECT_FIELD(name, kArgs, std::string{});
-  EXPECT_FIELD(name, kMinTime, std::string{});
-  EXPECT_FIELD(name, kIterations, std::string{});
-  EXPECT_FIELD(name, kRepetitions, std::string{});
-  EXPECT_FIELD(name, kTimeType, "hammer_time");
-  EXPECT_FIELD(name, kThreads, "threads:256");
+  auto name = BenchmarkName();
+  name.function_name = "function_name";
+  name.min_time = "min_time:3.4s";
+  name.threads = "threads:256";
+  EXPECT_EQ(name.str(), "function_name/min_time:3.4s/threads:256");
 }
 
-TEST(BenchmarkNameTest, TestReadMultipleFields) {
-  const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::kArgs, "first:3")
-                        .append(BenchmarkName::kArgs, "second:2")
-                        .append(BenchmarkName::kMinTime, "min_time:2")
-                        .append(BenchmarkName::kIterations, "iterations:3")
-                        .append(BenchmarkName::kRepetitions, "repetitions:4")
-                        .append(BenchmarkName::kTimeType, "hammer_time")
-                        .append(BenchmarkName::kThreads, "threads:6");
-
-  EXPECT_FIELD(name, kAll,
-               "root/first:3/second:2/min_time:2/iterations:3/repetitions:4/"
-               "hammer_time/threads:6");
-
-  EXPECT_EQ(name.get(BenchmarkName::kAll & ~BenchmarkName::kRoot),
-            "first:3/second:2/min_time:2/iterations:3/repetitions:4/"
-            "hammer_time/threads:6");
-
-  EXPECT_EQ(name.get(BenchmarkName::kAll & ~BenchmarkName::kArgs),
-            "root/min_time:2/iterations:3/repetitions:4/hammer_time/threads:6");
-
-  EXPECT_EQ(
-      name.get(BenchmarkName::kAll & ~BenchmarkName::kMinTime),
-      "root/first:3/second:2/iterations:3/repetitions:4/hammer_time/threads:6");
-
-  EXPECT_EQ(
-      name.get(BenchmarkName::kAll & ~BenchmarkName::kIterations),
-      "root/first:3/second:2/min_time:2/repetitions:4/hammer_time/threads:6");
-
-  EXPECT_EQ(
-      name.get(BenchmarkName::kAll & ~BenchmarkName::kRepetitions),
-      "root/first:3/second:2/min_time:2/iterations:3/hammer_time/threads:6");
-
-  EXPECT_EQ(
-      name.get(BenchmarkName::kAll & ~BenchmarkName::kTimeType),
-      "root/first:3/second:2/min_time:2/iterations:3/repetitions:4/threads:6");
-
-  EXPECT_EQ(name.get(BenchmarkName::kAll & ~BenchmarkName::kThreads),
-            "root/first:3/second:2/min_time:2/iterations:3/repetitions:4/"
-            "hammer_time");
-
-  EXPECT_EQ(name.get(BenchmarkName::kAll &
-                     ~(BenchmarkName::kThreads | BenchmarkName::kArgs)),
-            "root/min_time:2/iterations:3/repetitions:4/hammer_time");
-
-  EXPECT_EQ(name.get(BenchmarkName::kRoot | BenchmarkName::kThreads),
-            "root/threads:6");
+TEST(BenchmarkNameTest, TestEmptyFunctionName) {
+  auto name = BenchmarkName();
+  name.args = "first:3/second:4";
+  name.threads = "threads:22";
+  EXPECT_EQ(name.str(), "first:3/second:4/threads:22");
 }
-
-TEST(BenchmarkNameTest, TestEmptyRoot) {
-  const auto name = BenchmarkName(std::string{})
-                        .append(BenchmarkName::kArgs, "first:3")
-                        .append(BenchmarkName::kArgs, "second:4")
-                        .append(BenchmarkName::kThreads, "threads:22");
-
-  EXPECT_FIELD(name, kAll, "first:3/second:4/threads:22");
-  EXPECT_FIELD(name, kArgs, "first:3/second:4");
-  EXPECT_FIELD(name, kThreads, "threads:22");
-}
-
-#undef EXPECT_FIELD
 
 }  // end namespace

--- a/test/benchmark_name_gtest.cc
+++ b/test/benchmark_name_gtest.cc
@@ -1,0 +1,220 @@
+#include "benchmark/benchmark.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+using namespace benchmark;
+using namespace benchmark::internal;
+
+#define EXPECT_FIELD(name, field, expected) \
+  EXPECT_EQ((name.get(BenchmarkName::field)), (expected));
+
+TEST(BenchmarkNameTest, Empty) {
+  const auto name = BenchmarkName();
+
+  EXPECT_FIELD(name, ALL, std::string{});
+  EXPECT_FIELD(name, ROOT, std::string{});
+  EXPECT_FIELD(name, ARGS, std::string{});
+  EXPECT_FIELD(name, MIN_TIME, std::string{});
+  EXPECT_FIELD(name, ITERATIONS, std::string{});
+  EXPECT_FIELD(name, REPETITIONS, std::string{});
+  EXPECT_FIELD(name, TIME_TYPE, std::string{});
+  EXPECT_FIELD(name, THREADS, std::string{});
+}
+
+TEST(BenchmarkNameTest, Root) {
+  const auto name = BenchmarkName("root");
+
+  EXPECT_FIELD(name, ALL, "root");
+  EXPECT_FIELD(name, ROOT, "root");
+  EXPECT_FIELD(name, ARGS, std::string{});
+  EXPECT_FIELD(name, MIN_TIME, std::string{});
+  EXPECT_FIELD(name, ITERATIONS, std::string{});
+  EXPECT_FIELD(name, REPETITIONS, std::string{});
+  EXPECT_FIELD(name, TIME_TYPE, std::string{});
+  EXPECT_FIELD(name, THREADS, std::string{});
+}
+
+TEST(BenchmarkNameTest, AppendToRoot) {
+  const auto name =
+      BenchmarkName("root").append(BenchmarkName::ROOT, "subroot");
+
+  EXPECT_FIELD(name, ALL, "root/subroot");
+  EXPECT_FIELD(name, ROOT, "root/subroot");
+  EXPECT_FIELD(name, ARGS, std::string{});
+  EXPECT_FIELD(name, MIN_TIME, std::string{});
+  EXPECT_FIELD(name, ITERATIONS, std::string{});
+  EXPECT_FIELD(name, REPETITIONS, std::string{});
+  EXPECT_FIELD(name, TIME_TYPE, std::string{});
+  EXPECT_FIELD(name, THREADS, std::string{});
+}
+
+TEST(BenchmarkNameTest, RootAndArgs) {
+  const auto name = BenchmarkName("root")
+                        .append(BenchmarkName::ROOT, "subroot")
+                        .append(BenchmarkName::ARGS, "some_args:3/4/5");
+
+  EXPECT_FIELD(name, ALL, "root/subroot/some_args:3/4/5");
+  EXPECT_FIELD(name, ROOT, "root/subroot");
+  EXPECT_FIELD(name, ARGS, "some_args:3/4/5");
+  EXPECT_FIELD(name, MIN_TIME, std::string{});
+  EXPECT_FIELD(name, ITERATIONS, std::string{});
+  EXPECT_FIELD(name, REPETITIONS, std::string{});
+  EXPECT_FIELD(name, TIME_TYPE, std::string{});
+  EXPECT_FIELD(name, THREADS, std::string{});
+}
+
+TEST(BenchmarkNameTest, MultipleArgs) {
+  const auto name = BenchmarkName("root")
+                        .append(BenchmarkName::ARGS, "some_args:3")
+                        .append(BenchmarkName::ARGS, "4")
+                        .append(BenchmarkName::ARGS, "5");
+
+  EXPECT_FIELD(name, ALL, "root/some_args:3/4/5");
+  EXPECT_FIELD(name, ROOT, "root");
+  EXPECT_FIELD(name, ARGS, "some_args:3/4/5");
+  EXPECT_FIELD(name, MIN_TIME, std::string{});
+  EXPECT_FIELD(name, ITERATIONS, std::string{});
+  EXPECT_FIELD(name, REPETITIONS, std::string{});
+  EXPECT_FIELD(name, TIME_TYPE, std::string{});
+  EXPECT_FIELD(name, THREADS, std::string{});
+}
+
+TEST(BenchmarkNameTest, MinTime) {
+  const auto name = BenchmarkName("root")
+                        .append(BenchmarkName::ARGS, "some_args:3/4")
+                        .append(BenchmarkName::MIN_TIME, "min_time:3.4s");
+
+  EXPECT_FIELD(name, ALL, "root/some_args:3/4/min_time:3.4s");
+  EXPECT_FIELD(name, ROOT, "root");
+  EXPECT_FIELD(name, ARGS, "some_args:3/4");
+  EXPECT_FIELD(name, MIN_TIME, "min_time:3.4s");
+  EXPECT_FIELD(name, ITERATIONS, std::string{});
+  EXPECT_FIELD(name, REPETITIONS, std::string{});
+  EXPECT_FIELD(name, TIME_TYPE, std::string{});
+  EXPECT_FIELD(name, THREADS, std::string{});
+}
+
+TEST(BenchmarkNameTest, Iterations) {
+  const auto name = BenchmarkName("root")
+                        .append(BenchmarkName::MIN_TIME, "min_time:3.4s")
+                        .append(BenchmarkName::ITERATIONS, "iterations:42");
+
+  EXPECT_FIELD(name, ALL, "root/min_time:3.4s/iterations:42");
+  EXPECT_FIELD(name, ROOT, "root");
+  EXPECT_FIELD(name, ARGS, std::string{});
+  EXPECT_FIELD(name, MIN_TIME, "min_time:3.4s");
+  EXPECT_FIELD(name, ITERATIONS, "iterations:42");
+  EXPECT_FIELD(name, REPETITIONS, std::string{});
+  EXPECT_FIELD(name, TIME_TYPE, std::string{});
+  EXPECT_FIELD(name, THREADS, std::string{});
+}
+
+TEST(BenchmarkNameTest, Repetitions) {
+  const auto name = BenchmarkName("root")
+                        .append(BenchmarkName::ITERATIONS, "iterations:42")
+                        .append(BenchmarkName::REPETITIONS, "repetitions:24");
+
+  EXPECT_FIELD(name, ALL, "root/iterations:42/repetitions:24");
+  EXPECT_FIELD(name, ROOT, "root");
+  EXPECT_FIELD(name, ARGS, std::string{});
+  EXPECT_FIELD(name, MIN_TIME, std::string{});
+  EXPECT_FIELD(name, ITERATIONS, "iterations:42");
+  EXPECT_FIELD(name, REPETITIONS, "repetitions:24");
+  EXPECT_FIELD(name, TIME_TYPE, std::string{});
+  EXPECT_FIELD(name, THREADS, std::string{});
+}
+
+TEST(BenchmarkNameTest, TimeType) {
+  const auto name = BenchmarkName("root")
+                        .append(BenchmarkName::REPETITIONS, "repetitions:24")
+                        .append(BenchmarkName::TIME_TYPE, "hammer_time");
+
+  EXPECT_FIELD(name, ALL, "root/repetitions:24/hammer_time");
+  EXPECT_FIELD(name, ROOT, "root");
+  EXPECT_FIELD(name, ARGS, std::string{});
+  EXPECT_FIELD(name, MIN_TIME, std::string{});
+  EXPECT_FIELD(name, ITERATIONS, std::string{});
+  EXPECT_FIELD(name, REPETITIONS, "repetitions:24");
+  EXPECT_FIELD(name, TIME_TYPE, "hammer_time");
+  EXPECT_FIELD(name, THREADS, std::string{});
+}
+
+TEST(BenchmarkNameTest, Threads) {
+  const auto name = BenchmarkName("root")
+                        .append(BenchmarkName::TIME_TYPE, "hammer_time")
+                        .append(BenchmarkName::THREADS, "threads:256");
+
+  EXPECT_FIELD(name, ALL, "root/hammer_time/threads:256");
+  EXPECT_FIELD(name, ROOT, "root");
+  EXPECT_FIELD(name, ARGS, std::string{});
+  EXPECT_FIELD(name, MIN_TIME, std::string{});
+  EXPECT_FIELD(name, ITERATIONS, std::string{});
+  EXPECT_FIELD(name, REPETITIONS, std::string{});
+  EXPECT_FIELD(name, TIME_TYPE, "hammer_time");
+  EXPECT_FIELD(name, THREADS, "threads:256");
+}
+
+TEST(BenchmarkNameTest, TestReadMultipleFields) {
+  const auto name = BenchmarkName("root")
+                        .append(BenchmarkName::ARGS, "first:3")
+                        .append(BenchmarkName::ARGS, "second:2")
+                        .append(BenchmarkName::MIN_TIME, "min_time:2")
+                        .append(BenchmarkName::ITERATIONS, "iterations:3")
+                        .append(BenchmarkName::REPETITIONS, "repetitions:4")
+                        .append(BenchmarkName::TIME_TYPE, "hammer_time")
+                        .append(BenchmarkName::THREADS, "threads:6");
+
+  EXPECT_FIELD(name, ALL,
+               "root/first:3/second:2/min_time:2/iterations:3/repetitions:4/"
+               "hammer_time/threads:6");
+
+  EXPECT_EQ(name.get(BenchmarkName::ALL & ~BenchmarkName::ROOT),
+            "first:3/second:2/min_time:2/iterations:3/repetitions:4/"
+            "hammer_time/threads:6");
+
+  EXPECT_EQ(name.get(BenchmarkName::ALL & ~BenchmarkName::ARGS),
+            "root/min_time:2/iterations:3/repetitions:4/hammer_time/threads:6");
+
+  EXPECT_EQ(
+      name.get(BenchmarkName::ALL & ~BenchmarkName::MIN_TIME),
+      "root/first:3/second:2/iterations:3/repetitions:4/hammer_time/threads:6");
+
+  EXPECT_EQ(
+      name.get(BenchmarkName::ALL & ~BenchmarkName::ITERATIONS),
+      "root/first:3/second:2/min_time:2/repetitions:4/hammer_time/threads:6");
+
+  EXPECT_EQ(
+      name.get(BenchmarkName::ALL & ~BenchmarkName::REPETITIONS),
+      "root/first:3/second:2/min_time:2/iterations:3/hammer_time/threads:6");
+
+  EXPECT_EQ(
+      name.get(BenchmarkName::ALL & ~BenchmarkName::TIME_TYPE),
+      "root/first:3/second:2/min_time:2/iterations:3/repetitions:4/threads:6");
+
+  EXPECT_EQ(name.get(BenchmarkName::ALL & ~BenchmarkName::THREADS),
+            "root/first:3/second:2/min_time:2/iterations:3/repetitions:4/"
+            "hammer_time");
+
+  EXPECT_EQ(name.get(BenchmarkName::ALL &
+                     ~(BenchmarkName::THREADS | BenchmarkName::ARGS)),
+            "root/min_time:2/iterations:3/repetitions:4/hammer_time");
+
+  EXPECT_EQ(name.get(BenchmarkName::ROOT | BenchmarkName::THREADS),
+            "root/threads:6");
+}
+
+TEST(BenchmarkNameTest, TestEmptyRoot) {
+  const auto name = BenchmarkName(std::string{})
+                        .append(BenchmarkName::ARGS, "first:3")
+                        .append(BenchmarkName::ARGS, "second:4")
+                        .append(BenchmarkName::THREADS, "threads:22");
+
+  EXPECT_FIELD(name, ALL, "first:3/second:4/threads:22");
+  EXPECT_FIELD(name, ARGS, "first:3/second:4");
+  EXPECT_FIELD(name, THREADS, "threads:22");
+}
+
+#undef EXPECT_FIELD
+
+}  // end namespace

--- a/test/benchmark_name_gtest.cc
+++ b/test/benchmark_name_gtest.cc
@@ -12,207 +12,207 @@ using namespace benchmark::internal;
 TEST(BenchmarkNameTest, Empty) {
   const auto name = BenchmarkName();
 
-  EXPECT_FIELD(name, ALL, std::string{});
-  EXPECT_FIELD(name, ROOT, std::string{});
-  EXPECT_FIELD(name, ARGS, std::string{});
-  EXPECT_FIELD(name, MIN_TIME, std::string{});
-  EXPECT_FIELD(name, ITERATIONS, std::string{});
-  EXPECT_FIELD(name, REPETITIONS, std::string{});
-  EXPECT_FIELD(name, TIME_TYPE, std::string{});
-  EXPECT_FIELD(name, THREADS, std::string{});
+  EXPECT_FIELD(name, kAll, std::string{});
+  EXPECT_FIELD(name, kRoot, std::string{});
+  EXPECT_FIELD(name, kArgs, std::string{});
+  EXPECT_FIELD(name, kMinTime, std::string{});
+  EXPECT_FIELD(name, kIterations, std::string{});
+  EXPECT_FIELD(name, kRepetitions, std::string{});
+  EXPECT_FIELD(name, kTimeType, std::string{});
+  EXPECT_FIELD(name, kThreads, std::string{});
 }
 
 TEST(BenchmarkNameTest, Root) {
   const auto name = BenchmarkName("root");
 
-  EXPECT_FIELD(name, ALL, "root");
-  EXPECT_FIELD(name, ROOT, "root");
-  EXPECT_FIELD(name, ARGS, std::string{});
-  EXPECT_FIELD(name, MIN_TIME, std::string{});
-  EXPECT_FIELD(name, ITERATIONS, std::string{});
-  EXPECT_FIELD(name, REPETITIONS, std::string{});
-  EXPECT_FIELD(name, TIME_TYPE, std::string{});
-  EXPECT_FIELD(name, THREADS, std::string{});
+  EXPECT_FIELD(name, kAll, "root");
+  EXPECT_FIELD(name, kRoot, "root");
+  EXPECT_FIELD(name, kArgs, std::string{});
+  EXPECT_FIELD(name, kMinTime, std::string{});
+  EXPECT_FIELD(name, kIterations, std::string{});
+  EXPECT_FIELD(name, kRepetitions, std::string{});
+  EXPECT_FIELD(name, kTimeType, std::string{});
+  EXPECT_FIELD(name, kThreads, std::string{});
 }
 
 TEST(BenchmarkNameTest, AppendToRoot) {
   const auto name =
-      BenchmarkName("root").append(BenchmarkName::ROOT, "subroot");
+      BenchmarkName("root").append(BenchmarkName::kRoot, "subroot");
 
-  EXPECT_FIELD(name, ALL, "root/subroot");
-  EXPECT_FIELD(name, ROOT, "root/subroot");
-  EXPECT_FIELD(name, ARGS, std::string{});
-  EXPECT_FIELD(name, MIN_TIME, std::string{});
-  EXPECT_FIELD(name, ITERATIONS, std::string{});
-  EXPECT_FIELD(name, REPETITIONS, std::string{});
-  EXPECT_FIELD(name, TIME_TYPE, std::string{});
-  EXPECT_FIELD(name, THREADS, std::string{});
+  EXPECT_FIELD(name, kAll, "root/subroot");
+  EXPECT_FIELD(name, kRoot, "root/subroot");
+  EXPECT_FIELD(name, kArgs, std::string{});
+  EXPECT_FIELD(name, kMinTime, std::string{});
+  EXPECT_FIELD(name, kIterations, std::string{});
+  EXPECT_FIELD(name, kRepetitions, std::string{});
+  EXPECT_FIELD(name, kTimeType, std::string{});
+  EXPECT_FIELD(name, kThreads, std::string{});
 }
 
 TEST(BenchmarkNameTest, RootAndArgs) {
   const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::ROOT, "subroot")
-                        .append(BenchmarkName::ARGS, "some_args:3/4/5");
+                        .append(BenchmarkName::kRoot, "subroot")
+                        .append(BenchmarkName::kArgs, "some_args:3/4/5");
 
-  EXPECT_FIELD(name, ALL, "root/subroot/some_args:3/4/5");
-  EXPECT_FIELD(name, ROOT, "root/subroot");
-  EXPECT_FIELD(name, ARGS, "some_args:3/4/5");
-  EXPECT_FIELD(name, MIN_TIME, std::string{});
-  EXPECT_FIELD(name, ITERATIONS, std::string{});
-  EXPECT_FIELD(name, REPETITIONS, std::string{});
-  EXPECT_FIELD(name, TIME_TYPE, std::string{});
-  EXPECT_FIELD(name, THREADS, std::string{});
+  EXPECT_FIELD(name, kAll, "root/subroot/some_args:3/4/5");
+  EXPECT_FIELD(name, kRoot, "root/subroot");
+  EXPECT_FIELD(name, kArgs, "some_args:3/4/5");
+  EXPECT_FIELD(name, kMinTime, std::string{});
+  EXPECT_FIELD(name, kIterations, std::string{});
+  EXPECT_FIELD(name, kRepetitions, std::string{});
+  EXPECT_FIELD(name, kTimeType, std::string{});
+  EXPECT_FIELD(name, kThreads, std::string{});
 }
 
 TEST(BenchmarkNameTest, MultipleArgs) {
   const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::ARGS, "some_args:3")
-                        .append(BenchmarkName::ARGS, "4")
-                        .append(BenchmarkName::ARGS, "5");
+                        .append(BenchmarkName::kArgs, "some_args:3")
+                        .append(BenchmarkName::kArgs, "4")
+                        .append(BenchmarkName::kArgs, "5");
 
-  EXPECT_FIELD(name, ALL, "root/some_args:3/4/5");
-  EXPECT_FIELD(name, ROOT, "root");
-  EXPECT_FIELD(name, ARGS, "some_args:3/4/5");
-  EXPECT_FIELD(name, MIN_TIME, std::string{});
-  EXPECT_FIELD(name, ITERATIONS, std::string{});
-  EXPECT_FIELD(name, REPETITIONS, std::string{});
-  EXPECT_FIELD(name, TIME_TYPE, std::string{});
-  EXPECT_FIELD(name, THREADS, std::string{});
+  EXPECT_FIELD(name, kAll, "root/some_args:3/4/5");
+  EXPECT_FIELD(name, kRoot, "root");
+  EXPECT_FIELD(name, kArgs, "some_args:3/4/5");
+  EXPECT_FIELD(name, kMinTime, std::string{});
+  EXPECT_FIELD(name, kIterations, std::string{});
+  EXPECT_FIELD(name, kRepetitions, std::string{});
+  EXPECT_FIELD(name, kTimeType, std::string{});
+  EXPECT_FIELD(name, kThreads, std::string{});
 }
 
 TEST(BenchmarkNameTest, MinTime) {
   const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::ARGS, "some_args:3/4")
-                        .append(BenchmarkName::MIN_TIME, "min_time:3.4s");
+                        .append(BenchmarkName::kArgs, "some_args:3/4")
+                        .append(BenchmarkName::kMinTime, "min_time:3.4s");
 
-  EXPECT_FIELD(name, ALL, "root/some_args:3/4/min_time:3.4s");
-  EXPECT_FIELD(name, ROOT, "root");
-  EXPECT_FIELD(name, ARGS, "some_args:3/4");
-  EXPECT_FIELD(name, MIN_TIME, "min_time:3.4s");
-  EXPECT_FIELD(name, ITERATIONS, std::string{});
-  EXPECT_FIELD(name, REPETITIONS, std::string{});
-  EXPECT_FIELD(name, TIME_TYPE, std::string{});
-  EXPECT_FIELD(name, THREADS, std::string{});
+  EXPECT_FIELD(name, kAll, "root/some_args:3/4/min_time:3.4s");
+  EXPECT_FIELD(name, kRoot, "root");
+  EXPECT_FIELD(name, kArgs, "some_args:3/4");
+  EXPECT_FIELD(name, kMinTime, "min_time:3.4s");
+  EXPECT_FIELD(name, kIterations, std::string{});
+  EXPECT_FIELD(name, kRepetitions, std::string{});
+  EXPECT_FIELD(name, kTimeType, std::string{});
+  EXPECT_FIELD(name, kThreads, std::string{});
 }
 
 TEST(BenchmarkNameTest, Iterations) {
   const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::MIN_TIME, "min_time:3.4s")
-                        .append(BenchmarkName::ITERATIONS, "iterations:42");
+                        .append(BenchmarkName::kMinTime, "min_time:3.4s")
+                        .append(BenchmarkName::kIterations, "iterations:42");
 
-  EXPECT_FIELD(name, ALL, "root/min_time:3.4s/iterations:42");
-  EXPECT_FIELD(name, ROOT, "root");
-  EXPECT_FIELD(name, ARGS, std::string{});
-  EXPECT_FIELD(name, MIN_TIME, "min_time:3.4s");
-  EXPECT_FIELD(name, ITERATIONS, "iterations:42");
-  EXPECT_FIELD(name, REPETITIONS, std::string{});
-  EXPECT_FIELD(name, TIME_TYPE, std::string{});
-  EXPECT_FIELD(name, THREADS, std::string{});
+  EXPECT_FIELD(name, kAll, "root/min_time:3.4s/iterations:42");
+  EXPECT_FIELD(name, kRoot, "root");
+  EXPECT_FIELD(name, kArgs, std::string{});
+  EXPECT_FIELD(name, kMinTime, "min_time:3.4s");
+  EXPECT_FIELD(name, kIterations, "iterations:42");
+  EXPECT_FIELD(name, kRepetitions, std::string{});
+  EXPECT_FIELD(name, kTimeType, std::string{});
+  EXPECT_FIELD(name, kThreads, std::string{});
 }
 
 TEST(BenchmarkNameTest, Repetitions) {
   const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::ITERATIONS, "iterations:42")
-                        .append(BenchmarkName::REPETITIONS, "repetitions:24");
+                        .append(BenchmarkName::kIterations, "iterations:42")
+                        .append(BenchmarkName::kRepetitions, "repetitions:24");
 
-  EXPECT_FIELD(name, ALL, "root/iterations:42/repetitions:24");
-  EXPECT_FIELD(name, ROOT, "root");
-  EXPECT_FIELD(name, ARGS, std::string{});
-  EXPECT_FIELD(name, MIN_TIME, std::string{});
-  EXPECT_FIELD(name, ITERATIONS, "iterations:42");
-  EXPECT_FIELD(name, REPETITIONS, "repetitions:24");
-  EXPECT_FIELD(name, TIME_TYPE, std::string{});
-  EXPECT_FIELD(name, THREADS, std::string{});
+  EXPECT_FIELD(name, kAll, "root/iterations:42/repetitions:24");
+  EXPECT_FIELD(name, kRoot, "root");
+  EXPECT_FIELD(name, kArgs, std::string{});
+  EXPECT_FIELD(name, kMinTime, std::string{});
+  EXPECT_FIELD(name, kIterations, "iterations:42");
+  EXPECT_FIELD(name, kRepetitions, "repetitions:24");
+  EXPECT_FIELD(name, kTimeType, std::string{});
+  EXPECT_FIELD(name, kThreads, std::string{});
 }
 
 TEST(BenchmarkNameTest, TimeType) {
   const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::REPETITIONS, "repetitions:24")
-                        .append(BenchmarkName::TIME_TYPE, "hammer_time");
+                        .append(BenchmarkName::kRepetitions, "repetitions:24")
+                        .append(BenchmarkName::kTimeType, "hammer_time");
 
-  EXPECT_FIELD(name, ALL, "root/repetitions:24/hammer_time");
-  EXPECT_FIELD(name, ROOT, "root");
-  EXPECT_FIELD(name, ARGS, std::string{});
-  EXPECT_FIELD(name, MIN_TIME, std::string{});
-  EXPECT_FIELD(name, ITERATIONS, std::string{});
-  EXPECT_FIELD(name, REPETITIONS, "repetitions:24");
-  EXPECT_FIELD(name, TIME_TYPE, "hammer_time");
-  EXPECT_FIELD(name, THREADS, std::string{});
+  EXPECT_FIELD(name, kAll, "root/repetitions:24/hammer_time");
+  EXPECT_FIELD(name, kRoot, "root");
+  EXPECT_FIELD(name, kArgs, std::string{});
+  EXPECT_FIELD(name, kMinTime, std::string{});
+  EXPECT_FIELD(name, kIterations, std::string{});
+  EXPECT_FIELD(name, kRepetitions, "repetitions:24");
+  EXPECT_FIELD(name, kTimeType, "hammer_time");
+  EXPECT_FIELD(name, kThreads, std::string{});
 }
 
 TEST(BenchmarkNameTest, Threads) {
   const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::TIME_TYPE, "hammer_time")
-                        .append(BenchmarkName::THREADS, "threads:256");
+                        .append(BenchmarkName::kTimeType, "hammer_time")
+                        .append(BenchmarkName::kThreads, "threads:256");
 
-  EXPECT_FIELD(name, ALL, "root/hammer_time/threads:256");
-  EXPECT_FIELD(name, ROOT, "root");
-  EXPECT_FIELD(name, ARGS, std::string{});
-  EXPECT_FIELD(name, MIN_TIME, std::string{});
-  EXPECT_FIELD(name, ITERATIONS, std::string{});
-  EXPECT_FIELD(name, REPETITIONS, std::string{});
-  EXPECT_FIELD(name, TIME_TYPE, "hammer_time");
-  EXPECT_FIELD(name, THREADS, "threads:256");
+  EXPECT_FIELD(name, kAll, "root/hammer_time/threads:256");
+  EXPECT_FIELD(name, kRoot, "root");
+  EXPECT_FIELD(name, kArgs, std::string{});
+  EXPECT_FIELD(name, kMinTime, std::string{});
+  EXPECT_FIELD(name, kIterations, std::string{});
+  EXPECT_FIELD(name, kRepetitions, std::string{});
+  EXPECT_FIELD(name, kTimeType, "hammer_time");
+  EXPECT_FIELD(name, kThreads, "threads:256");
 }
 
 TEST(BenchmarkNameTest, TestReadMultipleFields) {
   const auto name = BenchmarkName("root")
-                        .append(BenchmarkName::ARGS, "first:3")
-                        .append(BenchmarkName::ARGS, "second:2")
-                        .append(BenchmarkName::MIN_TIME, "min_time:2")
-                        .append(BenchmarkName::ITERATIONS, "iterations:3")
-                        .append(BenchmarkName::REPETITIONS, "repetitions:4")
-                        .append(BenchmarkName::TIME_TYPE, "hammer_time")
-                        .append(BenchmarkName::THREADS, "threads:6");
+                        .append(BenchmarkName::kArgs, "first:3")
+                        .append(BenchmarkName::kArgs, "second:2")
+                        .append(BenchmarkName::kMinTime, "min_time:2")
+                        .append(BenchmarkName::kIterations, "iterations:3")
+                        .append(BenchmarkName::kRepetitions, "repetitions:4")
+                        .append(BenchmarkName::kTimeType, "hammer_time")
+                        .append(BenchmarkName::kThreads, "threads:6");
 
-  EXPECT_FIELD(name, ALL,
+  EXPECT_FIELD(name, kAll,
                "root/first:3/second:2/min_time:2/iterations:3/repetitions:4/"
                "hammer_time/threads:6");
 
-  EXPECT_EQ(name.get(BenchmarkName::ALL & ~BenchmarkName::ROOT),
+  EXPECT_EQ(name.get(BenchmarkName::kAll & ~BenchmarkName::kRoot),
             "first:3/second:2/min_time:2/iterations:3/repetitions:4/"
             "hammer_time/threads:6");
 
-  EXPECT_EQ(name.get(BenchmarkName::ALL & ~BenchmarkName::ARGS),
+  EXPECT_EQ(name.get(BenchmarkName::kAll & ~BenchmarkName::kArgs),
             "root/min_time:2/iterations:3/repetitions:4/hammer_time/threads:6");
 
   EXPECT_EQ(
-      name.get(BenchmarkName::ALL & ~BenchmarkName::MIN_TIME),
+      name.get(BenchmarkName::kAll & ~BenchmarkName::kMinTime),
       "root/first:3/second:2/iterations:3/repetitions:4/hammer_time/threads:6");
 
   EXPECT_EQ(
-      name.get(BenchmarkName::ALL & ~BenchmarkName::ITERATIONS),
+      name.get(BenchmarkName::kAll & ~BenchmarkName::kIterations),
       "root/first:3/second:2/min_time:2/repetitions:4/hammer_time/threads:6");
 
   EXPECT_EQ(
-      name.get(BenchmarkName::ALL & ~BenchmarkName::REPETITIONS),
+      name.get(BenchmarkName::kAll & ~BenchmarkName::kRepetitions),
       "root/first:3/second:2/min_time:2/iterations:3/hammer_time/threads:6");
 
   EXPECT_EQ(
-      name.get(BenchmarkName::ALL & ~BenchmarkName::TIME_TYPE),
+      name.get(BenchmarkName::kAll & ~BenchmarkName::kTimeType),
       "root/first:3/second:2/min_time:2/iterations:3/repetitions:4/threads:6");
 
-  EXPECT_EQ(name.get(BenchmarkName::ALL & ~BenchmarkName::THREADS),
+  EXPECT_EQ(name.get(BenchmarkName::kAll & ~BenchmarkName::kThreads),
             "root/first:3/second:2/min_time:2/iterations:3/repetitions:4/"
             "hammer_time");
 
-  EXPECT_EQ(name.get(BenchmarkName::ALL &
-                     ~(BenchmarkName::THREADS | BenchmarkName::ARGS)),
+  EXPECT_EQ(name.get(BenchmarkName::kAll &
+                     ~(BenchmarkName::kThreads | BenchmarkName::kArgs)),
             "root/min_time:2/iterations:3/repetitions:4/hammer_time");
 
-  EXPECT_EQ(name.get(BenchmarkName::ROOT | BenchmarkName::THREADS),
+  EXPECT_EQ(name.get(BenchmarkName::kRoot | BenchmarkName::kThreads),
             "root/threads:6");
 }
 
 TEST(BenchmarkNameTest, TestEmptyRoot) {
   const auto name = BenchmarkName(std::string{})
-                        .append(BenchmarkName::ARGS, "first:3")
-                        .append(BenchmarkName::ARGS, "second:4")
-                        .append(BenchmarkName::THREADS, "threads:22");
+                        .append(BenchmarkName::kArgs, "first:3")
+                        .append(BenchmarkName::kArgs, "second:4")
+                        .append(BenchmarkName::kThreads, "threads:22");
 
-  EXPECT_FIELD(name, ALL, "first:3/second:4/threads:22");
-  EXPECT_FIELD(name, ARGS, "first:3/second:4");
-  EXPECT_FIELD(name, THREADS, "threads:22");
+  EXPECT_FIELD(name, kAll, "first:3/second:4/threads:22");
+  EXPECT_FIELD(name, kArgs, "first:3/second:4");
+  EXPECT_FIELD(name, kThreads, "threads:22");
 }
 
 #undef EXPECT_FIELD

--- a/test/complexity_test.cc
+++ b/test/complexity_test.cc
@@ -177,6 +177,26 @@ ADD_COMPLEXITY_CASES(n_lg_n_test_name, big_o_n_lg_n_test_name,
                      rms_o_n_lg_n_test_name, lambda_big_o_n_lg_n);
 
 // ========================================================================= //
+// -------- Testing formatting of Complexity with captured args ------------ //
+// ========================================================================= //
+
+void BM_ComplexityCaptureArgs(benchmark::State &state, int n) {
+  for (auto _ : state) {
+  }
+  state.SetComplexityN(n);
+}
+
+BENCHMARK_CAPTURE(BM_ComplexityCaptureArgs, capture_test, 100)
+    ->Complexity(benchmark::oN)
+    ->Ranges({{1, 2}, {3, 4}});
+
+const std::string complexity_capture_name =
+    "BM_ComplexityCaptureArgs/capture_test";
+
+ADD_COMPLEXITY_CASES(complexity_capture_name, complexity_capture_name + "_BigO",
+                     complexity_capture_name + "_RMS", "N");
+
+// ========================================================================= //
 // --------------------------- TEST CASES END ------------------------------ //
 // ========================================================================= //
 


### PR DESCRIPTION
A second attempt to fix #730, inspired by the suggestion by @LebedevRI  in https://github.com/google/benchmark/pull/760. I'm not sure it is exactly what you were suggesting (perhaps it is) but hopefully encapsulating the name in this way is a sensible thing to do.