### PR TITLE
Add gitignore rule to ignore CMakeLists.txt.user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__
 CMakeCache.txt
 CMakeFiles/
 cmake_install.cmake
+CMakeLists.txt.user
 
 # makefiles.
 Makefile


### PR DESCRIPTION
  - Addresses : #862

  - `CMakeLists.txt.user` is a XML file created by Qt-Creator if the
    benchmark project is loaded into Qt-Creator using the `CMakeLists.txt`
    file.

  - `CMakeLists.txt.user` pollutes `git status` thus the new rule is added.