### PR TITLE
Add support for GNU Install Dirs from GNU Coding Standards. Fixes #807

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Allow the source files to find headers in src/
+include(GNUInstallDirs)
 include_directories(${PROJECT_SOURCE_DIR}/src)
 
 if (DEFINED BENCHMARK_CXX_LINKER_FLAGS)
@@ -55,11 +56,12 @@ target_include_directories(benchmark PUBLIC
     )
 target_link_libraries(benchmark_main benchmark)
 
-set(include_install_dir "include")
-set(lib_install_dir "lib/")
-set(bin_install_dir "bin/")
-set(config_install_dir "lib/cmake/${PROJECT_NAME}")
-set(pkgconfig_install_dir "lib/pkgconfig")
+set(include_install_dir "${CMAKE_INSTALL_INCLUDEDIR}")
+set(lib_install_dir "${CMAKE_INSTALL_LIBDIR}")
+set(bin_install_dir "${CMAKE_INSTALL_BINDIR}")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(pkgconfig_install_dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
 
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,12 +56,6 @@ target_include_directories(benchmark PUBLIC
     )
 target_link_libraries(benchmark_main benchmark)
 
-#set(include_install_dir "${CMAKE_INSTALL_INCLUDEDIR}")
-#set(lib_install_dir "${CMAKE_INSTALL_LIBDIR}")
-#set(bin_install_dir "${CMAKE_INSTALL_BINDIR}")
-set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-set(pkgconfig_install_dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-
 
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
@@ -97,14 +91,14 @@ if (BENCHMARK_ENABLE_INSTALL)
 
   install(
       FILES "${project_config}" "${version_config}"
-      DESTINATION "${config_install_dir}")
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
   install(
       FILES "${pkg_config}"
-      DESTINATION "${pkgconfig_install_dir}")
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
   install(
       EXPORT "${targets_export_name}"
       NAMESPACE "${namespace}"
-      DESTINATION "${config_install_dir}")
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,9 +56,9 @@ target_include_directories(benchmark PUBLIC
     )
 target_link_libraries(benchmark_main benchmark)
 
-set(include_install_dir "${CMAKE_INSTALL_INCLUDEDIR}")
-set(lib_install_dir "${CMAKE_INSTALL_LIBDIR}")
-set(bin_install_dir "${CMAKE_INSTALL_BINDIR}")
+#set(include_install_dir "${CMAKE_INSTALL_INCLUDEDIR}")
+#set(lib_install_dir "${CMAKE_INSTALL_LIBDIR}")
+#set(bin_install_dir "${CMAKE_INSTALL_BINDIR}")
 set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(pkgconfig_install_dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
@@ -85,14 +85,14 @@ if (BENCHMARK_ENABLE_INSTALL)
   install(
     TARGETS benchmark benchmark_main
     EXPORT ${targets_export_name}
-    ARCHIVE DESTINATION ${lib_install_dir}
-    LIBRARY DESTINATION ${lib_install_dir}
-    RUNTIME DESTINATION ${bin_install_dir}
-    INCLUDES DESTINATION ${include_install_dir})
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
   install(
     DIRECTORY "${PROJECT_SOURCE_DIR}/include/benchmark"
-    DESTINATION ${include_install_dir}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN "*.*h")
 
   install(


### PR DESCRIPTION
* src/CMakeLists.txt: Added support for setting the standard variables,
                      such as CMAKE_INSTALL_BINDIR.