### PR TITLE
Openmp compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,49 @@ BENCHMARK(BM_test)->Range(8, 8<<10)->UseRealTime();
 
 Without `UseRealTime`, CPU time is used by default.
 
+## CPU timers
+By default, the CPU timer only measures the time spent by the main thread.
+If the benchmark itself uses threads internally, this measurement may not
+be what you are looking for. Instead, there is a way to measure the total
+CPU usage of the process, by all the threads.
+
+```c++
+void callee(int i);
+
+static void MyMain(int size) {
+#pragma omp parallel for
+  for(int i = 0; i < size; i++)
+    callee(i);
+}
+
+static void BM_OpenMP(benchmark::State& state) {
+  for (auto _ : state)
+    MyMain(state.range(0);
+}
+
+// Measure the time spent by the main thread, use it to decide for how long to
+// run the benchmark loop. Depending on the internal implementation detail may
+// measure to anywhere from near-zero (the overhead spent before/after work
+// handoff to worker thread[s]) to the whole single-thread time.
+BENCHMARK(BM_OpenMP)->Range(8, 8<<10);
+
+// Measure the user-visible time, the wall clock (literally, the time that
+// has passed on the clock on the wall), use it to decide for how long to
+// run the benchmark loop. This will always be meaningful, an will match the
+// time spent by the main thread in single-threaded case, in general decreasing
+// with the number of internal threads doing the work.
+BENCHMARK(BM_OpenMP)->Range(8, 8<<10)->UseRealTime();
+
+// Measure the total CPU consumption, use it to decide for how long to
+// run the benchmark loop. This will always measure to no less than the
+// time spent by the main thread in single-threaded case.
+BENCHMARK(BM_OpenMP)->Range(8, 8<<10)->MeasureProcessCPUTime();
+
+// A mixture of the last two. Measure the total CPU consumption, but use the
+// wall clock to decide for how long to run the benchmark loop.
+BENCHMARK(BM_OpenMP)->Range(8, 8<<10)->MeasureProcessCPUTime()->UseRealTime();
+```
+
 ## Controlling timers
 Normally, the entire duration of the work loop (`for (auto _ : state) {}`)
 is measured. But sometimes, it is nessesary to do some work inside of

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -874,11 +874,18 @@ class Benchmark {
   // Same as ReportAggregatesOnly(), but applies to display reporter only.
   Benchmark* DisplayAggregatesOnly(bool value = true);
 
-  // If a particular benchmark is I/O bound, runs multiple threads internally or
-  // if for some reason CPU timings are not representative, call this method. If
-  // called, the elapsed time will be used to control how many iterations are
-  // run, and in the printing of items/second or MB/seconds values.  If not
-  // called, the cpu time used by the benchmark will be used.
+  // By default, the CPU time is measured only for the main thread, which may
+  // be unrepresentable if the benchmark uses threads internally. If called,
+  // the total CPU time spent by all the threads will be measured instead.
+  // By default, the only the main thread CPU time will be measured.
+  Benchmark* MeasureProcessCPUTime();
+
+  // If a particular benchmark should use the Wall clock instead of the CPU time
+  // (be it either the CPU time of the main thread only (default), or the
+  // total CPU usage of the benchmark), call this method. If called, the elapsed
+  // (wall) time will be used to control how many iterations are run, and in the
+  // printing of items/second or MB/seconds values.
+  // If not called, the CPU time used by the benchmark will be used.
   Benchmark* UseRealTime();
 
   // If a benchmark must measure time manually (e.g. if GPU execution time is
@@ -952,6 +959,7 @@ class Benchmark {
   double min_time_;
   size_t iterations_;
   int repetitions_;
+  bool measure_process_cpu_time_;
   bool use_real_time_;
   bool use_manual_time_;
   BigO complexity_;

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -875,7 +875,7 @@ class Benchmark {
   Benchmark* DisplayAggregatesOnly(bool value = true);
 
   // By default, the CPU time is measured only for the main thread, which may
-  // be unrepresentable if the benchmark uses threads internally. If called,
+  // be unrepresentative if the benchmark uses threads internally. If called,
   // the total CPU time spent by all the threads will be measured instead.
   // By default, the only the main thread CPU time will be measured.
   Benchmark* MeasureProcessCPUTime();

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -22,6 +22,7 @@ struct BenchmarkInstance {
   std::vector<int64_t> arg;
   TimeUnit time_unit;
   int range_multiplier;
+  bool measure_process_cpu_time;
   bool use_real_time;
   bool use_manual_time;
   BigO complexity;

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -165,6 +165,7 @@ bool BenchmarkFamilies::FindBenchmarks(
         instance.min_time = family->min_time_;
         instance.iterations = family->iterations_;
         instance.repetitions = family->repetitions_;
+        instance.measure_process_cpu_time = family->measure_process_cpu_time_;
         instance.use_real_time = family->use_real_time_;
         instance.use_manual_time = family->use_manual_time_;
         instance.complexity = family->complexity_;
@@ -201,6 +202,10 @@ bool BenchmarkFamilies::FindBenchmarks(
         if (family->repetitions_ != 0)
           instance.name.repetitions =
               StrFormat("repeats:%d", family->repetitions_);
+
+        if (family->measure_process_cpu_time_) {
+          instance.name += "/process_time";
+        }
 
         if (family->use_manual_time_) {
           instance.name.time_type = "manual_time";
@@ -252,6 +257,7 @@ Benchmark::Benchmark(const char* name)
       min_time_(0),
       iterations_(0),
       repetitions_(0),
+      measure_process_cpu_time_(false),
       use_real_time_(false),
       use_manual_time_(false),
       complexity_(oNone),
@@ -395,6 +401,12 @@ Benchmark* Benchmark::DisplayAggregatesOnly(bool value) {
         aggregation_report_mode_ & ~ARM_DisplayReportAggregatesOnly);
   }
 
+  return this;
+}
+
+Benchmark* Benchmark::MeasureProcessCPUTime() {
+  // Can be used together with UseRealTime() / UseManualTime().
+  measure_process_cpu_time_ = true;
   return this;
 }
 

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -204,13 +204,19 @@ bool BenchmarkFamilies::FindBenchmarks(
               StrFormat("repeats:%d", family->repetitions_);
 
         if (family->measure_process_cpu_time_) {
-          instance.name += "/process_time";
+          instance.name.time_type = "process_time";
         }
 
         if (family->use_manual_time_) {
-          instance.name.time_type = "manual_time";
+          if (!instance.name.time_type.empty()) {
+            instance.name.time_type += '/';
+          }
+          instance.name.time_type += "manual_time";
         } else if (family->use_real_time_) {
-          instance.name.time_type = "real_time";
+          if (!instance.name.time_type.empty()) {
+            instance.name.time_type += '/';
+          }
+          instance.name.time_type += "real_time";
         }
 
         // Add the number of threads used to the name

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -86,11 +86,7 @@ BenchmarkReporter::Run CreateRunReport(
     } else {
       report.real_accumulated_time = results.real_time_used;
     }
-    if (b.threads <= 1) {
-      report.cpu_accumulated_time = results.cpu_time_used;
-    } else {
-      report.cpu_accumulated_time = results.thread_cpu_time_used;
-    }
+    report.cpu_accumulated_time = results.cpu_time_used;
     report.complexity_n = results.complexity_n;
     report.complexity = b.complexity;
     report.complexity_lambda = b.complexity_lambda;
@@ -115,7 +111,7 @@ BenchmarkReporter::Run CreateRunReport(
 // Adds the stats collected for the thread into *total.
 void RunInThread(const BenchmarkInstance* b, size_t iters, int thread_id,
                  ThreadManager* manager) {
-  internal::ThreadTimer timer;
+  internal::ThreadTimer timer(b->measure_process_cpu_time);
   State st = b->Run(iters, thread_id, &timer, manager);
   CHECK(st.iterations() >= st.max_iterations)
       << "Benchmark returned before State::KeepRunning() returned false!";
@@ -123,7 +119,6 @@ void RunInThread(const BenchmarkInstance* b, size_t iters, int thread_id,
     MutexLock l(manager->GetBenchmarkMutex());
     internal::ThreadManager::Result& results = manager->results;
     results.iterations += st.iterations();
-    results.thread_cpu_time_used += timer.thread_cpu_time_used();
     results.cpu_time_used += timer.cpu_time_used();
     results.real_time_used += timer.real_time_used();
     results.manual_time_used += timer.manual_time_used();

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -86,7 +86,11 @@ BenchmarkReporter::Run CreateRunReport(
     } else {
       report.real_accumulated_time = results.real_time_used;
     }
-    report.cpu_accumulated_time = results.cpu_time_used;
+	if(b.threads <= 1){
+		report.cpu_accumulated_time = results.cpu_time_used;
+	}else{
+    	report.cpu_accumulated_time = results.thread_cpu_time_used;
+	}
     report.complexity_n = results.complexity_n;
     report.complexity = b.complexity;
     report.complexity_lambda = b.complexity_lambda;
@@ -119,6 +123,7 @@ void RunInThread(const BenchmarkInstance* b, size_t iters, int thread_id,
     MutexLock l(manager->GetBenchmarkMutex());
     internal::ThreadManager::Result& results = manager->results;
     results.iterations += st.iterations();
+	results.thread_cpu_time_used += timer.thread_cpu_time_used();
     results.cpu_time_used += timer.cpu_time_used();
     results.real_time_used += timer.real_time_used();
     results.manual_time_used += timer.manual_time_used();

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -111,7 +111,10 @@ BenchmarkReporter::Run CreateRunReport(
 // Adds the stats collected for the thread into *total.
 void RunInThread(const BenchmarkInstance* b, size_t iters, int thread_id,
                  ThreadManager* manager) {
-  internal::ThreadTimer timer(b->measure_process_cpu_time);
+  internal::ThreadTimer timer(
+      b->measure_process_cpu_time
+          ? internal::ThreadTimer::CreateProcessCpuTime()
+          : internal::ThreadTimer::Create());
   State st = b->Run(iters, thread_id, &timer, manager);
   CHECK(st.iterations() >= st.max_iterations)
       << "Benchmark returned before State::KeepRunning() returned false!";

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -86,11 +86,11 @@ BenchmarkReporter::Run CreateRunReport(
     } else {
       report.real_accumulated_time = results.real_time_used;
     }
-	if(b.threads <= 1){
-		report.cpu_accumulated_time = results.cpu_time_used;
-	}else{
-    	report.cpu_accumulated_time = results.thread_cpu_time_used;
-	}
+    if (b.threads <= 1) {
+      report.cpu_accumulated_time = results.cpu_time_used;
+    } else {
+      report.cpu_accumulated_time = results.thread_cpu_time_used;
+    }
     report.complexity_n = results.complexity_n;
     report.complexity = b.complexity;
     report.complexity_lambda = b.complexity_lambda;
@@ -123,7 +123,7 @@ void RunInThread(const BenchmarkInstance* b, size_t iters, int thread_id,
     MutexLock l(manager->GetBenchmarkMutex());
     internal::ThreadManager::Result& results = manager->results;
     results.iterations += st.iterations();
-	results.thread_cpu_time_used += timer.thread_cpu_time_used();
+    results.thread_cpu_time_used += timer.thread_cpu_time_used();
     results.cpu_time_used += timer.cpu_time_used();
     results.real_time_used += timer.real_time_used();
     results.manual_time_used += timer.manual_time_used();

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -226,6 +226,8 @@ class BenchmarkRunner {
     // Adjust real/manual time stats since they were reported per thread.
     i.results.real_time_used /= b.threads;
     i.results.manual_time_used /= b.threads;
+    // If we were measuring whole-process CPU usage, adjust the CPU time too.
+    if (b.measure_process_cpu_time) i.results.cpu_time_used /= b.threads;
 
     VLOG(2) << "Ran in " << i.results.cpu_time_used << "/"
             << i.results.real_time_used << "\n";

--- a/src/thread_manager.h
+++ b/src/thread_manager.h
@@ -40,6 +40,7 @@ class ThreadManager {
   struct Result {
     int64_t iterations = 0;
     double real_time_used = 0;
+	double thread_cpu_time_used = 0;
     double cpu_time_used = 0;
     double manual_time_used = 0;
     int64_t complexity_n = 0;

--- a/src/thread_manager.h
+++ b/src/thread_manager.h
@@ -40,7 +40,7 @@ class ThreadManager {
   struct Result {
     int64_t iterations = 0;
     double real_time_used = 0;
-	double thread_cpu_time_used = 0;
+    double thread_cpu_time_used = 0;
     double cpu_time_used = 0;
     double manual_time_used = 0;
     int64_t complexity_n = 0;

--- a/src/thread_manager.h
+++ b/src/thread_manager.h
@@ -40,7 +40,6 @@ class ThreadManager {
   struct Result {
     int64_t iterations = 0;
     double real_time_used = 0;
-    double thread_cpu_time_used = 0;
     double cpu_time_used = 0;
     double manual_time_used = 0;
     int64_t complexity_n = 0;

--- a/src/thread_timer.h
+++ b/src/thread_timer.h
@@ -15,11 +15,10 @@ class ThreadTimer {
 
   // Called by each thread
   void StartTimer() {
- std::cerr << "Timer start" << std::endl;
     running_ = true;
     start_real_time_ = ChronoClockNow();
-    //start_cpu_time_ = ThreadCPUUsage();
-	start_cpu_time_ = ProcessCPUUsage();
+    start_thread_cpu_time_ = ThreadCPUUsage();
+    start_cpu_time_ = ProcessCPUUsage();
   }
 
   // Called by each thread
@@ -29,9 +28,8 @@ class ThreadTimer {
     real_time_used_ += ChronoClockNow() - start_real_time_;
     // Floating point error can result in the subtraction producing a negative
     // time. Guard against that.
-    //cpu_time_used_ += std::max<double>(ThreadCPUUsage() - start_cpu_time_, 0);
-	cpu_time_used_ += std::max<double>(ProcessCPUUsage() - start_cpu_time_, 0);
-	std::cerr << "Timer stop" << std::endl;
+    thread_cpu_time_used_ += std::max<double>(ThreadCPUUsage() - start_thread_cpu_time_, 0);
+    cpu_time_used_ += std::max<double>(ProcessCPUUsage() - start_cpu_time_, 0);
   }
 
   // Called by each thread
@@ -51,6 +49,11 @@ class ThreadTimer {
     return cpu_time_used_;
   }
 
+  double thread_cpu_time_used() {
+    CHECK(!running_);
+    return thread_cpu_time_used_;
+  }
+
   // REQUIRES: timer is not running
   double manual_time_used() {
     CHECK(!running_);
@@ -61,10 +64,12 @@ class ThreadTimer {
   bool running_ = false;        // Is the timer running
   double start_real_time_ = 0;  // If running_
   double start_cpu_time_ = 0;   // If running_
+  double start_thread_cpu_time_ = 0;   // If running_
 
   // Accumulated time so far (does not contain current slice if running_)
   double real_time_used_ = 0;
   double cpu_time_used_ = 0;
+  double thread_cpu_time_used_ = 0;
   // Manually set iteration time. User sets this with SetIterationTime(seconds).
   double manual_time_used_ = 0;
 };

--- a/src/thread_timer.h
+++ b/src/thread_timer.h
@@ -4,6 +4,8 @@
 #include "check.h"
 #include "timers.h"
 
+#include <iostream>
+
 namespace benchmark {
 namespace internal {
 
@@ -13,9 +15,11 @@ class ThreadTimer {
 
   // Called by each thread
   void StartTimer() {
+ std::cerr << "Timer start" << std::endl;
     running_ = true;
     start_real_time_ = ChronoClockNow();
-    start_cpu_time_ = ThreadCPUUsage();
+    //start_cpu_time_ = ThreadCPUUsage();
+	start_cpu_time_ = ProcessCPUUsage();
   }
 
   // Called by each thread
@@ -25,7 +29,9 @@ class ThreadTimer {
     real_time_used_ += ChronoClockNow() - start_real_time_;
     // Floating point error can result in the subtraction producing a negative
     // time. Guard against that.
-    cpu_time_used_ += std::max<double>(ThreadCPUUsage() - start_cpu_time_, 0);
+    //cpu_time_used_ += std::max<double>(ThreadCPUUsage() - start_cpu_time_, 0);
+	cpu_time_used_ += std::max<double>(ProcessCPUUsage() - start_cpu_time_, 0);
+	std::cerr << "Timer stop" << std::endl;
   }
 
   // Called by each thread

--- a/src/thread_timer.h
+++ b/src/thread_timer.h
@@ -28,7 +28,8 @@ class ThreadTimer {
     real_time_used_ += ChronoClockNow() - start_real_time_;
     // Floating point error can result in the subtraction producing a negative
     // time. Guard against that.
-    thread_cpu_time_used_ += std::max<double>(ThreadCPUUsage() - start_thread_cpu_time_, 0);
+    thread_cpu_time_used_ +=
+        std::max<double>(ThreadCPUUsage() - start_thread_cpu_time_, 0);
     cpu_time_used_ += std::max<double>(ProcessCPUUsage() - start_cpu_time_, 0);
   }
 
@@ -64,7 +65,7 @@ class ThreadTimer {
   bool running_ = false;        // Is the timer running
   double start_real_time_ = 0;  // If running_
   double start_cpu_time_ = 0;   // If running_
-  double start_thread_cpu_time_ = 0;   // If running_
+  double start_thread_cpu_time_ = 0;  // If running_
 
   // Accumulated time so far (does not contain current slice if running_)
   double real_time_used_ = 0;

--- a/src/thread_timer.h
+++ b/src/thread_timer.h
@@ -8,9 +8,16 @@ namespace benchmark {
 namespace internal {
 
 class ThreadTimer {
- public:
-  ThreadTimer(bool measure_process_cpu_time_)
+  explicit ThreadTimer(bool measure_process_cpu_time_)
       : measure_process_cpu_time(measure_process_cpu_time_) {}
+
+ public:
+  static ThreadTimer Create() {
+    return ThreadTimer(/*measure_process_cpu_time_=*/false);
+  }
+  static ThreadTimer CreateProcessCpuTime() {
+    return ThreadTimer(/*measure_process_cpu_time_=*/true);
+  }
 
   // Called by each thread
   void StartTimer() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -125,6 +125,9 @@ add_test(templated_fixture_test templated_fixture_test --benchmark_min_time=0.01
 compile_output_test(user_counters_test)
 add_test(user_counters_test user_counters_test --benchmark_min_time=0.01)
 
+compile_output_test(internal_threading_test)
+add_test(internal_threading_test internal_threading_test --benchmark_min_time=0.01)
+
 compile_output_test(report_aggregates_only_test)
 add_test(report_aggregates_only_test report_aggregates_only_test --benchmark_min_time=0.01)
 

--- a/test/internal_threading_test.cc
+++ b/test/internal_threading_test.cc
@@ -62,7 +62,7 @@ ADD_CASES(TC_JSONOut,
            {"\"time_unit\": \"ns\",$", MR_Next},
            {"\"invtime\":", MR_Next},
            {"}", MR_Next}});
-ADD_CASES(TC_CSVOut, {{"^\"BM_MainThread/iterations:1\",%csv_report,%float$"}});
+ADD_CASES(TC_CSVOut, {{"^\"BM_MainThread/iterations:1\",%csv_report,[^,]+"}});
 void CheckTestVariantZero(Results const& e) {
   // check that the values are within 10% of the expected values
   CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.1);
@@ -86,7 +86,7 @@ ADD_CASES(TC_JSONOut,
            {"\"invtime\":", MR_Next},
            {"}", MR_Next}});
 ADD_CASES(TC_CSVOut,
-          {{"^\"BM_MainThread/iterations:1/real_time\",%csv_report,%float$"}});
+          {{"^\"BM_MainThread/iterations:1/real_time\",%csv_report,[^,]+"}});
 CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1/real_time",
                         &CheckTestVariantZero);
 
@@ -104,9 +104,8 @@ ADD_CASES(TC_JSONOut,
            {"\"time_unit\": \"ns\",$", MR_Next},
            {"\"invtime\":", MR_Next},
            {"}", MR_Next}});
-ADD_CASES(
-    TC_CSVOut,
-    {{"^\"BM_MainThread/iterations:1/process_time\",%csv_report,%float$"}});
+ADD_CASES(TC_CSVOut,
+          {{"^\"BM_MainThread/iterations:1/process_time\",%csv_report,[^,]+"}});
 CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1/process_time",
                         &CheckTestVariantZero);
 
@@ -126,7 +125,7 @@ ADD_CASES(
      {"\"invtime\":", MR_Next},
      {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_MainThread/iterations:1/process_time/"
-                       "real_time\",%csv_report,%float$"}});
+                       "real_time\",%csv_report,[^,]+"}});
 CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1/process_time/real_time",
                         &CheckTestVariantZero);
 
@@ -154,8 +153,7 @@ ADD_CASES(TC_JSONOut,
            {"\"time_unit\": \"ns\",$", MR_Next},
            {"\"invtime\":", MR_Next},
            {"}", MR_Next}});
-ADD_CASES(TC_CSVOut,
-          {{"^\"BM_WorkerThread/iterations:1\",%csv_report,%float$"}});
+ADD_CASES(TC_CSVOut, {{"^\"BM_WorkerThread/iterations:1\",%csv_report,[^,]+"}});
 void CheckTestVariantOne(Results const& e) {
   // check that the value is within 10% of the expected
   CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.1);
@@ -180,9 +178,8 @@ ADD_CASES(TC_JSONOut,
            {"\"time_unit\": \"ns\",$", MR_Next},
            {"\"invtime\":", MR_Next},
            {"}", MR_Next}});
-ADD_CASES(
-    TC_CSVOut,
-    {{"^\"BM_WorkerThread/iterations:1/real_time\",%csv_report,%float$"}});
+ADD_CASES(TC_CSVOut,
+          {{"^\"BM_WorkerThread/iterations:1/real_time\",%csv_report,[^,]+"}});
 CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1/real_time$",
                         &CheckTestVariantOne);
 
@@ -202,7 +199,7 @@ ADD_CASES(TC_JSONOut,
            {"}", MR_Next}});
 ADD_CASES(
     TC_CSVOut,
-    {{"^\"BM_WorkerThread/iterations:1/process_time\",%csv_report,%float$"}});
+    {{"^\"BM_WorkerThread/iterations:1/process_time\",%csv_report,[^,]+"}});
 void CheckTestVariantTwo(Results const& e) {
   // check that the values are within 10% of the expected values
   CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
@@ -231,7 +228,7 @@ ADD_CASES(
      {"\"invtime\":", MR_Next},
      {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_WorkerThread/iterations:1/process_time/"
-                       "real_time\",%csv_report,%float$"}});
+                       "real_time\",%csv_report,[^,]+"}});
 CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1/process_time/real_time$",
                         &CheckTestVariantTwo);
 
@@ -263,7 +260,7 @@ ADD_CASES(TC_JSONOut,
            {"}", MR_Next}});
 ADD_CASES(
     TC_CSVOut,
-    {{"^\"BM_MainThreadAndWorkerThread/iterations:1\",%csv_report,%float$"}});
+    {{"^\"BM_MainThreadAndWorkerThread/iterations:1\",%csv_report,[^,]+"}});
 CHECK_BENCHMARK_RESULTS("BM_MainThreadAndWorkerThread/iterations:1$",
                         &CheckTestVariantTwo);
 
@@ -283,7 +280,7 @@ ADD_CASES(
      {"\"invtime\":", MR_Next},
      {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
-                       "real_time\",%csv_report,%float$"}});
+                       "real_time\",%csv_report,[^,]+"}});
 CHECK_BENCHMARK_RESULTS("BM_MainThreadAndWorkerThread/iterations:1/real_time$",
                         &CheckTestVariantTwo);
 
@@ -304,7 +301,7 @@ ADD_CASES(
      {"\"invtime\":", MR_Next},
      {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
-                       "process_time\",%csv_report,%float$"}});
+                       "process_time\",%csv_report,[^,]+"}});
 void CheckTestVariantThree(Results const& e) {
   // check that the values are within 10% of the expected values
   CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
@@ -338,7 +335,7 @@ ADD_CASES(
      {"\"invtime\":", MR_Next},
      {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
-                       "process_time/real_time\",%csv_report,%float$"}});
+                       "process_time/real_time\",%csv_report,[^,]+"}});
 void CheckTestVariantFour(Results const& e) {
   // check that the values are within 10% of the expected values
   CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);

