### PR TITLE
Introduce ScientificNotation and little format updates and fixes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,6 +46,7 @@ Roman Lebedev <lebedev.ri@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Steinar H. Gunderson <sgunderson@bigfoot.com>
 Stripe, Inc.
+Tommaso Bonvicini <tommasobonvicini@gmail.com>
 Yixuan Qiu <yixuanq@gmail.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Zbigniew Skowron <zbychs@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -67,6 +67,7 @@ Roman Lebedev <lebedev.ri@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Tobias Ulvgård <tobias.ulvgard@dirac.se>
 Tom Madams <tom.ej.madams@gmail.com> <tmadams@google.com>
+Tommaso Bonvicini <tommasobonvicini@gmail.com>
 Yixuan Qiu <yixuanq@gmail.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Zbigniew Skowron <zbychs@gmail.com>

--- a/README.md
+++ b/README.md
@@ -263,9 +263,9 @@ tabular data on stdout. Example tabular output looks like:
 ```
 Benchmark                               Time(ns)    CPU(ns) Iterations
 ----------------------------------------------------------------------
-BM_SetInsert/1024/1                        28928      29349      23853  133.097kB/s   33.2742k items/s
-BM_SetInsert/1024/8                        32065      32913      21375  949.487kB/s   237.372k items/s
-BM_SetInsert/1024/10                       33157      33648      21431  1.13369MB/s   290.225k items/s
+BM_SetInsert/1024/1                        28928      29349      23853  133.097kiB/s   33.2742k items/s
+BM_SetInsert/1024/8                        32065      32913      21375  949.487kiB/s   237.372k items/s
+BM_SetInsert/1024/10                       33157      33648      21431  1.13369MiB/s   290.225k items/s
 ```
 
 The JSON format outputs human readable json split into two top level attributes.

