### PR TITLE
Fix win32 link on case-sensitive fs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 
 # We need extra libraries on Windows
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  target_link_libraries(benchmark Shlwapi)
+  target_link_libraries(benchmark shlwapi)
 endif()
 
 # We need extra libraries on Solaris


### PR DESCRIPTION
This fixes cross-builds with MinGW from case-sensitive file-systems (on Linux)