--- a/test/internal_threading_test.cc
+++ b/test/internal_threading_test.cc
@@ -162,9 +162,9 @@ void CheckTestVariantOne(Results const& e) {
   // check that the value is within 10% of the expected
   CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.1);
   // check that the cpu time is between 0 and (wall time / 100)
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, (time_frame_in_ns / 100.), 2.0);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / (time_frame_in_sec / 100.0),
-                            2.0);
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, (time_frame_in_ns / 50.), 1.0);
+  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / (time_frame_in_sec / 200.0),
+                            1.0);
 }
 CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1$", &CheckTestVariantOne);
 
@@ -207,9 +207,9 @@ ADD_CASES(
     {{"^\"BM_WorkerThread/iterations:1/process_time\",%csv_report,%float$"}});
 void CheckTestVariantTwo(Results const& e) {
   // check that the values are within 10% of the expected values
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.1);
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, time_frame_in_ns, 0.1);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.1);
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, time_frame_in_ns, 0.33);
+  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.33);
 }
 CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1/process_time$",
                         &CheckTestVariantTwo);
@@ -345,8 +345,8 @@ ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
 void CheckTestVariantFour(Results const& e) {
   // check that the values are within 10% of the expected values
   CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, 2.0 * time_frame_in_ns, 0.1);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.1);
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, 2.0 * time_frame_in_ns, 0.33);
+  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.33);
 }
 CHECK_BENCHMARK_RESULTS(
     "BM_MainThreadAndWorkerThread/iterations:1/process_time/real_time$",

--- a/test/internal_threading_test.cc
+++ b/test/internal_threading_test.cc
@@ -65,9 +65,9 @@ ADD_CASES(TC_JSONOut,
 ADD_CASES(TC_CSVOut, {{"^\"BM_MainThread/iterations:1\",%csv_report,[^,]+"}});
 void CheckTestVariantZero(Results const& e) {
   // check that the values are within 10% of the expected values
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.1);
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, time_frame_in_ns, 0.1);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.1);
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, time_frame_in_ns, 0.33);
+  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.33);
 }
 CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1$", &CheckTestVariantZero);
 
