### PR TITLE
Add command line flags tests

### DIFF
--- a/src/commandlineflags.cc
+++ b/src/commandlineflags.cc
@@ -21,8 +21,8 @@
 #include <limits>
 
 namespace benchmark {
-
 namespace {
+
 // Parses 'str' for a 32-bit signed integer.  If successful, writes
 // the result to *value and returns true; otherwise leaves *value
 // unchanged and returns false.

--- a/src/commandlineflags.cc
+++ b/src/commandlineflags.cc
@@ -21,6 +21,8 @@
 #include <limits>
 
 namespace benchmark {
+
+namespace {
 // Parses 'str' for a 32-bit signed integer.  If successful, writes
 // the result to *value and returns true; otherwise leaves *value
 // unchanged and returns false.
@@ -87,6 +89,8 @@ static std::string FlagToEnvVar(const char* flag) {
 
   return "BENCHMARK_" + env_var;
 }
+
+}  // namespace
 
 // Reads and returns the Boolean environment variable corresponding to
 // the given flag; if it's not set, returns default_value.

--- a/src/commandlineflags.h
+++ b/src/commandlineflags.h
@@ -23,16 +23,10 @@
   std::string FLAG(name) = (default_val)
 
 namespace benchmark {
-// Parses 'str' for a 32-bit signed integer.  If successful, writes the result
-// to *value and returns true; otherwise leaves *value unchanged and returns
-// false.
-bool ParseInt32(const std::string& src_text, const char* str, int32_t* value);
-
 // Parses a bool/Int32/string from the environment variable
 // corresponding to the given Google Test flag.
 bool BoolFromEnv(const char* flag, bool default_val);
 int32_t Int32FromEnv(const char* flag, int32_t default_val);
-double DoubleFromEnv(const char* flag, double default_val);
 const char* StringFromEnv(const char* flag, const char* default_val);
 
 // Parses a string for a bool flag, in the form of either

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -195,6 +195,7 @@ if (BENCHMARK_ENABLE_GTEST_TESTS)
 
   add_gtest(benchmark_gtest)
   add_gtest(benchmark_name_gtest)
+  add_gtest(commandlineflags_gtest)
   add_gtest(statistics_gtest)
   add_gtest(string_util_gtest)
 endif(BENCHMARK_ENABLE_GTEST_TESTS)

--- a/test/commandlineflags_gtest.cc
+++ b/test/commandlineflags_gtest.cc
@@ -11,10 +11,10 @@ namespace {
 int setenv(const char* name, const char* value, int overwrite) {
   int errcode = 0;
   if (!overwrite) {
-    size_t envsize = 0;
-    errcode = getenv_s(&envsize, nullptr, 0, name);
-    if (errcode || envsize) {
-      return errcode;
+    // NOTE: getenv_s is far superior but not available under mingw.
+    char* value = getenv(name);
+    if (value == nullptr) {
+      return -1;
     }
   }
   return _putenv_s(name, value);

--- a/test/commandlineflags_gtest.cc
+++ b/test/commandlineflags_gtest.cc
@@ -1,0 +1,57 @@
+#include "../src/commandlineflags.h"
+#include "gtest/gtest.h"
+
+namespace benchmark {
+namespace {
+
+TEST(BoolFromEnv, Default) {
+  ASSERT_EQ(unsetenv("BENCHMARK_NOT_IN_ENV"), 0);
+  EXPECT_EQ(BoolFromEnv("not_in_env", true), true);
+}
+
+TEST(BoolFromEnv, False) {
+  ASSERT_EQ(setenv("BENCHMARK_IN_ENV", "0", 1), 0);
+  EXPECT_EQ(BoolFromEnv("in_env", true), false);
+  unsetenv("BENCHMARK_IN_ENV");
+}
+
+TEST(BoolFromEnv, True) {
+  ASSERT_EQ(setenv("BENCHMARK_IN_ENV", "1", 1), 0);
+  EXPECT_EQ(BoolFromEnv("in_env", false), true);
+  unsetenv("BENCHMARK_IN_ENV");
+
+  ASSERT_EQ(setenv("BENCHMARK_IN_ENV", "foo", 1), 0);
+  EXPECT_EQ(BoolFromEnv("in_env", false), true);
+  unsetenv("BENCHMARK_IN_ENV");
+}
+
+TEST(Int32FromEnv, NotInEnv) {
+  ASSERT_EQ(unsetenv("BENCHMARK_NOT_IN_ENV"), 0);
+  EXPECT_EQ(Int32FromEnv("not_in_env", 42), 42);
+}
+
+TEST(Int32FromEnv, InvalidInteger) {
+  ASSERT_EQ(setenv("BENCHMARK_IN_ENV", "foo", 1), 0);
+  EXPECT_EQ(Int32FromEnv("in_env", 42), 42);
+  ASSERT_EQ(unsetenv("BENCHMARK_IN_ENV"), 0);
+}
+
+TEST(Int32FromEnv, ValidInteger) {
+  ASSERT_EQ(setenv("BENCHMARK_IN_ENV", "42", 1), 0);
+  EXPECT_EQ(Int32FromEnv("in_env", 64), 42);
+  unsetenv("BENCHMARK_IN_ENV");
+}
+
+TEST(StringFromEnv, Default) {
+  ASSERT_EQ(unsetenv("BENCHMARK_NOT_IN_ENV"), 0);
+  EXPECT_STREQ(StringFromEnv("not_in_env", "foo"), "foo");
+}
+
+TEST(StringFromEnv, Valid) {
+  ASSERT_EQ(setenv("BENCHMARK_IN_ENV", "foo", 1), 0);
+  EXPECT_STREQ(StringFromEnv("in_env", "bar"), "foo");
+  unsetenv("BENCHMARK_IN_ENV");
+}
+
+}  // namespace
+}  // namespace benchmark

--- a/test/commandlineflags_gtest.cc
+++ b/test/commandlineflags_gtest.cc
@@ -12,7 +12,7 @@ int setenv(const char* name, const char* value, int overwrite) {
   int errcode = 0;
   if (!overwrite) {
     size_t envsize = 0;
-    errcod = getenv_s(&envsize, nullptr, 0, name);
+    errcode = getenv_s(&envsize, nullptr, 0, name);
     if (errcode || envsize) {
       return errcode;
     }

--- a/test/commandlineflags_gtest.cc
+++ b/test/commandlineflags_gtest.cc
@@ -1,8 +1,29 @@
+#include <cstdlib>
+
 #include "../src/commandlineflags.h"
 #include "gtest/gtest.h"
 
 namespace benchmark {
 namespace {
+
+#if defined(BENCHMARK_OS_WINDOWS)
+int setenv(const char* name, const char* value, int overwrite) {
+  int errcode = 0;
+  if (!overwrite) {
+    size_t envsize = 0;
+    errcod = getenv_s(&envsize, nullptr, 0, name);
+    if (errcode || envsize) {
+      return errcode;
+    }
+  }
+  return _putenv_s(name, value);
+}
+
+int unsetenv(const char* name) {
+  return _putenv_s(name, "");
+}
+
+#endif  // BENCHMARK_OS_WINDOWS
 
 TEST(BoolFromEnv, Default) {
   ASSERT_EQ(unsetenv("BENCHMARK_NOT_IN_ENV"), 0);

--- a/test/commandlineflags_gtest.cc
+++ b/test/commandlineflags_gtest.cc
@@ -9,11 +9,10 @@ namespace {
 
 #if defined(BENCHMARK_OS_WINDOWS)
 int setenv(const char* name, const char* value, int overwrite) {
-  int errcode = 0;
   if (!overwrite) {
     // NOTE: getenv_s is far superior but not available under mingw.
-    char* value = getenv(name);
-    if (value == nullptr) {
+    char* env_value = getenv(name);
+    if (env_value == nullptr) {
       return -1;
     }
   }

--- a/test/commandlineflags_gtest.cc
+++ b/test/commandlineflags_gtest.cc
@@ -1,6 +1,7 @@
 #include <cstdlib>
 
 #include "../src/commandlineflags.h"
+#include "../src/internal_macros.h"
 #include "gtest/gtest.h"
 
 namespace benchmark {


### PR DESCRIPTION
Also clean up the command line flags implementation to remove unused code, move internal methods to the implementation file, and add an unnamed namespace to protect those symbols from cross-translation-unit references.