### PR TITLE
Silence CMake Policy 0063 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ foreach(p
     CMP0054 # CMake 3.1
     CMP0056 # export EXE_LINKER_FLAGS to try_run
     CMP0057 # Support no if() IN_LIST operator
+    CMP0063 # Honor visibility properties for all targets
     )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)


### PR DESCRIPTION
Summary:
- When google benchmark is used as a submodule in a parent projects
  whose min CMake version is 3.3.2 or later, the google benchmark
  `CMakeLists.txt` triggers a warning regarding CMake policy 0063:

```
CMake Warning (dev) at tests/googlebenchmark/src/CMakeLists.txt:19 (add_library):
  Policy CMP0063 is not set: Honor visibility properties for all target
  types.  Run "cmake --help-policy CMP0063" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  Target "benchmark" of type "STATIC_LIBRARY" has the following visibility
  properties set for CXX:

    CXX_VISIBILITY_PRESET
    VISIBILITY_INLINES_HIDDEN

  For compatibility CMake is not honoring them for this target.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

- Set CMake Policy 0063 to NEW if the policy is available. This will not
  affect parent projects who include benchmark but do not have a CMake min
  version of 3.3.2 or later, i.e. when this policy is introduced.