@@ -156,7 +156,7 @@ ADD_CASES(TC_JSONOut,
 ADD_CASES(TC_CSVOut, {{"^\"BM_WorkerThread/iterations:1\",%csv_report,[^,]+"}});
 void CheckTestVariantOne(Results const& e) {
   // check that the value is within 10% of the expected
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.1);
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
   // check that the cpu time is between 0 and (wall time / 100)
   CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, (time_frame_in_ns / 50.), 1.0);
   CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / (time_frame_in_sec / 200.0),
@@ -305,9 +305,9 @@ ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
 void CheckTestVariantThree(Results const& e) {
   // check that the values are within 10% of the expected values
   CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, 2.0 * time_frame_in_ns, 0.1);
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, 2.0 * time_frame_in_ns, 0.33);
   CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / (2. * time_frame_in_sec),
-                            0.1);
+                            0.33);
 }
 CHECK_BENCHMARK_RESULTS(
     "BM_MainThreadAndWorkerThread/iterations:1/process_time$",

--- a/test/internal_threading_test.cc
+++ b/test/internal_threading_test.cc
@@ -64,10 +64,10 @@ ADD_CASES(TC_JSONOut,
            {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_MainThread/iterations:1\",%csv_report,[^,]+"}});
 void CheckTestVariantZero(Results const& e) {
-  // check that the values are within 10% of the expected values
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, time_frame_in_ns, 0.33);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.33);
+  // check that the values are within 50% of the expected values
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.5);
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, time_frame_in_ns, 0.5);
+  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.5);
 }
 CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1$", &CheckTestVariantZero);
 
@@ -155,8 +155,8 @@ ADD_CASES(TC_JSONOut,
            {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_WorkerThread/iterations:1\",%csv_report,[^,]+"}});
 void CheckTestVariantOne(Results const& e) {
-  // check that the value is within 10% of the expected
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
+  // check that the value is within 50% of the expected
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.5);
   // check that the cpu time is between 0 and (wall time / 100)
   CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, (time_frame_in_ns / 25.), 1.0);
   CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / (time_frame_in_sec / 500.0),
@@ -201,10 +201,10 @@ ADD_CASES(
     TC_CSVOut,
     {{"^\"BM_WorkerThread/iterations:1/process_time\",%csv_report,[^,]+"}});
 void CheckTestVariantTwo(Results const& e) {
-  // check that the values are within 10% of the expected values
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, time_frame_in_ns, 0.33);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.33);
+  // check that the values are within 50% of the expected values
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.5);
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, time_frame_in_ns, 0.5);
+  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.5);
 }
 CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1/process_time$",
                         &CheckTestVariantTwo);
@@ -303,11 +303,11 @@ ADD_CASES(
 ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
                        "process_time\",%csv_report,[^,]+"}});
 void CheckTestVariantThree(Results const& e) {
-  // check that the values are within 10% of the expected values
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, 2.0 * time_frame_in_ns, 0.33);
+  // check that the values are within 50% of the expected values
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.5);
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, 2.0 * time_frame_in_ns, 0.5);
   CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / (2. * time_frame_in_sec),
