### PR TITLE
Fix Error C2146 and error C4430 in MSVC.

### DIFF
--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -59,7 +59,7 @@ MemoryManager* memory_manager = nullptr;
 
 namespace {
 
-static constexpr IterationCount kMaxIterations = 1000000000;
+static const IterationCount kMaxIterations = 1000000000;
 
 BenchmarkReporter::Run CreateRunReport(
     const benchmark::internal::BenchmarkInstance& b,


### PR DESCRIPTION
Replace ‘constexpr’ with 'const', for Visual Studio 2013.
Fixes #853
CLA: trivial