### PR TITLE
Prefer -pthread to -lpthread flag in INTERFACE_LINK_LIBS for better compatibility when cross-compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,7 @@ if (NOT BENCHMARK_ENABLE_EXCEPTIONS AND HAVE_STD_REGEX
 endif()
 cxx_feature_check(STEADY_CLOCK)
 # Ensure we have pthreads
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 # Set up directories


### PR DESCRIPTION
Linking with `-lpthread` instead of `-pthread` can cause failures of the sort like

```
/home/travis/build/apache/arrow/cpp-toolchain/bin/ld: /home/travis/build/apache/arrow/cpp-toolchain/lib/libbenchmark.a(benchmark.cc.o): in function `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*, benchmark::BenchmarkReporter*)':
benchmark.cc:(.text+0x2235): undefined reference to `std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)())'
/home/travis/build/apache/arrow/cpp-toolchain/bin/ld: /home/travis/build/apache/arrow/cpp-toolchain/lib/libbenchmark.a(benchmark.cc.o): in function `std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(benchmark::internal::Benchmark::Instance const*, unsigned long, int, benchmark::internal::ThreadManager*), benchmark::internal::Benchmark::Instance const*, unsigned long, int, benchmark::internal::ThreadManager*> > >::~_State_impl()':
benchmark.cc:(.text._ZNSt6thread11_State_implINS_8_InvokerISt5tupleIJPFvPKN9benchmark8internal9Benchmark8InstanceEmiPNS4_13ThreadManagerEES8_miSA_EEEEED2Ev[_ZNSt6thread11_State_implINS_8_InvokerISt5tupleIJPFvPKN9benchmark8internal9Benchmark8InstanceEmiPNS4_13ThreadManagerEES8_miSA_EEEEED5Ev]+0x10): undefined reference to `std::thread::_State::~_State()'
/home/travis/build/apache/arrow/cpp-toolchain/bin/ld: /home/travis/build/apache/arrow/cpp-toolchain/lib/libbenchmark.a(benchmark.cc.o): in function `std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(benchmark::internal::Benchmark::Instance const*, unsigned long, int, benchmark::internal::ThreadManager*), benchmark::internal::Benchmark::Instance const*, unsigned long, int, benchmark::internal::ThreadManager*> > >::~_State_impl()':
benchmark.cc:(.text._ZNSt6thread11_State_implINS_8_InvokerISt5tupleIJPFvPKN9benchmark8internal9Benchmark8InstanceEmiPNS4_13ThreadManagerEES8_miSA_EEEEED0Ev[_ZNSt6thread11_State_implINS_8_InvokerISt5tupleIJPFvPKN9benchmark8internal9Benchmark8InstanceEmiPNS4_13ThreadManagerEES8_miSA_EEEEED5Ev]+0x14): undefined reference to `std::thread::_State::~_State()'
/home/travis/build/apache/arrow/cpp-toolchain/bin/ld: /home/travis/build/apache/arrow/cpp-toolchain/lib/libbenchmark.a(benchmark.cc.o):(.data.rel.ro._ZTINSt6thread11_State_implINS_8_InvokerISt5tupleIJPFvPKN9benchmark8internal9Benchmark8InstanceEmiPNS4_13ThreadManagerEES8_miSA_EEEEEE[_ZTINSt6thread11_State_implINS_8_InvokerISt5tupleIJPFvPKN9benchmark8internal9Benchmark8InstanceEmiPNS4_13ThreadManagerEES8_miSA_EEEEEE]+0x10): undefined reference to `typeinfo for std::thread::_State'
collect2: error: ld returned 1 exit status
```

when using libraries cross-compiled on one host for use on another. CMake version 3.1 and higher has the `THREADS_PREFER_PTHREAD_FLAG` flag which toggles the behavior of `${CMAKE_THREAD_LIBS_INIT}`. 

See https://cmake.org/cmake/help/v3.1/module/FindThreads.html