-                            0.33);
+                            0.5);
 }
 CHECK_BENCHMARK_RESULTS(
     "BM_MainThreadAndWorkerThread/iterations:1/process_time$",
@@ -337,10 +337,10 @@ ADD_CASES(
 ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
                        "process_time/real_time\",%csv_report,[^,]+"}});
 void CheckTestVariantFour(Results const& e) {
-  // check that the values are within 10% of the expected values
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, 2.0 * time_frame_in_ns, 0.33);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.33);
+  // check that the values are within 50% of the expected values
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.5);
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, 2.0 * time_frame_in_ns, 0.5);
+  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.5);
 }
 CHECK_BENCHMARK_RESULTS(
     "BM_MainThreadAndWorkerThread/iterations:1/process_time/real_time$",

--- a/test/internal_threading_test.cc
+++ b/test/internal_threading_test.cc
@@ -1,0 +1,312 @@
+
+#undef NDEBUG
+
+#include <chrono>
+#include <thread>
+#include "benchmark/benchmark.h"
+#include "output_test.h"
+
+static const std::chrono::duration<double, std::milli> time_frame(50);
+static const double time_frame_in_ns(
+    std::chrono::duration_cast<std::chrono::nanoseconds>(time_frame).count());
+
+void MyBusySpinwait() {
+  const auto start = std::chrono::high_resolution_clock::now();
+
+  while (true) {
+    const auto now = std::chrono::high_resolution_clock::now();
+    const auto elapsed = now - start;
+
+    if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed) >=
+        std::chrono::duration<double, std::milli>(50))
+      return;
+  }
+}
+
+// ========================================================================= //
+// --------------------------- TEST CASES BEGIN ---------------------------- //
+// ========================================================================= //
+
+ADD_CASES(TC_ConsoleOut, {{"^[-]+$", MR_Next},
+                          {"^Benchmark %s Time %s CPU %s Iterations$", MR_Next},
+                          {"^[-]+$", MR_Next}});
+ADD_CASES(TC_CSVOut, {{"%csv_header"}});
+
+// ========================================================================= //
+// BM_MainThread
+
+void BM_MainThread(benchmark::State& state) {
+  for (auto _ : state) MyBusySpinwait();
+}
+
+BENCHMARK(BM_MainThread)->Iterations(1);
+ADD_CASES(TC_ConsoleOut, {{"^BM_MainThread/iterations:1 %console_report$"}});
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_MainThread/iterations:1\",$"},
+           {"\"run_name\": \"BM_MainThread/iterations:1\",$", MR_Next},
+           {"\"run_type\": \"iteration\",$", MR_Next},
+           {"\"iterations\": 1,$", MR_Next},
+           {"\"real_time\": %float,$", MR_Next},
+           {"\"cpu_time\": %float,$", MR_Next},
+           {"\"time_unit\": \"ns\"$", MR_Next},
+           {"}", MR_Next}});
+ADD_CASES(TC_CSVOut, {{"^\"BM_MainThread/iterations:1\",%csv_report$"}});
+void CheckTestVariantZero(Results const& e) {
+  // check that the values are within 10% of the expected values
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.1);
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, time_frame_in_ns, 0.1);
+}
+CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1$", &CheckTestVariantZero);
+
+BENCHMARK(BM_MainThread)->Iterations(1)->UseRealTime();
+ADD_CASES(TC_ConsoleOut,
+          {{"^BM_MainThread/iterations:1/real_time %console_report$"}});
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_MainThread/iterations:1/real_time\",$"},
+           {"\"run_name\": \"BM_MainThread/iterations:1/real_time\",$",
+            MR_Next},
+           {"\"run_type\": \"iteration\",$", MR_Next},
+           {"\"iterations\": 1,$", MR_Next},
+           {"\"real_time\": %float,$", MR_Next},
+           {"\"cpu_time\": %float,$", MR_Next},
+           {"\"time_unit\": \"ns\"$", MR_Next},
+           {"}", MR_Next}});
+ADD_CASES(TC_CSVOut,
+          {{"^\"BM_MainThread/iterations:1/real_time\",%csv_report$"}});
+CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1/real_time",
+                        &CheckTestVariantZero);
+
+BENCHMARK(BM_MainThread)->Iterations(1)->MeasureProcessCPUTime();
+ADD_CASES(TC_ConsoleOut,
+          {{"^BM_MainThread/iterations:1/process_time %console_report$"}});
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_MainThread/iterations:1/process_time\",$"},
+           {"\"run_name\": \"BM_MainThread/iterations:1/process_time\",$",
+            MR_Next},
+           {"\"run_type\": \"iteration\",$", MR_Next},
+           {"\"iterations\": 1,$", MR_Next},
+           {"\"real_time\": %float,$", MR_Next},
+           {"\"cpu_time\": %float,$", MR_Next},
+           {"\"time_unit\": \"ns\"$", MR_Next},
+           {"}", MR_Next}});
+ADD_CASES(TC_CSVOut,
+          {{"^\"BM_MainThread/iterations:1/process_time\",%csv_report$"}});
+CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1/process_time",
+                        &CheckTestVariantZero);
+
+BENCHMARK(BM_MainThread)->Iterations(1)->MeasureProcessCPUTime()->UseRealTime();
+ADD_CASES(
+    TC_ConsoleOut,
+    {{"^BM_MainThread/iterations:1/process_time/real_time %console_report$"}});
+ADD_CASES(
+    TC_JSONOut,
+    {{"\"name\": \"BM_MainThread/iterations:1/process_time/real_time\",$"},
+     {"\"run_name\": \"BM_MainThread/iterations:1/process_time/real_time\",$",
+      MR_Next},
+     {"\"run_type\": \"iteration\",$", MR_Next},
+     {"\"iterations\": 1,$", MR_Next},
+     {"\"real_time\": %float,$", MR_Next},
+     {"\"cpu_time\": %float,$", MR_Next},
+     {"\"time_unit\": \"ns\"$", MR_Next},
+     {"}", MR_Next}});
+ADD_CASES(
+    TC_CSVOut,
+    {{"^\"BM_MainThread/iterations:1/process_time/real_time\",%csv_report$"}});
+CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1/process_time/real_time",
+                        &CheckTestVariantZero);
+
+// ========================================================================= //
+// BM_WorkerThread
+
+void BM_WorkerThread(benchmark::State& state) {
+  for (auto _ : state) {
+    std::thread Worker(&MyBusySpinwait);
+    Worker.join();
+  }
+}
+BENCHMARK(BM_WorkerThread)->Iterations(1);
+ADD_CASES(TC_ConsoleOut, {{"^BM_WorkerThread/iterations:1 %console_report$"}});
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_WorkerThread/iterations:1\",$"},
+           {"\"run_name\": \"BM_WorkerThread/iterations:1\",$", MR_Next},
+           {"\"run_type\": \"iteration\",$", MR_Next},
+           {"\"iterations\": 1,$", MR_Next},
+           {"\"real_time\": %float,$", MR_Next},
+           {"\"cpu_time\": %float,$", MR_Next},
+           {"\"time_unit\": \"ns\"$", MR_Next},
+           {"}", MR_Next}});
+ADD_CASES(TC_CSVOut, {{"^\"BM_WorkerThread/iterations:1\",%csv_report$"}});
+void CheckTestVariantOne(Results const& e) {
+  // check that the value is within 10% of the expected
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.1);
+  // check that the cpu time is between 0 and (wall time / 100)
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, (time_frame_in_ns / 100.), 2.0);
+}
+CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1$", &CheckTestVariantOne);
+
+BENCHMARK(BM_WorkerThread)->Iterations(1)->UseRealTime();
+ADD_CASES(TC_ConsoleOut,
+          {{"^BM_WorkerThread/iterations:1/real_time %console_report$"}});
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_WorkerThread/iterations:1/real_time\",$"},
+           {"\"run_name\": \"BM_WorkerThread/iterations:1/real_time\",$",
+            MR_Next},
+           {"\"run_type\": \"iteration\",$", MR_Next},
+           {"\"iterations\": 1,$", MR_Next},
+           {"\"real_time\": %float,$", MR_Next},
+           {"\"cpu_time\": %float,$", MR_Next},
+           {"\"time_unit\": \"ns\"$", MR_Next},
+           {"}", MR_Next}});
+ADD_CASES(TC_CSVOut,
+          {{"^\"BM_WorkerThread/iterations:1/real_time\",%csv_report$"}});
+CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1/real_time$",
+                        &CheckTestVariantOne);
+
+BENCHMARK(BM_WorkerThread)->Iterations(1)->MeasureProcessCPUTime();
+ADD_CASES(TC_ConsoleOut,
+          {{"^BM_WorkerThread/iterations:1/process_time %console_report$"}});
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_WorkerThread/iterations:1/process_time\",$"},
+           {"\"run_name\": \"BM_WorkerThread/iterations:1/process_time\",$",
+            MR_Next},
+           {"\"run_type\": \"iteration\",$", MR_Next},
+           {"\"iterations\": 1,$", MR_Next},
+           {"\"real_time\": %float,$", MR_Next},
+           {"\"cpu_time\": %float,$", MR_Next},
+           {"\"time_unit\": \"ns\"$", MR_Next},
+           {"}", MR_Next}});
+ADD_CASES(TC_CSVOut,
+          {{"^\"BM_WorkerThread/iterations:1/process_time\",%csv_report$"}});
+void CheckTestVariantTwo(Results const& e) {
+  // check that the values are within 10% of the expected values
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.1);
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, time_frame_in_ns, 0.1);
+}
+CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1/process_time$",
+                        &CheckTestVariantTwo);
+
+BENCHMARK(BM_WorkerThread)
+    ->Iterations(1)
+    ->MeasureProcessCPUTime()
+    ->UseRealTime();
+ADD_CASES(TC_ConsoleOut, {{"^BM_WorkerThread/iterations:1/process_time/"
+                           "real_time %console_report$"}});
+ADD_CASES(
+    TC_JSONOut,
+    {{"\"name\": \"BM_WorkerThread/iterations:1/process_time/real_time\",$"},
+     {"\"run_name\": \"BM_WorkerThread/iterations:1/process_time/real_time\",$",
+      MR_Next},
+     {"\"run_type\": \"iteration\",$", MR_Next},
+     {"\"iterations\": 1,$", MR_Next},
+     {"\"real_time\": %float,$", MR_Next},
+     {"\"cpu_time\": %float,$", MR_Next},
+     {"\"time_unit\": \"ns\"$", MR_Next},
+     {"}", MR_Next}});
+ADD_CASES(TC_CSVOut, {{"^\"BM_WorkerThread/iterations:1/process_time/"
+                       "real_time\",%csv_report$"}});
+CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1/process_time/real_time$",
+                        &CheckTestVariantTwo);
+
+// ========================================================================= //
+// BM_MainThreadAndWorkerThread
+
+void BM_MainThreadAndWorkerThread(benchmark::State& state) {
+  for (auto _ : state) {
+    std::thread Worker(&MyBusySpinwait);
+    MyBusySpinwait();
+    Worker.join();
+  }
+}
+BENCHMARK(BM_MainThreadAndWorkerThread)->Iterations(1);
+ADD_CASES(TC_ConsoleOut,
+          {{"^BM_MainThreadAndWorkerThread/iterations:1 %console_report$"}});
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_MainThreadAndWorkerThread/iterations:1\",$"},
+           {"\"run_name\": \"BM_MainThreadAndWorkerThread/iterations:1\",$",
+            MR_Next},
+           {"\"run_type\": \"iteration\",$", MR_Next},
+           {"\"iterations\": 1,$", MR_Next},
+           {"\"real_time\": %float,$", MR_Next},
+           {"\"cpu_time\": %float,$", MR_Next},
+           {"\"time_unit\": \"ns\"$", MR_Next},
+           {"}", MR_Next}});
+ADD_CASES(TC_CSVOut,
+          {{"^\"BM_MainThreadAndWorkerThread/iterations:1\",%csv_report$"}});
+CHECK_BENCHMARK_RESULTS("BM_MainThreadAndWorkerThread/iterations:1$",
+                        &CheckTestVariantTwo);
+
+BENCHMARK(BM_MainThreadAndWorkerThread)->Iterations(1)->UseRealTime();
+ADD_CASES(TC_ConsoleOut, {{"^BM_MainThreadAndWorkerThread/iterations:1/"
+                           "real_time %console_report$"}});
+ADD_CASES(
+    TC_JSONOut,
+    {{"\"name\": \"BM_MainThreadAndWorkerThread/iterations:1/real_time\",$"},
+     {"\"run_name\": \"BM_MainThreadAndWorkerThread/iterations:1/real_time\",$",
+      MR_Next},
+     {"\"run_type\": \"iteration\",$", MR_Next},
+     {"\"iterations\": 1,$", MR_Next},
+     {"\"real_time\": %float,$", MR_Next},
+     {"\"cpu_time\": %float,$", MR_Next},
+     {"\"time_unit\": \"ns\"$", MR_Next},
+     {"}", MR_Next}});
+ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
+                       "real_time\",%csv_report$"}});
+CHECK_BENCHMARK_RESULTS("BM_MainThreadAndWorkerThread/iterations:1/real_time$",
+                        &CheckTestVariantTwo);
+
+BENCHMARK(BM_MainThreadAndWorkerThread)->Iterations(1)->MeasureProcessCPUTime();
+ADD_CASES(TC_ConsoleOut, {{"^BM_MainThreadAndWorkerThread/iterations:1/"
+                           "process_time %console_report$"}});
+ADD_CASES(
+    TC_JSONOut,
+    {{"\"name\": \"BM_MainThreadAndWorkerThread/iterations:1/process_time\",$"},
+     {"\"run_name\": "
+      "\"BM_MainThreadAndWorkerThread/iterations:1/process_time\",$",
+      MR_Next},
+     {"\"run_type\": \"iteration\",$", MR_Next},
+     {"\"iterations\": 1,$", MR_Next},
+     {"\"real_time\": %float,$", MR_Next},
+     {"\"cpu_time\": %float,$", MR_Next},
+     {"\"time_unit\": \"ns\"$", MR_Next},
+     {"}", MR_Next}});
+ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
+                       "process_time\",%csv_report$"}});
+void CheckTestVariantThree(Results const& e) {
+  // check that the values are within 10% of the expected values
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.1);
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, 2.0 * time_frame_in_ns, 0.1);
+}
+CHECK_BENCHMARK_RESULTS(
+    "BM_MainThreadAndWorkerThread/iterations:1/process_time$",
+    &CheckTestVariantThree);
+
+BENCHMARK(BM_MainThreadAndWorkerThread)
+    ->Iterations(1)
+    ->MeasureProcessCPUTime()
+    ->UseRealTime();
+ADD_CASES(TC_ConsoleOut, {{"^BM_MainThreadAndWorkerThread/iterations:1/"
+                           "process_time/real_time %console_report$"}});
+ADD_CASES(
+    TC_JSONOut,
+    {{"\"name\": "
+      "\"BM_MainThreadAndWorkerThread/iterations:1/process_time/real_time\",$"},
+     {"\"run_name\": "
+      "\"BM_MainThreadAndWorkerThread/iterations:1/process_time/real_time\",$",
+      MR_Next},
+     {"\"run_type\": \"iteration\",$", MR_Next},
+     {"\"iterations\": 1,$", MR_Next},
+     {"\"real_time\": %float,$", MR_Next},
+     {"\"cpu_time\": %float,$", MR_Next},
+     {"\"time_unit\": \"ns\"$", MR_Next},
+     {"}", MR_Next}});
+ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
+                       "process_time/real_time\",%csv_report$"}});
+CHECK_BENCHMARK_RESULTS(
+    "BM_MainThreadAndWorkerThread/iterations:1/process_time/real_time$",
+    &CheckTestVariantThree);
+
+// ========================================================================= //
+// ---------------------------- TEST CASES END ----------------------------- //
+// ========================================================================= //
+
+int main(int argc, char* argv[]) { RunOutputTests(argc, argv); }