--- a/README.md
+++ b/README.md
@@ -681,6 +681,9 @@ and a flag specifying the 'unit' - i.e. is 1k a 1000 (default,
 
   // This says that we process with the rate of state.range(0) bytes every iteration:
   state.counters["BytesProcessed"] = Counter(state.range(0), benchmark::Counter::kIsIterationInvariantRate, benchmark::Counter::OneK::kIs1024);
+
+  // Set the numeric output according to scientific notation (e.g. 1.23456E+05) 
+  state.counters["FooVal"] = Counter(numFoos).setFormat(benchmark::Counter::kScientificNotation);
 ```
 
 When you're compiling in C++11 mode or later you can use `insert()` with

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -380,7 +380,7 @@ class Counter {
 
   enum Format {
     // 123.456M
-    kSI_BaseUnit = 0,
+    kSIUnits = 0,
     // 1.23456E+05
     kScientificNotation = 1
   };
@@ -392,7 +392,7 @@ class Counter {
 
   BENCHMARK_ALWAYS_INLINE
   Counter(double v = 0., Flags f = kDefaults, 
-          OneK k = kIs1000, Format form = kSI_BaseUnit)
+          OneK k = kIs1000, Format form = kSIUnits)
           : value(v), flags(f), oneK(k), format (form) {}
   
   BENCHMARK_ALWAYS_INLINE

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -378,13 +378,22 @@ class Counter {
     kIs1024 = 1024
   };
 
+  enum Format {
+    // 123.456M
+    kSI_BaseUnit = 0,
+    // 1.23456E+05
+    kScientificNotation = 1
+  };
+
   double value;
   Flags flags;
   OneK oneK;
+  Format format;
 
   BENCHMARK_ALWAYS_INLINE
-  Counter(double v = 0., Flags f = kDefaults, OneK k = kIs1000)
-      : value(v), flags(f), oneK(k) {}
+  Counter(double v = 0., Flags f = kDefaults, 
+          OneK k = kIs1000, Format form = kSI_BaseUnit)
+          : value(v), flags(f), oneK(k), format (form) {}
 
   BENCHMARK_ALWAYS_INLINE operator double const&() const { return value; }
   BENCHMARK_ALWAYS_INLINE operator double&() { return value; }

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -394,6 +394,9 @@ class Counter {
   Counter(double v = 0., Flags f = kDefaults, 
           OneK k = kIs1000, Format form = kSI_BaseUnit)
           : value(v), flags(f), oneK(k), format (form) {}
+  
+  BENCHMARK_ALWAYS_INLINE
+  Counter setFormat (Format form) { format = form; return *this; }
 
   BENCHMARK_ALWAYS_INLINE operator double const&() const { return value; }
   BENCHMARK_ALWAYS_INLINE operator double&() { return value; }

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -396,6 +396,10 @@ class Counter {
           : value(v), flags(f), oneK(k), format (form) {}
   
   BENCHMARK_ALWAYS_INLINE
+  Counter setFlags (Flags f) { flags = f; return *this; }
+  BENCHMARK_ALWAYS_INLINE
+  Counter setOneK (OneK k) { oneK = k; return *this; }
+  BENCHMARK_ALWAYS_INLINE
   Counter setFormat (Format form) { format = form; return *this; }
 
   BENCHMARK_ALWAYS_INLINE operator double const&() const { return value; }

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -79,9 +79,8 @@ void ConsoleReporter::PrintHeader(const Run& run) {
                                  "Benchmark", "Time", "CPU", "Iterations");
   if(!run.counters.empty()) {
     if(output_options_ & OO_Tabular) {
-      for(auto const& c : run.counters) {
-        str += FormatString(" %10s", c.first.c_str());
-      }
+      for(auto const& c : run.counters)
+        str += FormatString(" %1$*2$s", c.first.c_str(), ColumnWidth(c));
     } else {
       str += " UserCounters...";
     }

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -70,7 +70,7 @@ static uint ColumnWidth(const std::pair <std::string, Counter>& pair) {
   const Counter& c = pair.second;
   const std::string& name = pair.first;
 
-  uint width = (c.format == Counter::kSI_BaseUnit) ? widths::SI : widths::SN;
+  uint width = (c.format == Counter::kSIUnits) ? widths::SI : widths::SN;
   width += (c.oneK == Counter::kIs1024) ? 1U : 0U;
   width += (c.flags & Counter::kIsRate) ? 2U : 0U;
   return widths::Padding + std::max(width, (uint) name.length());
@@ -178,7 +178,7 @@ void ConsoleReporter::PrintRunData(const Run& result) {
   const bool tabular = (output_options_ & OO_Tabular);
   const char* fmt = tabular ? " %*s" : " %3$s=%2$*1$s";
   for (auto const& c : result.counters) { 
-    std::string value = (c.second.format == Counter::kSI_BaseUnit) ?
+    std::string value = (c.second.format == Counter::kSIUnits) ?
                         HumanReadableNumber(c.second.value, c.second.oneK) :
                         FormatString("%.*E", widths::DecimalPrecision, c.second.value);
     if (c.second.oneK == Counter::kIs1024) 

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -71,6 +71,7 @@ static uint ColumnWidth(const std::pair <std::string, Counter>& pair) {
   const std::string& name = pair.first;
 
   uint width = (c.format == Counter::kSI_BaseUnit) ? widths::SI : widths::SN;
+  width += (c.flags & Counter::kIsRate) ? 2U : 0U;
   return widths::Padding + std::max(width, (uint) name.length());
 }
 
@@ -179,6 +180,8 @@ void ConsoleReporter::PrintRunData(const Run& result) {
     std::string value = (c.second.format == Counter::kSI_BaseUnit) ?
                         HumanReadableNumber(c.second.value, c.second.oneK) :
                         FormatString("%.*E", widths::DecimalPrecision, c.second.value);
+    if (c.second.flags & Counter::kIsRate) 
+      value.append("/s");
 
     int minColWidth = tabular ? ColumnWidth(c) : 0U;
     printer(Out, COLOR_DEFAULT, fmt, minColWidth, value.c_str(), c.first.c_str());

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -52,6 +52,18 @@ bool ConsoleReporter::ReportContext(const Context& context) {
   return true;
 }
 
+// Namespace containing constants related to counter values formatting.
+namespace widths {
+  // Base amount of chars occupied by a float in SN, excluding decimals.
+  static constexpr uint BaseFloat = 8U;
+  // Amount of desired decimal digits for floats in SN.
+  static constexpr uint DecimalPrecision = 5U;
+  // Total amount of chars occupied by a float printed in ScientificNotation.
+  static constexpr uint SN = BaseFloat + DecimalPrecision;
+  // Total amount of chars occupied by a float printed in SI base units.
+  static constexpr uint SI = 9U;
+}
+
 void ConsoleReporter::PrintHeader(const Run& run) {
   std::string str = FormatString("%-*s %13s %15s %12s", static_cast<int>(name_field_width_),
                                  "Benchmark", "Time", "CPU", "Iterations");

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -62,6 +62,8 @@ namespace widths {
   static constexpr uint SN = BaseFloat + DecimalPrecision;
   // Total amount of chars occupied by a float printed in SI base units.
   static constexpr uint SI = 9U;
+  // Additional desired whitespace padding, useful to separate counters. 
+  static constexpr uint Padding = 1U;
 }
 
 void ConsoleReporter::PrintHeader(const Run& run) {

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -71,7 +71,7 @@ static uint ColumnWidth(const std::pair <std::string, Counter>& pair) {
   const std::string& name = pair.first;
 
   uint width = (c.format == Counter::kSIUnits) ? widths::SI : widths::SN;
-  width += (c.oneK == Counter::kIs1024) ? 1U : 0U;
+  width += (c.oneK == Counter::kIs1024) ? 2U : 0U;
   width += (c.flags & Counter::kIsRate) ? 2U : 0U;
   return widths::Padding + std::max(width, (uint) name.length());
 }
@@ -182,7 +182,7 @@ void ConsoleReporter::PrintRunData(const Run& result) {
                         HumanReadableNumber(c.second.value, c.second.oneK) :
                         FormatString("%.*E", widths::DecimalPrecision, c.second.value);
     if (c.second.oneK == Counter::kIs1024) 
-      value.append("i");
+      value.append("iB");
     if (c.second.flags & Counter::kIsRate) 
       value.append("/s");
 

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -71,6 +71,7 @@ static uint ColumnWidth(const std::pair <std::string, Counter>& pair) {
   const std::string& name = pair.first;
 
   uint width = (c.format == Counter::kSI_BaseUnit) ? widths::SI : widths::SN;
+  width += (c.oneK == Counter::kIs1024) ? 1U : 0U;
   width += (c.flags & Counter::kIsRate) ? 2U : 0U;
   return widths::Padding + std::max(width, (uint) name.length());
 }
@@ -180,6 +181,8 @@ void ConsoleReporter::PrintRunData(const Run& result) {
     std::string value = (c.second.format == Counter::kSI_BaseUnit) ?
                         HumanReadableNumber(c.second.value, c.second.oneK) :
                         FormatString("%.*E", widths::DecimalPrecision, c.second.value);
+    if (c.second.oneK == Counter::kIs1024) 
+      value.append("i");
     if (c.second.flags & Counter::kIsRate) 
       value.append("/s");
 

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -66,6 +66,14 @@ namespace widths {
   static constexpr uint Padding = 1U;
 }
 
+static uint ColumnWidth(const std::pair <std::string, Counter>& pair) {
+  const Counter& c = pair.second;
+  const std::string& name = pair.first;
+
+  uint width = (c.format == Counter::kSI_BaseUnit) ? widths::SI : widths::SN;
+  return widths::Padding + std::max(width, (uint) name.length());
+}
+
 void ConsoleReporter::PrintHeader(const Run& run) {
   std::string str = FormatString("%-*s %13s %15s %12s", static_cast<int>(name_field_width_),
                                  "Benchmark", "Time", "CPU", "Iterations");


### PR DESCRIPTION
This PR tries to solve this ISSUES:
* #818: Introduce scientific notation for counters in console
* #819: The "B" bytes suffix isn't really printed
* #820: Use the IEC standard ("i" suffix) when dealing with OneK::kIs1024

I tried to be as clean as possible when building commits.
I suggest to go through the commits one-by-one to follow the various branch development stages.

Any secondary commit (least fundamental ones) should be atomically droppable.