### PR TITLE
[#766] add x-compile support for QNX SDP7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,10 @@ else()
     add_definitions(-D_GNU_SOURCE=1)
   endif()
 
+  if (QNXNTO)
+    add_definitions(-D_QNX_SOURCE)
+  endif()
+
   # Link time optimisation
   if (BENCHMARK_ENABLE_LTO)
     add_cxx_compiler_flag(-flto)

--- a/src/internal_macros.h
+++ b/src/internal_macros.h
@@ -70,6 +70,8 @@
 #define BENCHMARK_OS_FUCHSIA 1
 #elif defined (__SVR4) && defined (__sun)
 #define BENCHMARK_OS_SOLARIS 1
+#elif defined(__QNX__)
+#define BENCHMARK_OS_QNX 1
 #endif
 
 #if defined(__ANDROID__) && defined(__GLIBCXX__)

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -389,6 +389,8 @@ std::string GetSystemName() {
 #else // defined(BENCHMARK_OS_WINDOWS)
 #ifdef BENCHMARK_OS_MACOSX //Mac Doesnt have HOST_NAME_MAX defined
 #define HOST_NAME_MAX 64
+#elif defined(BENCHMARK_OS_QNX)
+#define HOST_NAME_MAX 154
 #endif
   char hostname[HOST_NAME_MAX];
   int retVal = gethostname(hostname, HOST_NAME_MAX);


### PR DESCRIPTION
Since googletest already supports x-compilation for QNX, it is nice to
 have google benchmark support it too.
Fixes #766