--- a/test/internal_threading_test.cc
+++ b/test/internal_threading_test.cc
@@ -310,7 +310,7 @@ ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
                        "process_time\",%csv_report,%float$"}});
 void CheckTestVariantThree(Results const& e) {
   // check that the values are within 10% of the expected values
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.1);
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
   CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, 2.0 * time_frame_in_ns, 0.1);
   CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / (2. * time_frame_in_sec),
                             0.1);
@@ -344,7 +344,7 @@ ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
                        "process_time/real_time\",%csv_report,%float$"}});
 void CheckTestVariantFour(Results const& e) {
   // check that the values are within 10% of the expected values
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.1);
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
   CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, 2.0 * time_frame_in_ns, 0.1);
   CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.1);
 }

--- a/test/internal_threading_test.cc
+++ b/test/internal_threading_test.cc
@@ -158,8 +158,8 @@ void CheckTestVariantOne(Results const& e) {
   // check that the value is within 10% of the expected
   CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.33);
   // check that the cpu time is between 0 and (wall time / 100)
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, (time_frame_in_ns / 50.), 1.0);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / (time_frame_in_sec / 200.0),
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, (time_frame_in_ns / 25.), 1.0);
+  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / (time_frame_in_sec / 500.0),
                             1.0);
 }
 CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1$", &CheckTestVariantOne);

--- a/test/internal_threading_test.cc
+++ b/test/internal_threading_test.cc
@@ -3,6 +3,7 @@
 
 #include <chrono>
 #include <thread>
+#include "../src/timers.h"
 #include "benchmark/benchmark.h"
 #include "output_test.h"
 
@@ -17,14 +18,14 @@ static const double time_frame_in_sec(
         .count());
 
 void MyBusySpinwait() {
-  const auto start = std::chrono::high_resolution_clock::now();
+  const auto start = benchmark::ChronoClockNow();
 
   while (true) {
-    const auto now = std::chrono::high_resolution_clock::now();
+    const auto now = benchmark::ChronoClockNow();
     const auto elapsed = now - start;
 
-    if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed) >=
-        std::chrono::duration<double, std::milli>(50))
+    if (std::chrono::duration<double, std::chrono::seconds::period>(elapsed) >=
+        time_frame)
       return;
   }
 }
@@ -204,7 +205,7 @@ void CheckTestVariantTwo(Results const& e) {
   // check that the values are within 50% of the expected values
   CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.5);
   CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, time_frame_in_ns, 0.5);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.5);
+  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 1.0);
 }
 CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1/process_time$",
                         &CheckTestVariantTwo);

--- a/test/internal_threading_test.cc
+++ b/test/internal_threading_test.cc
@@ -50,9 +50,8 @@ void BM_MainThread(benchmark::State& state) {
 }
 
 BENCHMARK(BM_MainThread)->Iterations(1);
-ADD_CASES(
-    TC_ConsoleOut,
-    {{"^BM_MainThread/iterations:1 %console_report invtime=%hrfloat/s$"}});
+ADD_CASES(TC_ConsoleOut,
+          {{"^BM_MainThread/iterations:1 %console_report invtime=[^/]+/s$"}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_MainThread/iterations:1\",$"},
            {"\"run_name\": \"BM_MainThread/iterations:1\",$", MR_Next},
@@ -61,7 +60,7 @@ ADD_CASES(TC_JSONOut,
            {"\"real_time\": %float,$", MR_Next},
            {"\"cpu_time\": %float,$", MR_Next},
            {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\": %float$", MR_Next},
+           {"\"invtime\":", MR_Next},
            {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_MainThread/iterations:1\",%csv_report,%float$"}});
 void CheckTestVariantZero(Results const& e) {
@@ -74,7 +73,7 @@ CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1$", &CheckTestVariantZero);
 
 BENCHMARK(BM_MainThread)->Iterations(1)->UseRealTime();
 ADD_CASES(TC_ConsoleOut, {{"^BM_MainThread/iterations:1/real_time "
-                           "%console_report invtime=%hrfloat/s$"}});
+                           "%console_report invtime=[^/]+/s$"}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_MainThread/iterations:1/real_time\",$"},
            {"\"run_name\": \"BM_MainThread/iterations:1/real_time\",$",
@@ -84,7 +83,7 @@ ADD_CASES(TC_JSONOut,
            {"\"real_time\": %float,$", MR_Next},
            {"\"cpu_time\": %float,$", MR_Next},
            {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\": %float$", MR_Next},
+           {"\"invtime\":", MR_Next},
            {"}", MR_Next}});
 ADD_CASES(TC_CSVOut,
           {{"^\"BM_MainThread/iterations:1/real_time\",%csv_report,%float$"}});
