### PR TITLE
Added support for hardware performance counters via PAPI library (#869)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,6 +48,7 @@ Sayan Bhattacharjee <aero.sayan@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Steinar H. Gunderson <sgunderson@bigfoot.com>
 Stripe, Inc.
+Walther Zwart <walther.zwart@gmail.com>
 Yixuan Qiu <yixuanq@gmail.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Zbigniew Skowron <zbychs@gmail.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,12 @@ cxx_feature_check(STEADY_CLOCK)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
+# Check if we have libpapi headers
+find_package(Papi)
+if (Papi_FOUND)
+  add_definitions(-DBENCHMARK_HAS_PAPI)
+endif()
+
 # Set up directories
 include_directories(${PROJECT_SOURCE_DIR}/include)
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -69,6 +69,7 @@ Sayan Bhattacharjee <aero.sayan@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Tobias Ulvgård <tobias.ulvgard@dirac.se>
 Tom Madams <tom.ej.madams@gmail.com> <tmadams@google.com>
+Walther Zwart <walther.zwart@gmail.com>
 Yixuan Qiu <yixuanq@gmail.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Zbigniew Skowron <zbychs@gmail.com>

--- a/cmake/Modules/FindPapi.cmake
+++ b/cmake/Modules/FindPapi.cmake
@@ -1,0 +1,14 @@
+find_path(
+  Papi_INCLUDE_DIR
+  NAMES papi.h)
+
+find_library(Papi_LIBRARIES papi)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(
+  Papi
+  DEFAULT_MSG
+  Papi_LIBRARIES Papi_INCLUDE_DIR)
+
+mark_as_advanced(Papi_INCLUDE_DIR Papi_LIBRARIES)

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -435,6 +435,7 @@ struct Statistics {
 
 struct BenchmarkInstance;
 class ThreadTimer;
+class PerformanceCounter;
 class ThreadManager;
 
 enum AggregationReportMode
@@ -672,7 +673,7 @@ class State {
  private:
   State(IterationCount max_iters, const std::vector<int64_t>& ranges,
         int thread_i, int n_threads, internal::ThreadTimer* timer,
-        internal::ThreadManager* manager);
+        internal::PerformanceCounter* perf_counters, internal::ThreadManager* manager);
 
   void StartKeepRunning();
   // Implementation of KeepRunning() and KeepRunningBatch().
@@ -680,6 +681,7 @@ class State {
   bool KeepRunningInternal(IterationCount n, bool is_batch);
   void FinishKeepRunning();
   internal::ThreadTimer* timer_;
+  internal::PerformanceCounter* perf_counters_;
   internal::ThreadManager* manager_;
 
   friend struct internal::BenchmarkInstance;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,12 @@ set_target_properties(benchmark PROPERTIES
 target_include_directories(benchmark PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
     )
+if (Papi_FOUND)
+  target_include_directories(benchmark PRIVATE
+      ${Papi_INCLUDE_DIR}
+      )
+  target_link_libraries(benchmark ${Papi_LIBRARIES})
+endif()
 
 # Link threads.
 target_link_libraries(benchmark  ${BENCHMARK_CXX_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})

--- a/src/benchmark_api_internal.cc
+++ b/src/benchmark_api_internal.cc
@@ -5,8 +5,9 @@ namespace internal {
 
 State BenchmarkInstance::Run(IterationCount iters, int thread_id,
                              internal::ThreadTimer* timer,
+                             internal::PerformanceCounter* perf_counters,
                              internal::ThreadManager* manager) const {
-  State st(iters, arg, thread_id, threads, timer, manager);
+  State st(iters, arg, thread_id, threads, timer, perf_counters, manager);
   benchmark->Run(st);
   return st;
 }

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -2,6 +2,7 @@
 #define BENCHMARK_API_INTERNAL_H
 
 #include "benchmark/benchmark.h"
+#include "performance_events.h"
 #include "commandlineflags.h"
 
 #include <cmath>
@@ -34,14 +35,16 @@ struct BenchmarkInstance {
   double min_time;
   IterationCount iterations;
   int threads;  // Number of concurrent threads to us
+  PerformanceEvents events;
 
   State Run(IterationCount iters, int thread_id, internal::ThreadTimer* timer,
-            internal::ThreadManager* manager) const;
+  internal::PerformanceCounter* perf_counters, internal::ThreadManager* manager) const;
 };
 
 bool FindBenchmarksInternal(const std::string& re,
                             std::vector<BenchmarkInstance>* benchmarks,
-                            std::ostream* Err);
+                            std::ostream* Err,
+                            const std::string& event_list);
 
 bool IsZero(double n);
 

--- a/src/performance_events.cc
+++ b/src/performance_events.cc
@@ -1,0 +1,152 @@
+#include "performance_events.h"
+#ifdef BENCHMARK_HAS_PAPI
+extern "C"
+{
+#include <papi.h>
+}
+
+namespace benchmark {
+namespace internal {
+
+namespace {
+
+  bool Init()
+  {
+    auto inited = PAPI_is_initialized();
+    switch (inited)
+    {
+    case PAPI_NOT_INITED:
+      if (PAPI_VER_CURRENT != PAPI_library_init(PAPI_VER_CURRENT))
+        return false;
+      // fallthrough
+    case PAPI_LOW_LEVEL_INITED:
+    case PAPI_HIGH_LEVEL_INITED:
+      if (PAPI_OK != PAPI_thread_init(pthread_self))
+        return false;
+      break;
+    case PAPI_THREAD_LEVEL_INITED:
+      break;
+    }
+    return true;
+  }
+
+}
+
+PerformanceCounter::PerformanceCounter(const PerformanceEvents& events)
+    : event_set_(PAPI_NULL)
+    , counters_(events.size())
+{
+  if (!Init())
+    return;
+  if (PAPI_OK != PAPI_create_eventset(&event_set_))
+    return;
+  for (const auto event: events)
+  {
+    char name[PAPI_MAX_STR_LEN];
+    if (PAPI_OK != PAPI_event_code_to_name(event, name))
+      continue;
+    event_names_.push_back(std::string(name).substr(5));
+    if (PAPI_OK != PAPI_add_event(event_set_, event))
+      continue;
+  }
+}
+
+PerformanceCounter::~PerformanceCounter()
+{
+  PAPI_cleanup_eventset(event_set_);
+  PAPI_destroy_eventset(&event_set_);
+}
+
+bool PerformanceCounter::Start()
+{
+  return PAPI_OK == PAPI_start(event_set_);
+}
+
+bool PerformanceCounter::Stop()
+{
+  if (PAPI_OK != PAPI_accum(event_set_, counters_.data()))
+    return false;
+  std::vector<long long> dummies(counters_.size());
+  return PAPI_OK == PAPI_stop(event_set_, dummies.data());
+}
+
+void PerformanceCounter::IncrementCounters(UserCounters& counters) const
+{
+  for (std::size_t i = 0; i < counters_.size(); ++i)
+  {
+    auto it = counters.find(event_names_[i]);
+    if (it == counters.end())
+      counters.emplace(event_names_[i], Counter(counters_[i], Counter::kAvgIterations));
+    else
+      it->second.value += counters_[i];
+  }
+}
+
+PerformanceEvents PerformanceCounter::ReadEvents(const std::string& input, std::ostream& err_stream)
+{
+  if (input.empty())
+    return {};
+  if (!Init())
+  {
+    err_stream << "***WARNING*** Could not init papi library\n";
+    return {};
+  }
+  PerformanceEvents events;
+  std::string::size_type start = 0;
+  for (;;)
+  {
+    auto next = input.find(',', start);
+    const auto name = "PAPI_" + input.substr(start, next-start);
+    int code = 0;
+    if (PAPI_OK != PAPI_event_name_to_code(name.data(), &code))
+      err_stream << "***WARNING*** Skipping unknown PAPI event: '" << name << "', check output of papi_avail\n";
+    else
+      events.push_back(code);
+    if (next >= input.size())
+      break;
+    start = next + 1;
+  }
+  return events;
+}
+
+}  // namespace internal
+}  // namespace benchmark
+
+#else
+
+namespace benchmark {
+namespace internal {
+
+PerformanceCounter::PerformanceCounter(const PerformanceEvents&)
+{
+}
+
+PerformanceCounter::~PerformanceCounter()
+{
+}
+
+bool PerformanceCounter::Start()
+{
+  return true;
+}
+
+bool PerformanceCounter::Stop()
+{
+  return true;
+}
+
+void PerformanceCounter::IncrementCounters(UserCounters&) const
+{
+}
+
+PerformanceEvents PerformanceCounter::ReadEvents(const std::string& events, std::ostream& err_stream)
+{
+  if (!events.empty())
+    err_stream << "***WARNING*** PerformanceCounters not supported\n";
+  return PerformanceEvents();
+}
+
+}  // namespace internal
+}  // namespace benchmark
+
+#endif

--- a/src/performance_events.h
+++ b/src/performance_events.h
@@ -1,0 +1,38 @@
+#ifndef BENCHMARK_PERFORMANCE_COUNTER_H
+#define BENCHMARK_PERFORMANCE_COUNTER_H
+
+#include "benchmark/benchmark.h"
+#include <vector>
+#include <string>
+#include <ostream>
+
+namespace benchmark {
+namespace internal {
+
+using PerformanceEvents = std::vector<int>;
+
+class PerformanceCounter
+{
+public:
+  explicit PerformanceCounter(const PerformanceEvents& events);
+  ~PerformanceCounter();
+
+  bool Start();
+  bool Stop();
+
+  void IncrementCounters(UserCounters&) const;
+
+  static PerformanceEvents ReadEvents(const std::string& input, std::ostream& err_stream);
+
+private:
+#ifdef BENCHMARK_HAS_PAPI
+  int event_set_;
+  std::vector<long long> counters_;
+  std::vector<std::string> event_names_;
+#endif
+};
+
+}  // namespace internal
+}  // namespace benchmark
+
+#endif  // BENCHMARK_PERFORMANCE_COUNTER_H


### PR DESCRIPTION
This adds support for performance counters, so you can see why a
benchmark is slow. Currently only works for linux and if the papi
library and headers are found. The output is generated as
UserCounters.