### PR TITLE
Add .gitignore rule to ignore temporary .swp backup files created by vim.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 !/cmake/*.cmake
 !/test/AssemblyTests.cmake
 *~
+*.swp
 *.pyc
 __pycache__
 


### PR DESCRIPTION

  - Addresses : #858 

  - Rule `*.swp` is added to `.gitignore` to ensure that the vim temporary
    `.swp` backup files are ignored and they don't pollute the results of
    `git status -u`.