@@ -93,7 +92,7 @@ CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1/real_time",
 
 BENCHMARK(BM_MainThread)->Iterations(1)->MeasureProcessCPUTime();
 ADD_CASES(TC_ConsoleOut, {{"^BM_MainThread/iterations:1/process_time "
-                           "%console_report invtime=%hrfloat/s$"}});
+                           "%console_report invtime=[^/]+/s$"}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_MainThread/iterations:1/process_time\",$"},
            {"\"run_name\": \"BM_MainThread/iterations:1/process_time\",$",
@@ -103,7 +102,7 @@ ADD_CASES(TC_JSONOut,
            {"\"real_time\": %float,$", MR_Next},
            {"\"cpu_time\": %float,$", MR_Next},
            {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\": %float$", MR_Next},
+           {"\"invtime\":", MR_Next},
            {"}", MR_Next}});
 ADD_CASES(
     TC_CSVOut,
@@ -113,7 +112,7 @@ CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1/process_time",
 
 BENCHMARK(BM_MainThread)->Iterations(1)->MeasureProcessCPUTime()->UseRealTime();
 ADD_CASES(TC_ConsoleOut, {{"^BM_MainThread/iterations:1/process_time/real_time "
-                           "%console_report invtime=%hrfloat/s$"}});
+                           "%console_report invtime=[^/]+/s$"}});
 ADD_CASES(
     TC_JSONOut,
     {{"\"name\": \"BM_MainThread/iterations:1/process_time/real_time\",$"},
@@ -124,7 +123,7 @@ ADD_CASES(
      {"\"real_time\": %float,$", MR_Next},
      {"\"cpu_time\": %float,$", MR_Next},
      {"\"time_unit\": \"ns\",$", MR_Next},
-     {"\"invtime\": %float$", MR_Next},
+     {"\"invtime\":", MR_Next},
      {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_MainThread/iterations:1/process_time/"
                        "real_time\",%csv_report,%float$"}});
@@ -143,9 +142,8 @@ void BM_WorkerThread(benchmark::State& state) {
       benchmark::Counter{1, benchmark::Counter::kIsRate};
 }
 BENCHMARK(BM_WorkerThread)->Iterations(1);
-ADD_CASES(
-    TC_ConsoleOut,
-    {{"^BM_WorkerThread/iterations:1 %console_report invtime=%hrfloat/s$"}});
+ADD_CASES(TC_ConsoleOut,
+          {{"^BM_WorkerThread/iterations:1 %console_report invtime=[^/]+/s$"}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_WorkerThread/iterations:1\",$"},
            {"\"run_name\": \"BM_WorkerThread/iterations:1\",$", MR_Next},
@@ -154,7 +152,7 @@ ADD_CASES(TC_JSONOut,
            {"\"real_time\": %float,$", MR_Next},
            {"\"cpu_time\": %float,$", MR_Next},
            {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\": %float$", MR_Next},
+           {"\"invtime\":", MR_Next},
            {"}", MR_Next}});
 ADD_CASES(TC_CSVOut,
           {{"^\"BM_WorkerThread/iterations:1\",%csv_report,%float$"}});
@@ -170,7 +168,7 @@ CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1$", &CheckTestVariantOne);
 
 BENCHMARK(BM_WorkerThread)->Iterations(1)->UseRealTime();
 ADD_CASES(TC_ConsoleOut, {{"^BM_WorkerThread/iterations:1/real_time "
-                           "%console_report invtime=%hrfloat/s$"}});
+                           "%console_report invtime=[^/]+/s$"}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_WorkerThread/iterations:1/real_time\",$"},
            {"\"run_name\": \"BM_WorkerThread/iterations:1/real_time\",$",
@@ -180,7 +178,7 @@ ADD_CASES(TC_JSONOut,
            {"\"real_time\": %float,$", MR_Next},
            {"\"cpu_time\": %float,$", MR_Next},
            {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\": %float$", MR_Next},
+           {"\"invtime\":", MR_Next},
            {"}", MR_Next}});
 ADD_CASES(
     TC_CSVOut,
@@ -190,7 +188,7 @@ CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1/real_time$",
 
 BENCHMARK(BM_WorkerThread)->Iterations(1)->MeasureProcessCPUTime();
 ADD_CASES(TC_ConsoleOut, {{"^BM_WorkerThread/iterations:1/process_time "
-                           "%console_report invtime=%hrfloat/s$"}});
+                           "%console_report invtime=[^/]+/s$"}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_WorkerThread/iterations:1/process_time\",$"},
            {"\"run_name\": \"BM_WorkerThread/iterations:1/process_time\",$",
@@ -200,7 +198,7 @@ ADD_CASES(TC_JSONOut,
            {"\"real_time\": %float,$", MR_Next},
            {"\"cpu_time\": %float,$", MR_Next},
            {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\": %float$", MR_Next},
+           {"\"invtime\":", MR_Next},
            {"}", MR_Next}});
 ADD_CASES(
     TC_CSVOut,
@@ -219,7 +217,7 @@ BENCHMARK(BM_WorkerThread)
     ->MeasureProcessCPUTime()
     ->UseRealTime();
 ADD_CASES(TC_ConsoleOut, {{"^BM_WorkerThread/iterations:1/process_time/"
-                           "real_time %console_report invtime=%hrfloat/s$"}});
+                           "real_time %console_report invtime=[^/]+/s$"}});
 ADD_CASES(
     TC_JSONOut,
     {{"\"name\": \"BM_WorkerThread/iterations:1/process_time/real_time\",$"},
@@ -230,7 +228,7 @@ ADD_CASES(
      {"\"real_time\": %float,$", MR_Next},
      {"\"cpu_time\": %float,$", MR_Next},
      {"\"time_unit\": \"ns\",$", MR_Next},
-     {"\"invtime\": %float$", MR_Next},
+     {"\"invtime\":", MR_Next},
      {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_WorkerThread/iterations:1/process_time/"
                        "real_time\",%csv_report,%float$"}});
@@ -251,7 +249,7 @@ void BM_MainThreadAndWorkerThread(benchmark::State& state) {
 }
 BENCHMARK(BM_MainThreadAndWorkerThread)->Iterations(1);
 ADD_CASES(TC_ConsoleOut, {{"^BM_MainThreadAndWorkerThread/iterations:1 "
-                           "%console_report invtime=%hrfloat/s$"}});
+                           "%console_report invtime=[^/]+/s$"}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_MainThreadAndWorkerThread/iterations:1\",$"},
            {"\"run_name\": \"BM_MainThreadAndWorkerThread/iterations:1\",$",
@@ -261,7 +259,7 @@ ADD_CASES(TC_JSONOut,
            {"\"real_time\": %float,$", MR_Next},
            {"\"cpu_time\": %float,$", MR_Next},
            {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\": %float$", MR_Next},
+           {"\"invtime\":", MR_Next},
            {"}", MR_Next}});
 ADD_CASES(
     TC_CSVOut,
@@ -271,7 +269,7 @@ CHECK_BENCHMARK_RESULTS("BM_MainThreadAndWorkerThread/iterations:1$",
 
 BENCHMARK(BM_MainThreadAndWorkerThread)->Iterations(1)->UseRealTime();
 ADD_CASES(TC_ConsoleOut, {{"^BM_MainThreadAndWorkerThread/iterations:1/"
-                           "real_time %console_report invtime=%hrfloat/s$"}});
+                           "real_time %console_report invtime=[^/]+/s$"}});
 ADD_CASES(
     TC_JSONOut,
     {{"\"name\": \"BM_MainThreadAndWorkerThread/iterations:1/real_time\",$"},
@@ -282,7 +280,7 @@ ADD_CASES(
      {"\"real_time\": %float,$", MR_Next},
      {"\"cpu_time\": %float,$", MR_Next},
      {"\"time_unit\": \"ns\",$", MR_Next},
-     {"\"invtime\": %float$", MR_Next},
+     {"\"invtime\":", MR_Next},
      {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
                        "real_time\",%csv_report,%float$"}});
@@ -290,9 +288,8 @@ CHECK_BENCHMARK_RESULTS("BM_MainThreadAndWorkerThread/iterations:1/real_time$",
                         &CheckTestVariantTwo);
 
 BENCHMARK(BM_MainThreadAndWorkerThread)->Iterations(1)->MeasureProcessCPUTime();
-ADD_CASES(TC_ConsoleOut,
-          {{"^BM_MainThreadAndWorkerThread/iterations:1/"
-            "process_time %console_report invtime=%hrfloat/s$"}});
+ADD_CASES(TC_ConsoleOut, {{"^BM_MainThreadAndWorkerThread/iterations:1/"
+                           "process_time %console_report invtime=[^/]+/s$"}});
 ADD_CASES(
     TC_JSONOut,
     {{"\"name\": \"BM_MainThreadAndWorkerThread/iterations:1/process_time\",$"},
@@ -304,7 +301,7 @@ ADD_CASES(
      {"\"real_time\": %float,$", MR_Next},
      {"\"cpu_time\": %float,$", MR_Next},
      {"\"time_unit\": \"ns\",$", MR_Next},
-     {"\"invtime\": %float$", MR_Next},
+     {"\"invtime\":", MR_Next},
      {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
                        "process_time\",%csv_report,%float$"}});
@@ -325,7 +322,7 @@ BENCHMARK(BM_MainThreadAndWorkerThread)
     ->UseRealTime();
 ADD_CASES(TC_ConsoleOut,
           {{"^BM_MainThreadAndWorkerThread/iterations:1/"
-            "process_time/real_time %console_report invtime=%hrfloat/s$"}});
+            "process_time/real_time %console_report invtime=[^/]+/s$"}});
 ADD_CASES(
     TC_JSONOut,
     {{"\"name\": "
@@ -338,7 +335,7 @@ ADD_CASES(
      {"\"real_time\": %float,$", MR_Next},
      {"\"cpu_time\": %float,$", MR_Next},
      {"\"time_unit\": \"ns\",$", MR_Next},
-     {"\"invtime\": %float$", MR_Next},
+     {"\"invtime\":", MR_Next},
      {"}", MR_Next}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
                        "process_time/real_time\",%csv_report,%float$"}});

--- a/test/internal_threading_test.cc
+++ b/test/internal_threading_test.cc
@@ -8,10 +8,6 @@
 #include "output_test.h"
 
 static const std::chrono::duration<double, std::milli> time_frame(50);
-static const double time_frame_in_ns(
-    std::chrono::duration_cast<std::chrono::duration<double, std::nano>>(
-        time_frame)
-        .count());
 static const double time_frame_in_sec(
     std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1, 1>>>(
         time_frame)
@@ -34,101 +30,47 @@ void MyBusySpinwait() {
 // --------------------------- TEST CASES BEGIN ---------------------------- //
 // ========================================================================= //
 
-ADD_CASES(TC_ConsoleOut,
-          {{"^[-]+$", MR_Next},
-           {"^Benchmark %s Time %s CPU %s Iterations UserCounters...$",
-            MR_Next},
-           {"^[-]+$", MR_Next}});
-ADD_CASES(TC_CSVOut, {{"%csv_header"}});
-
 // ========================================================================= //
 // BM_MainThread
 
 void BM_MainThread(benchmark::State& state) {
-  for (auto _ : state) MyBusySpinwait();
+  for (auto _ : state) {
+    MyBusySpinwait();
+    state.SetIterationTime(time_frame_in_sec);
+  }
   state.counters["invtime"] =
       benchmark::Counter{1, benchmark::Counter::kIsRate};
 }
 
-BENCHMARK(BM_MainThread)->Iterations(1);
-ADD_CASES(TC_ConsoleOut,
-          {{"^BM_MainThread/iterations:1 %console_report invtime=[^/]+/s$"}});
-ADD_CASES(TC_JSONOut,
-          {{"\"name\": \"BM_MainThread/iterations:1\",$"},
-           {"\"run_name\": \"BM_MainThread/iterations:1\",$", MR_Next},
-           {"\"run_type\": \"iteration\",$", MR_Next},
-           {"\"iterations\": 1,$", MR_Next},
-           {"\"real_time\": %float,$", MR_Next},
-           {"\"cpu_time\": %float,$", MR_Next},
-           {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\":", MR_Next},
-           {"}", MR_Next}});
-ADD_CASES(TC_CSVOut, {{"^\"BM_MainThread/iterations:1\",%csv_report,[^,]+"}});
-void CheckTestVariantZero(Results const& e) {
-  // check that the values are within 50% of the expected values
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.5);
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, time_frame_in_ns, 0.5);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.5);
-}
-CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1$", &CheckTestVariantZero);
+BENCHMARK(BM_MainThread)->Iterations(1)->Threads(1);
+BENCHMARK(BM_MainThread)->Iterations(1)->Threads(1)->UseRealTime();
+BENCHMARK(BM_MainThread)->Iterations(1)->Threads(1)->UseManualTime();
+BENCHMARK(BM_MainThread)->Iterations(1)->Threads(1)->MeasureProcessCPUTime();
+BENCHMARK(BM_MainThread)
+    ->Iterations(1)
+    ->Threads(1)
+    ->MeasureProcessCPUTime()
+    ->UseRealTime();
+BENCHMARK(BM_MainThread)
+    ->Iterations(1)
+    ->Threads(1)
+    ->MeasureProcessCPUTime()
+    ->UseManualTime();
 
