### PR TITLE
Perform IWYU on library sources

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -167,21 +167,23 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #define BENCHMARK_HAS_CXX11
 #endif
 
-#include <stdint.h>
+#include <stdint.h>  // IWYU pragma: keep
 
-#include <algorithm>
-#include <cassert>
-#include <cstddef>
-#include <iosfwd>
-#include <map>
-#include <set>
-#include <string>
-#include <vector>
+#include <algorithm>  // for max
+#include <cassert>    // for assert
+#include <cstddef>    // for size_t, ptrdiff_t
+#include <iosfwd>     // for ostream
+#include <iterator>   // for forward_iterator_tag
+#include <map>        // for map
+#include <set>        // for set
+#include <string>     // for string
+#include <vector>     // for vector
+// IWYU pragma: no_include <cstdint>
 
 #if defined(BENCHMARK_HAS_CXX11)
-#include <initializer_list>
-#include <type_traits>
-#include <utility>
+#include <initializer_list>  // IWYU pragma: keep
+#include <type_traits>       // for decay
+#include <utility>           // for pair, make_pair, forward
 #endif
 
 #if defined(_MSC_VER)
@@ -284,8 +286,6 @@ void RegisterMemoryManager(MemoryManager* memory_manager);
 
 namespace internal {
 class Benchmark;
-class BenchmarkImp;
-class BenchmarkFamilies;
 
 void UseCharPointer(char const volatile*);
 

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -13,41 +13,26 @@
 // limitations under the License.
 
 #include "benchmark/benchmark.h"
-#include "benchmark_api_internal.h"
-#include "benchmark_runner.h"
-#include "internal_macros.h"
-
-#ifndef BENCHMARK_OS_WINDOWS
-#ifndef BENCHMARK_OS_FUCHSIA
-#include <sys/resource.h>
-#endif
-#include <sys/time.h>
-#include <unistd.h>
-#endif
 
 #include <algorithm>
-#include <atomic>
-#include <condition_variable>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <fstream>
+#include <fstream>  // IWYU pragma: keep
+#include <initializer_list>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <string>
-#include <thread>
-#include <utility>
+// IWYU pragma: no_include <stdint.h>
 
+#include "benchmark_api_internal.h"
+#include "benchmark_runner.h"
 #include "check.h"
 #include "colorprint.h"
 #include "commandlineflags.h"
-#include "complexity.h"
-#include "counter.h"
-#include "internal_macros.h"
 #include "log.h"
 #include "mutex.h"
-#include "re.h"
-#include "statistics.h"
-#include "string_util.h"
 #include "thread_manager.h"
 #include "thread_timer.h"
 

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -1,15 +1,15 @@
 #ifndef BENCHMARK_API_INTERNAL_H
 #define BENCHMARK_API_INTERNAL_H
 
-#include "benchmark/benchmark.h"
-#include "commandlineflags.h"
+#include <stdint.h>
 
-#include <cmath>
 #include <iosfwd>
-#include <limits>
-#include <memory>
 #include <string>
 #include <vector>
+
+#include "benchmark/benchmark.h"
+#include "thread_manager.h"  // IWYU pragma: keep
+#include "thread_timer.h"    // IWYU pragma: keep
 
 namespace benchmark {
 namespace internal {

--- a/src/benchmark_name.cc
+++ b/src/benchmark_name.cc
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <benchmark/benchmark.h>
+#include <stddef.h>
+
+#include <string>
+
+#include "benchmark/benchmark.h"
 
 namespace benchmark {
 

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -14,41 +14,23 @@
 
 #include "benchmark_register.h"
 
-#ifndef BENCHMARK_OS_WINDOWS
-#ifndef BENCHMARK_OS_FUCHSIA
-#include <sys/resource.h>
-#endif
-#include <sys/time.h>
-#include <unistd.h>
-#endif
-
 #include <algorithm>
-#include <atomic>
-#include <condition_variable>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
+#include <cinttypes>
+#include <cstdint>
 #include <fstream>
-#include <iostream>
 #include <memory>
-#include <sstream>
-#include <thread>
-
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+#include <string>
+#include <utility>
+// IWYU pragma: no_include <ext/new_allocator.h>
 
 #include "benchmark/benchmark.h"
 #include "benchmark_api_internal.h"
 #include "check.h"
-#include "commandlineflags.h"
-#include "complexity.h"
-#include "internal_macros.h"
 #include "log.h"
 #include "mutex.h"
 #include "re.h"
 #include "statistics.h"
 #include "string_util.h"
-#include "timers.h"
 
 namespace benchmark {
 

--- a/src/benchmark_register.h
+++ b/src/benchmark_register.h
@@ -1,6 +1,11 @@
 #ifndef BENCHMARK_REGISTER_H
 #define BENCHMARK_REGISTER_H
 
+#include <stddef.h>
+
+#include <algorithm>
+#include <limits>
+#include <type_traits>
 #include <vector>
 
 #include "check.h"

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -13,41 +13,26 @@
 // limitations under the License.
 
 #include "benchmark_runner.h"
-#include "benchmark/benchmark.h"
-#include "benchmark_api_internal.h"
-#include "internal_macros.h"
 
-#ifndef BENCHMARK_OS_WINDOWS
-#ifndef BENCHMARK_OS_FUCHSIA
-#include <sys/resource.h>
-#endif
-#include <sys/time.h>
-#include <unistd.h>
-#endif
+#include <assert.h>
 
 #include <algorithm>
-#include <atomic>
-#include <condition_variable>
-#include <cstdio>
-#include <cstdlib>
+#include <cstdint>
 #include <fstream>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <thread>
 #include <utility>
+// IWYU pragma: no_include <ext/alloc_traits.h>
 
+#include "benchmark/benchmark.h"
+#include "benchmark_api_internal.h"
 #include "check.h"
-#include "colorprint.h"
-#include "commandlineflags.h"
 #include "complexity.h"
 #include "counter.h"
-#include "internal_macros.h"
 #include "log.h"
 #include "mutex.h"
-#include "re.h"
 #include "statistics.h"
-#include "string_util.h"
 #include "thread_manager.h"
 #include "thread_timer.h"
 

--- a/src/benchmark_runner.h
+++ b/src/benchmark_runner.h
@@ -15,8 +15,11 @@
 #ifndef BENCHMARK_RUNNER_H_
 #define BENCHMARK_RUNNER_H_
 
-#include "benchmark_api_internal.h"
-#include "internal_macros.h"
+#include <vector>
+
+#include "benchmark/benchmark.h"
+#include "benchmark_api_internal.h"  // IWYU pragma: keep
+#include "commandlineflags.h"
 
 DECLARE_double(benchmark_min_time);
 

--- a/src/colorprint.cc
+++ b/src/colorprint.cc
@@ -22,14 +22,14 @@
 #include <string>
 
 #include "check.h"
-#include "internal_macros.h"
+#include "internal_macros.h"  // IWYU pragma: keep
 
 #ifdef BENCHMARK_OS_WINDOWS
 #include <windows.h>
 #include <io.h>
-#else
+#else  // ifdef BENCHMARK_OS_WINDOWS
 #include <unistd.h>
-#endif  // BENCHMARK_OS_WINDOWS
+#endif  // ifndef BENCHMARK_OS_WINDOWS
 
 namespace benchmark {
 namespace {

--- a/src/complexity.cc
+++ b/src/complexity.cc
@@ -15,12 +15,16 @@
 // Source project : https://github.com/ismaelJimenez/cpp.leastsq
 // Adapted to be used with google benchmark
 
-#include "benchmark/benchmark.h"
-
-#include <algorithm>
-#include <cmath>
-#include "check.h"
 #include "complexity.h"
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+// IWYU pragma: no_include <memory>
+
+#include "benchmark/benchmark.h"
+#include "check.h"
+#include "log.h"
 
 namespace benchmark {
 

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -12,24 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <stdarg.h>
+
 #include <algorithm>
-#include <cstdint>
-#include <cstdio>
 #include <cstring>
 #include <iostream>
 #include <string>
-#include <tuple>
+#include <utility>
 #include <vector>
 
 #include "benchmark/benchmark.h"
-#include "check.h"
 #include "colorprint.h"
-#include "commandlineflags.h"
 #include "complexity.h"
 #include "counter.h"
-#include "internal_macros.h"
+#include "internal_macros.h"  // IWYU pragma: keep
 #include "string_util.h"
-#include "timers.h"
 
 namespace benchmark {
 

--- a/src/counter.cc
+++ b/src/counter.cc
@@ -14,6 +14,9 @@
 
 #include "counter.h"
 
+#include <map>
+#include <utility>
+
 namespace benchmark {
 namespace internal {
 

--- a/src/csv_reporter.cc
+++ b/src/csv_reporter.cc
@@ -12,19 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "benchmark/benchmark.h"
-#include "complexity.h"
-
-#include <algorithm>
-#include <cstdint>
 #include <iostream>
+#include <map>
+#include <set>
 #include <string>
-#include <tuple>
+#include <utility>
 #include <vector>
 
+#include "benchmark/benchmark.h"
 #include "check.h"
-#include "string_util.h"
-#include "timers.h"
+#include "complexity.h"
+#include "log.h"
 
 // File format reference: http://edoceo.com/utilitas/csv-file-format.
 

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "benchmark/benchmark.h"
-#include "complexity.h"
+#include <stddef.h>
 
-#include <algorithm>
 #include <cmath>
 #include <cstdint>
-#include <iomanip>  // for setprecision
+#include <iomanip>
 #include <iostream>
 #include <limits>
 #include <string>
-#include <tuple>
+#include <utility>
 #include <vector>
 
+#include "benchmark/benchmark.h"
+#include "complexity.h"
 #include "string_util.h"
 #include "timers.h"
 

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "benchmark/benchmark.h"
-#include "timers.h"
-
-#include <cstdlib>
-
 #include <iostream>
-#include <tuple>
+#include <string>
 #include <vector>
 
+#include "benchmark/benchmark.h"
 #include "check.h"
+#include "log.h"
 #include "string_util.h"
+#include "timers.h"
 
 namespace benchmark {
 

--- a/src/sleep.cc
+++ b/src/sleep.cc
@@ -15,10 +15,9 @@
 #include "sleep.h"
 
 #include <cerrno>
-#include <cstdlib>
 #include <ctime>
 
-#include "internal_macros.h"
+#include "internal_macros.h"  // IWYU pragma: keep
 
 #ifdef BENCHMARK_OS_WINDOWS
 #include <windows.h>

--- a/src/statistics.cc
+++ b/src/statistics.cc
@@ -13,15 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "benchmark/benchmark.h"
+#include "statistics.h"
 
 #include <algorithm>
 #include <cmath>
+#include <iosfwd>
+#include <map>
 #include <numeric>
 #include <string>
+#include <utility>
 #include <vector>
+// IWYU pragma: no_include <memory>
+
+#include "benchmark/benchmark.h"
 #include "check.h"
-#include "statistics.h"
 
 namespace benchmark {
 

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -1,13 +1,16 @@
 #include "string_util.h"
 
+#include <algorithm>
 #include <array>
-#include <cmath>
+#include <cmath>  // IWYU pragma: keep
 #include <cstdarg>
+#include <cstdint>
 #include <cstdio>
 #include <memory>
 #include <sstream>
 
 #include "arraysize.h"
+#include "internal_macros.h"  // IWYU pragma: keep
 
 namespace benchmark {
 namespace {

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -4,7 +4,9 @@
 #include <sstream>
 #include <string>
 #include <utility>
-#include "internal_macros.h"
+
+#include "benchmark/benchmark.h"
+#include "internal_macros.h"  // IWYU pragma: keep
 
 namespace benchmark {
 

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -12,58 +12,64 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "internal_macros.h"
+#include "benchmark/benchmark.h"
+#include "internal_macros.h"  // IWYU pragma: keep
 
 #ifdef BENCHMARK_OS_WINDOWS
 #include <shlwapi.h>
 #undef StrCat  // Don't let StrCat in string_util.h be renamed to lstrcatA
 #include <versionhelpers.h>
 #include <windows.h>
+
 #include <codecvt>
-#else
-#include <fcntl.h>
-#ifndef BENCHMARK_OS_FUCHSIA
-#include <sys/resource.h>
-#endif
-#include <sys/time.h>
-#include <sys/types.h>  // this header must be included before 'sys/sysctl.h' to avoid compilation error on FreeBSD
+#include <memory>
+#else  // ifdef BENCHMARK_OS_WINDOWS
 #include <unistd.h>
+// IWYU pragma: no_include <bits/local_lim.h>
+#endif  // ifndef BENCHMARK_OS_WINDOWS
+
 #if defined BENCHMARK_OS_FREEBSD || defined BENCHMARK_OS_MACOSX || \
     defined BENCHMARK_OS_NETBSD || defined BENCHMARK_OS_OPENBSD
+#include <sys/types.h>  // this header must be included before 'sys/sysctl.h' to avoid compilation error on FreeBSD
 #define BENCHMARK_HAS_SYSCTL
 #include <sys/sysctl.h>
-#endif
-#endif
+#endif  //  defined BENCHMARK_OS_FREEBSD || defined BENCHMARK_OS_MACOSX ||
+        //  defined BENCHMARK_OS_NETBSD || defined BENCHMARK_OS_OPENBSD
+
 #if defined(BENCHMARK_OS_SOLARIS)
 #include <kstat.h>
-#endif
+#endif  //  defined(BENCHMARK_OS_SOLARIS)
+
 #if defined(BENCHMARK_OS_QNX)
 #include <sys/syspage.h>
-#endif
+#endif  // defined(BENCHMARK_OS_QNX)
 
 #include <algorithm>
 #include <array>
 #include <bitset>
-#include <cerrno>
+#include <cctype>
 #include <climits>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
-#include <fstream>
+#include <cstring>  // IWYU pragma: keep
+#include <fstream>  // IWYU pragma: keep
 #include <iostream>
-#include <iterator>
-#include <limits>
-#include <memory>
-#include <sstream>
-#include <locale>
+#include <string>
+#include <utility>
+#include <vector>
 
-#include "check.h"
+#ifdef BENCHMARK_HAS_SYSCTL
+#include <memory>
+#endif  // ifdef BENCHMARK_HAS_SYSCTL
+
 #include "cycleclock.h"
-#include "internal_macros.h"
-#include "log.h"
 #include "sleep.h"
 #include "string_util.h"
+
+#ifdef BENCHMARK_HAS_SYSCTL
+#include "check.h"
+#endif  // ifdef BENCHMARK_HAS_SYSCTL
 
 namespace benchmark {
 namespace {
@@ -434,10 +440,10 @@ std::string GetSystemName() {
 #elif defined(BENCHMARK_OS_QNX)
 #define HOST_NAME_MAX 154
 #endif
-  char hostname[HOST_NAME_MAX];
-  int retVal = gethostname(hostname, HOST_NAME_MAX);
+  std::array<char, HOST_NAME_MAX> hostname;
+  int retVal = gethostname(hostname.data(), HOST_NAME_MAX);
   if (retVal != 0) return std::string("");
-  return std::string(hostname);
+  return std::string(hostname.data());
 #endif // Catch-all POSIX block.
 }
 

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -13,49 +13,45 @@
 // limitations under the License.
 
 #include "timers.h"
-#include "internal_macros.h"
+
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+
+#include "internal_macros.h"  // IWYU pragma: keep
 
 #ifdef BENCHMARK_OS_WINDOWS
 #include <shlwapi.h>
 #undef StrCat  // Don't let StrCat in string_util.h be renamed to lstrcatA
 #include <versionhelpers.h>
 #include <windows.h>
-#else
-#include <fcntl.h>
+#endif  // ifdef BENCHMARK_OS_WINDOWS
+
+#ifndef BENCHMARK_OS_WINDOWS
 #ifndef BENCHMARK_OS_FUCHSIA
-#include <sys/resource.h>
+#include <sys/resource.h>  // IWYU pragma: keep
 #endif
 #include <sys/time.h>
-#include <sys/types.h>  // this header must be included before 'sys/sysctl.h' to avoid compilation error on FreeBSD
-#include <unistd.h>
+// IWYU pragma: no_include <bits/types/struct_rusage.h>
+// IWYU pragma: no_include <bits/types/struct_tm.h>
+#endif  // ifndef BENCHMARK_OS_WINDOWS
+
 #if defined BENCHMARK_OS_FREEBSD || defined BENCHMARK_OS_MACOSX
 #include <sys/sysctl.h>
-#endif
+#include <sys/types.h>  // this header must be included before 'sys/sysctl.h' to avoid compilation error on FreeBSD
+#endif  // defined BENCHMARK_OS_FREEBSD || defined BENCHMARK_OS_MACOSX
+
 #if defined(BENCHMARK_OS_MACOSX)
 #include <mach/mach_init.h>
 #include <mach/mach_port.h>
 #include <mach/thread_act.h>
-#endif
-#endif
+#endif  // defined(BENCHMARK_OS_MACOSX)
 
 #ifdef BENCHMARK_OS_EMSCRIPTEN
 #include <emscripten.h>
-#endif
-
-#include <cerrno>
-#include <cstdint>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
-#include <iostream>
-#include <limits>
-#include <mutex>
+#endif  // ifdef BENCHMARK_OS_EMSCRIPTEN
 
 #include "check.h"
-#include "log.h"
-#include "sleep.h"
-#include "string_util.h"
 
 namespace benchmark {
 


### PR DESCRIPTION
Was looking at time distribution clang spends on my projects
that builds benchmark in-tree, and to my surprise
benchmark_register.cc + benchmark.cc + benchmark_runner.cc +
statistics.cc + benchmark.h were near the top.

There are two (well three) solutions here - to include less
stuff in benchmark's sources, to further partition benchmark's
sources (and to not build it in-tree :S).

This performs the first solution, since it's most straight-forward
and least controversial. The diff looks scary, and indeed i will be
quite surprized if this doesn't break build on some platform.
But I don't foresee any way to avoid that risk.

Repeating the measurements show that this either helps
(- ~2s clang front-end time), or the initial measurement was noisy.