### PR TITLE
Correct-erer JSON output for inf/nan. Fixes #784

### DIFF
--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -23,6 +23,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include <cmath>
 
 #include "string_util.h"
 #include "timers.h"
@@ -53,10 +54,15 @@ std::string FormatKV(std::string const& key, double value) {
   std::stringstream ss;
   ss << '"' << key << "\": ";
 
-  const auto max_digits10 = std::numeric_limits<decltype(value)>::max_digits10;
-  const auto max_fractional_digits10 = max_digits10 - 1;
-
-  ss << std::scientific << std::setprecision(max_fractional_digits10) << value;
+  if (std::isnan(value))
+    ss << "NaN";
+  else if (std::isinf(value))
+    ss << (value < 0 ? "-" : "") << "Infinity";
+  else {
+    const auto max_digits10 = std::numeric_limits<decltype(value)>::max_digits10;
+    const auto max_fractional_digits10 = max_digits10 - 1;
+    ss << std::scientific << std::setprecision(max_fractional_digits10) << value;
+  }
   return ss.str();
 }
 


### PR DESCRIPTION
Output javascript nan/inf values into JSON instead of c-style nan/inf.  Neither is technically "correct JSON", but many JSON parsers support the javascript symbols.