-BENCHMARK(BM_MainThread)->Iterations(1)->UseRealTime();
-ADD_CASES(TC_ConsoleOut, {{"^BM_MainThread/iterations:1/real_time "
-                           "%console_report invtime=[^/]+/s$"}});
-ADD_CASES(TC_JSONOut,
-          {{"\"name\": \"BM_MainThread/iterations:1/real_time\",$"},
-           {"\"run_name\": \"BM_MainThread/iterations:1/real_time\",$",
-            MR_Next},
-           {"\"run_type\": \"iteration\",$", MR_Next},
-           {"\"iterations\": 1,$", MR_Next},
-           {"\"real_time\": %float,$", MR_Next},
-           {"\"cpu_time\": %float,$", MR_Next},
-           {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\":", MR_Next},
-           {"}", MR_Next}});
-ADD_CASES(TC_CSVOut,
-          {{"^\"BM_MainThread/iterations:1/real_time\",%csv_report,[^,]+"}});
-CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1/real_time",
-                        &CheckTestVariantZero);
-
-BENCHMARK(BM_MainThread)->Iterations(1)->MeasureProcessCPUTime();
-ADD_CASES(TC_ConsoleOut, {{"^BM_MainThread/iterations:1/process_time "
-                           "%console_report invtime=[^/]+/s$"}});
-ADD_CASES(TC_JSONOut,
-          {{"\"name\": \"BM_MainThread/iterations:1/process_time\",$"},
-           {"\"run_name\": \"BM_MainThread/iterations:1/process_time\",$",
-            MR_Next},
-           {"\"run_type\": \"iteration\",$", MR_Next},
-           {"\"iterations\": 1,$", MR_Next},
-           {"\"real_time\": %float,$", MR_Next},
-           {"\"cpu_time\": %float,$", MR_Next},
-           {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\":", MR_Next},
-           {"}", MR_Next}});
-ADD_CASES(TC_CSVOut,
-          {{"^\"BM_MainThread/iterations:1/process_time\",%csv_report,[^,]+"}});
-CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1/process_time",
-                        &CheckTestVariantZero);
-
-BENCHMARK(BM_MainThread)->Iterations(1)->MeasureProcessCPUTime()->UseRealTime();
-ADD_CASES(TC_ConsoleOut, {{"^BM_MainThread/iterations:1/process_time/real_time "
-                           "%console_report invtime=[^/]+/s$"}});
-ADD_CASES(
-    TC_JSONOut,
-    {{"\"name\": \"BM_MainThread/iterations:1/process_time/real_time\",$"},
-     {"\"run_name\": \"BM_MainThread/iterations:1/process_time/real_time\",$",
-      MR_Next},
-     {"\"run_type\": \"iteration\",$", MR_Next},
-     {"\"iterations\": 1,$", MR_Next},
-     {"\"real_time\": %float,$", MR_Next},
-     {"\"cpu_time\": %float,$", MR_Next},
-     {"\"time_unit\": \"ns\",$", MR_Next},
-     {"\"invtime\":", MR_Next},
-     {"}", MR_Next}});
-ADD_CASES(TC_CSVOut, {{"^\"BM_MainThread/iterations:1/process_time/"
-                       "real_time\",%csv_report,[^,]+"}});
-CHECK_BENCHMARK_RESULTS("BM_MainThread/iterations:1/process_time/real_time",
-                        &CheckTestVariantZero);
+BENCHMARK(BM_MainThread)->Iterations(1)->Threads(2);
+BENCHMARK(BM_MainThread)->Iterations(1)->Threads(2)->UseRealTime();
+BENCHMARK(BM_MainThread)->Iterations(1)->Threads(2)->UseManualTime();
+BENCHMARK(BM_MainThread)->Iterations(1)->Threads(2)->MeasureProcessCPUTime();
+BENCHMARK(BM_MainThread)
+    ->Iterations(1)
+    ->Threads(2)
+    ->MeasureProcessCPUTime()
+    ->UseRealTime();
+BENCHMARK(BM_MainThread)
+    ->Iterations(1)
+    ->Threads(2)
+    ->MeasureProcessCPUTime()
+    ->UseManualTime();
 
 // ========================================================================= //
 // BM_WorkerThread
@@ -137,101 +79,41 @@ void BM_WorkerThread(benchmark::State& state) {
   for (auto _ : state) {
     std::thread Worker(&MyBusySpinwait);
     Worker.join();
+    state.SetIterationTime(time_frame_in_sec);
   }
   state.counters["invtime"] =
       benchmark::Counter{1, benchmark::Counter::kIsRate};
 }
-BENCHMARK(BM_WorkerThread)->Iterations(1);
-ADD_CASES(TC_ConsoleOut,
-          {{"^BM_WorkerThread/iterations:1 %console_report invtime=[^/]+/s$"}});
-ADD_CASES(TC_JSONOut,
-          {{"\"name\": \"BM_WorkerThread/iterations:1\",$"},
-           {"\"run_name\": \"BM_WorkerThread/iterations:1\",$", MR_Next},
-           {"\"run_type\": \"iteration\",$", MR_Next},
-           {"\"iterations\": 1,$", MR_Next},
-           {"\"real_time\": %float,$", MR_Next},
-           {"\"cpu_time\": %float,$", MR_Next},
-           {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\":", MR_Next},
-           {"}", MR_Next}});
-ADD_CASES(TC_CSVOut, {{"^\"BM_WorkerThread/iterations:1\",%csv_report,[^,]+"}});
-void CheckTestVariantOne(Results const& e) {
-  // check that the value is within 50% of the expected
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.5);
-  // check that the cpu time is between 0 and (wall time / 100)
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, (time_frame_in_ns / 25.), 1.0);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / (time_frame_in_sec / 500.0),
-                            1.0);
-}
-CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1$", &CheckTestVariantOne);
 
-BENCHMARK(BM_WorkerThread)->Iterations(1)->UseRealTime();
-ADD_CASES(TC_ConsoleOut, {{"^BM_WorkerThread/iterations:1/real_time "
-                           "%console_report invtime=[^/]+/s$"}});
-ADD_CASES(TC_JSONOut,
-          {{"\"name\": \"BM_WorkerThread/iterations:1/real_time\",$"},
-           {"\"run_name\": \"BM_WorkerThread/iterations:1/real_time\",$",
-            MR_Next},
-           {"\"run_type\": \"iteration\",$", MR_Next},
-           {"\"iterations\": 1,$", MR_Next},
-           {"\"real_time\": %float,$", MR_Next},
-           {"\"cpu_time\": %float,$", MR_Next},
-           {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\":", MR_Next},
-           {"}", MR_Next}});
-ADD_CASES(TC_CSVOut,
-          {{"^\"BM_WorkerThread/iterations:1/real_time\",%csv_report,[^,]+"}});
-CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1/real_time$",
-                        &CheckTestVariantOne);
-
-BENCHMARK(BM_WorkerThread)->Iterations(1)->MeasureProcessCPUTime();
-ADD_CASES(TC_ConsoleOut, {{"^BM_WorkerThread/iterations:1/process_time "
-                           "%console_report invtime=[^/]+/s$"}});
-ADD_CASES(TC_JSONOut,
-          {{"\"name\": \"BM_WorkerThread/iterations:1/process_time\",$"},
-           {"\"run_name\": \"BM_WorkerThread/iterations:1/process_time\",$",
-            MR_Next},
-           {"\"run_type\": \"iteration\",$", MR_Next},
-           {"\"iterations\": 1,$", MR_Next},
-           {"\"real_time\": %float,$", MR_Next},
-           {"\"cpu_time\": %float,$", MR_Next},
-           {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\":", MR_Next},
-           {"}", MR_Next}});
-ADD_CASES(
-    TC_CSVOut,
-    {{"^\"BM_WorkerThread/iterations:1/process_time\",%csv_report,[^,]+"}});
-void CheckTestVariantTwo(Results const& e) {
-  // check that the values are within 50% of the expected values
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.5);
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, time_frame_in_ns, 0.5);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 1.0);
-}
-CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1/process_time$",
-                        &CheckTestVariantTwo);
-
+BENCHMARK(BM_WorkerThread)->Iterations(1)->Threads(1);
+BENCHMARK(BM_WorkerThread)->Iterations(1)->Threads(1)->UseRealTime();
+BENCHMARK(BM_WorkerThread)->Iterations(1)->Threads(1)->UseManualTime();
+BENCHMARK(BM_WorkerThread)->Iterations(1)->Threads(1)->MeasureProcessCPUTime();
 BENCHMARK(BM_WorkerThread)
     ->Iterations(1)
+    ->Threads(1)
     ->MeasureProcessCPUTime()
     ->UseRealTime();
