### PR TITLE
Addresses issue #634.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ Alternatively, link against the `benchmark_main` library and remove
 The compiled executable will run all benchmarks by default. Pass the `--help`
 flag for option information or see the guide below.
 
-### Platform Specific Build Instructions
+## Platform Specific Build Instructions
 
-#### Building with GCC
+### Building with GCC
 
 When the library is built using GCC it is necessary to link with the pthread
 library due to how GCC implements `std::thread`. Failing to link to pthread will
@@ -204,12 +204,12 @@ can link to pthread by adding `-pthread` to your linker command. Note, you can
 also use `-lpthread`, but there are potential issues with ordering of command
 line parameters if you use that.
 
-#### Building with Visual Studio 2015 or 2017
+### Building with Visual Studio 2015 or 2017
 
 The `shlwapi` library (`-lshlwapi`) is required to support a call to `CPUInfo` which reads the registry. Either add `shlwapi.lib` under `[ Configuration Properties > Linker > Input ]`, or use the following:
 
 ```
-// Alternatively, can add these libraries under [ Configuration Properties > Linker > Input ].
+// Alternatively, can add libraries using linker options.
 #ifdef _WIN32
 #pragma comment ( lib, "Shlwapi.lib" )
 #ifdef _DEBUG
@@ -227,7 +227,7 @@ Can also use the graphical version of CMake:
 * Click `Configure`, `Generate`, `Open Project`.
 * If build fails, try deleting entire directory and starting again, or unticking options to build less.
 
-#### Building with Intel 2015 Update 1 or Intel System Studio Update 4
+### Building with Intel 2015 Update 1 or Intel System Studio Update 4
 
 See instructions for building with Visual Studio. Once built, right click on the solution and change the build to Intel.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The following minimum versions are required to build the library:
 * Visual Studio 14 2015
 * Intel 2015 Update 1
 
+See [Platform-Specific Build Instructions](#platform-specific-build-instructions).
+
 ## Installation
 
 This describes the installation process using cmake. As pre-requisites, you'll
@@ -190,7 +192,9 @@ Alternatively, link against the `benchmark_main` library and remove
 The compiled executable will run all benchmarks by default. Pass the `--help`
 flag for option information or see the guide below.
 
-### Platform-specific instructions
+### Platform Specific Build Instructions
+
+#### Building with GCC
 
 When the library is built using GCC it is necessary to link with the pthread
 library due to how GCC implements `std::thread`. Failing to link to pthread will
@@ -200,8 +204,34 @@ can link to pthread by adding `-pthread` to your linker command. Note, you can
 also use `-lpthread`, but there are potential issues with ordering of command
 line parameters if you use that.
 
-If you're running benchmarks on Windows, the shlwapi library (`-lshlwapi`) is
-also required.
+#### Building with Visual Studio 2015 or 2017
+
+The `shlwapi` library (`-lshlwapi`) is required to support a call to `CPUInfo` which reads the registry. Either add `shlwapi.lib` under `[ Configuration Properties > Linker > Input ]`, or use the following:
+
+```
+// Alternatively, can add these libraries under [ Configuration Properties > Linker > Input ].
+#ifdef _WIN32
+#pragma comment ( lib, "Shlwapi.lib" )
+#ifdef _DEBUG
+#pragma comment ( lib, "benchmarkd.lib" )
+#else
+#pragma comment ( lib, "benchmark.lib" )
+#endif
+#endif
+```
+
+Can also use the graphical version of CMake:
+* Open `CMake GUI`.
+* Under `Where to build the binaries`, same path as source plus `build`.
+* Under `CMAKE_INSTALL_PREFIX`, same path as source plus `install`.
+* Click `Configure`, `Generate`, `Open Project`.
+* If build fails, try deleting entire directory and starting again, or unticking options to build less.
+
+#### Building with Intel 2015 Update 1 or Intel System Studio Update 4
+
+See instructions for building with Visual Studio. Once built, right click on the solution and change the build to Intel.
+
+### Building on Solaris
 
 If you're running benchmarks on solaris, you'll want the kstat library linked in
 too (`-lkstat`).


### PR DESCRIPTION
Fix for issue #634

I spent 3 days trying to build this library under Visual Studio 2017, only to discover it needs the library `Shlwapi.lib` or else it generates almost totally opaque linker errors.

Became so frustrated with the docs that I added full build instructions for Visual Studio 2015, 2017 and Intel Compiler 2015 and 2019.



