### PR TITLE
If gtest targets are already defined, use them.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,9 @@ add_subdirectory(src)
 
 if (BENCHMARK_ENABLE_TESTING)
   enable_testing()
-  if (BENCHMARK_ENABLE_GTEST_TESTS)
+  if (BENCHMARK_ENABLE_GTEST_TESTS AND
+      NOT (TARGET gtest AND TARGET gtest_main AND
+           TARGET gmock AND TARGET gmock_main))
     include(GoogleTest)
   endif()
   add_subdirectory(test)


### PR DESCRIPTION
This allows a project to include both googletest and benchmark as top-level git submodule.

This allows incorporating Benchmark to an existing CMake project that already incorporates googletest.
https://github.com/google/googletest/blob/master/googletest/README.md#incorporating-into-an-existing-cmake-project
https://github.com/abseil/abseil-cpp/tree/master/CMake#incorporating-abseil-into-a-cmake-project