### PR TITLE
Guard definition of __STDC_FORMAT_MACROS in ifndef

### DIFF
--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -34,7 +34,9 @@
 #include <sstream>
 #include <thread>
 
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
 
 #include "benchmark/benchmark.h"


### PR DESCRIPTION
This macro is sometimes already defined and redefining it results
in build errors.

This closes #873