-ADD_CASES(TC_ConsoleOut, {{"^BM_WorkerThread/iterations:1/process_time/"
-                           "real_time %console_report invtime=[^/]+/s$"}});
-ADD_CASES(
-    TC_JSONOut,
-    {{"\"name\": \"BM_WorkerThread/iterations:1/process_time/real_time\",$"},
-     {"\"run_name\": \"BM_WorkerThread/iterations:1/process_time/real_time\",$",
-      MR_Next},
-     {"\"run_type\": \"iteration\",$", MR_Next},
-     {"\"iterations\": 1,$", MR_Next},
-     {"\"real_time\": %float,$", MR_Next},
-     {"\"cpu_time\": %float,$", MR_Next},
-     {"\"time_unit\": \"ns\",$", MR_Next},
-     {"\"invtime\":", MR_Next},
-     {"}", MR_Next}});
-ADD_CASES(TC_CSVOut, {{"^\"BM_WorkerThread/iterations:1/process_time/"
-                       "real_time\",%csv_report,[^,]+"}});
-CHECK_BENCHMARK_RESULTS("BM_WorkerThread/iterations:1/process_time/real_time$",
-                        &CheckTestVariantTwo);
+BENCHMARK(BM_WorkerThread)
+    ->Iterations(1)
+    ->Threads(1)
+    ->MeasureProcessCPUTime()
+    ->UseManualTime();
+
+BENCHMARK(BM_WorkerThread)->Iterations(1)->Threads(2);
+BENCHMARK(BM_WorkerThread)->Iterations(1)->Threads(2)->UseRealTime();
+BENCHMARK(BM_WorkerThread)->Iterations(1)->Threads(2)->UseManualTime();
+BENCHMARK(BM_WorkerThread)->Iterations(1)->Threads(2)->MeasureProcessCPUTime();
+BENCHMARK(BM_WorkerThread)
+    ->Iterations(1)
+    ->Threads(2)
+    ->MeasureProcessCPUTime()
+    ->UseRealTime();
+BENCHMARK(BM_WorkerThread)
+    ->Iterations(1)
+    ->Threads(2)
+    ->MeasureProcessCPUTime()
+    ->UseManualTime();
 
 // ========================================================================= //
 // BM_MainThreadAndWorkerThread
@@ -241,111 +123,59 @@ void BM_MainThreadAndWorkerThread(benchmark::State& state) {
     std::thread Worker(&MyBusySpinwait);
     MyBusySpinwait();
     Worker.join();
+    state.SetIterationTime(time_frame_in_sec);
   }
   state.counters["invtime"] =
       benchmark::Counter{1, benchmark::Counter::kIsRate};
 }
-BENCHMARK(BM_MainThreadAndWorkerThread)->Iterations(1);
-ADD_CASES(TC_ConsoleOut, {{"^BM_MainThreadAndWorkerThread/iterations:1 "
-                           "%console_report invtime=[^/]+/s$"}});
-ADD_CASES(TC_JSONOut,
-          {{"\"name\": \"BM_MainThreadAndWorkerThread/iterations:1\",$"},
-           {"\"run_name\": \"BM_MainThreadAndWorkerThread/iterations:1\",$",
-            MR_Next},
-           {"\"run_type\": \"iteration\",$", MR_Next},
-           {"\"iterations\": 1,$", MR_Next},
-           {"\"real_time\": %float,$", MR_Next},
-           {"\"cpu_time\": %float,$", MR_Next},
-           {"\"time_unit\": \"ns\",$", MR_Next},
-           {"\"invtime\":", MR_Next},
-           {"}", MR_Next}});
-ADD_CASES(
-    TC_CSVOut,
-    {{"^\"BM_MainThreadAndWorkerThread/iterations:1\",%csv_report,[^,]+"}});
-CHECK_BENCHMARK_RESULTS("BM_MainThreadAndWorkerThread/iterations:1$",
-                        &CheckTestVariantTwo);
 
-BENCHMARK(BM_MainThreadAndWorkerThread)->Iterations(1)->UseRealTime();
-ADD_CASES(TC_ConsoleOut, {{"^BM_MainThreadAndWorkerThread/iterations:1/"
-                           "real_time %console_report invtime=[^/]+/s$"}});
-ADD_CASES(
-    TC_JSONOut,
-    {{"\"name\": \"BM_MainThreadAndWorkerThread/iterations:1/real_time\",$"},
-     {"\"run_name\": \"BM_MainThreadAndWorkerThread/iterations:1/real_time\",$",
-      MR_Next},
-     {"\"run_type\": \"iteration\",$", MR_Next},
-     {"\"iterations\": 1,$", MR_Next},
-     {"\"real_time\": %float,$", MR_Next},
-     {"\"cpu_time\": %float,$", MR_Next},
-     {"\"time_unit\": \"ns\",$", MR_Next},
-     {"\"invtime\":", MR_Next},
-     {"}", MR_Next}});
-ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
-                       "real_time\",%csv_report,[^,]+"}});
-CHECK_BENCHMARK_RESULTS("BM_MainThreadAndWorkerThread/iterations:1/real_time$",
-                        &CheckTestVariantTwo);
-
-BENCHMARK(BM_MainThreadAndWorkerThread)->Iterations(1)->MeasureProcessCPUTime();
-ADD_CASES(TC_ConsoleOut, {{"^BM_MainThreadAndWorkerThread/iterations:1/"
-                           "process_time %console_report invtime=[^/]+/s$"}});
-ADD_CASES(
-    TC_JSONOut,
-    {{"\"name\": \"BM_MainThreadAndWorkerThread/iterations:1/process_time\",$"},
-     {"\"run_name\": "
-      "\"BM_MainThreadAndWorkerThread/iterations:1/process_time\",$",
-      MR_Next},
-     {"\"run_type\": \"iteration\",$", MR_Next},
-     {"\"iterations\": 1,$", MR_Next},
-     {"\"real_time\": %float,$", MR_Next},
-     {"\"cpu_time\": %float,$", MR_Next},
-     {"\"time_unit\": \"ns\",$", MR_Next},
-     {"\"invtime\":", MR_Next},
-     {"}", MR_Next}});
-ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
-                       "process_time\",%csv_report,[^,]+"}});
-void CheckTestVariantThree(Results const& e) {
-  // check that the values are within 50% of the expected values
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.5);
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, 2.0 * time_frame_in_ns, 0.5);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / (2. * time_frame_in_sec),
-                            0.5);
-}
-CHECK_BENCHMARK_RESULTS(
-    "BM_MainThreadAndWorkerThread/iterations:1/process_time$",
-    &CheckTestVariantThree);
-
+BENCHMARK(BM_MainThreadAndWorkerThread)->Iterations(1)->Threads(1);
 BENCHMARK(BM_MainThreadAndWorkerThread)
     ->Iterations(1)
+    ->Threads(1)
+    ->UseRealTime();
+BENCHMARK(BM_MainThreadAndWorkerThread)
+    ->Iterations(1)
+    ->Threads(1)
+    ->UseManualTime();
+BENCHMARK(BM_MainThreadAndWorkerThread)
+    ->Iterations(1)
+    ->Threads(1)
+    ->MeasureProcessCPUTime();
+BENCHMARK(BM_MainThreadAndWorkerThread)
+    ->Iterations(1)
+    ->Threads(1)
     ->MeasureProcessCPUTime()
     ->UseRealTime();
-ADD_CASES(TC_ConsoleOut,
-          {{"^BM_MainThreadAndWorkerThread/iterations:1/"
-            "process_time/real_time %console_report invtime=[^/]+/s$"}});
-ADD_CASES(
-    TC_JSONOut,
-    {{"\"name\": "
-      "\"BM_MainThreadAndWorkerThread/iterations:1/process_time/real_time\",$"},
-     {"\"run_name\": "
-      "\"BM_MainThreadAndWorkerThread/iterations:1/process_time/real_time\",$",
-      MR_Next},
-     {"\"run_type\": \"iteration\",$", MR_Next},
-     {"\"iterations\": 1,$", MR_Next},
-     {"\"real_time\": %float,$", MR_Next},
-     {"\"cpu_time\": %float,$", MR_Next},
-     {"\"time_unit\": \"ns\",$", MR_Next},
-     {"\"invtime\":", MR_Next},
-     {"}", MR_Next}});
-ADD_CASES(TC_CSVOut, {{"^\"BM_MainThreadAndWorkerThread/iterations:1/"
-                       "process_time/real_time\",%csv_report,[^,]+"}});
-void CheckTestVariantFour(Results const& e) {
-  // check that the values are within 50% of the expected values
-  CHECK_FLOAT_RESULT_VALUE(e, "real_time", EQ, time_frame_in_ns, 0.5);
-  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", EQ, 2.0 * time_frame_in_ns, 0.5);
-  CHECK_FLOAT_COUNTER_VALUE(e, "invtime", EQ, 1. / time_frame_in_sec, 0.5);
-}
-CHECK_BENCHMARK_RESULTS(
-    "BM_MainThreadAndWorkerThread/iterations:1/process_time/real_time$",
-    &CheckTestVariantFour);
+BENCHMARK(BM_MainThreadAndWorkerThread)
+    ->Iterations(1)
+    ->Threads(1)
+    ->MeasureProcessCPUTime()
+    ->UseManualTime();
+
+BENCHMARK(BM_MainThreadAndWorkerThread)->Iterations(1)->Threads(2);
+BENCHMARK(BM_MainThreadAndWorkerThread)
+    ->Iterations(1)
+    ->Threads(2)
+    ->UseRealTime();
+BENCHMARK(BM_MainThreadAndWorkerThread)
+    ->Iterations(1)
+    ->Threads(2)
+    ->UseManualTime();
+BENCHMARK(BM_MainThreadAndWorkerThread)
+    ->Iterations(1)
+    ->Threads(2)
+    ->MeasureProcessCPUTime();
+BENCHMARK(BM_MainThreadAndWorkerThread)
+    ->Iterations(1)
+    ->Threads(2)
+    ->MeasureProcessCPUTime()
+    ->UseRealTime();
+BENCHMARK(BM_MainThreadAndWorkerThread)
+    ->Iterations(1)
+    ->Threads(2)
+    ->MeasureProcessCPUTime()
+    ->UseManualTime();
 
 // ========================================================================= //
 // ---------------------------- TEST CASES END ----------------------------- //


### PR DESCRIPTION
This patch makes Google Benchmark compatible with OpenMP and other user-level thread management.
Until now, google benchmark would only report the CPU usage of the master thread if the code being benchmarked used OpenMP or otherwise spawned multiple threads internally.

This version reports the total process CPU usage if the number of google-benchmark threads is set to <= 1 , but reverts to the existing behaviour otherwise.

It may actually be preferable to report the total process CPU usage in all cases, but this is sufficient for my needs.

We have been using google benchmark in our parallel programming class, however, every term students are confused when the CPU time roughly reflects the wall-clock time for parallelized codes doing the same amount of work. This version is also advantageous because it can better demonstrate the overhead of threading, that some tasks take more total CPU time when multi-threaded, and, sometimes, tasks may actually take less overall CPU time.

If my feature patch cannot be merged, I would like to request that the maintainers implement this. It is very important to us.