### PR TITLE
Define HOST_NAME_MAX for NaCl and RTEMS

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -429,11 +429,20 @@ std::string GetSystemName() {
 #endif
   return str;
 #else // defined(BENCHMARK_OS_WINDOWS)
+#ifndef HOST_NAME_MAX
 #ifdef BENCHMARK_HAS_SYSCTL // BSD/Mac Doesnt have HOST_NAME_MAX defined
+#define HOST_NAME_MAX 64
+#elif defined(BENCHMARK_OS_NACL)
 #define HOST_NAME_MAX 64
 #elif defined(BENCHMARK_OS_QNX)
 #define HOST_NAME_MAX 154
+#elif defined(BENCHMARK_OS_RTEMS)
+#define HOST_NAME_MAX 256
+#else
+#warning "HOST_NAME_MAX not defined. using 64"
+#define HOST_NAME_MAX 64
 #endif
+#endif // def HOST_NAME_MAX
   char hostname[HOST_NAME_MAX];
   int retVal = gethostname(hostname, HOST_NAME_MAX);
   if (retVal != 0) return std::string("");


### PR DESCRIPTION
These OS's don't always have HOST_NAME_MAX defined, resulting in
build errors.

A few related changes as well:
* Only define HOST_NAME_MAX if it's not already defined. There are
  some cases where this is already defined, e.g. with NaCl if
  __USE_POSIX is set. To avoid all of these, only define it if it's
  not already defined.
* Default HOST_NAME_MAX to 64 and issue a #warning. Having the wrong
  max length is pretty harmless. The name just ends up getting
  truncated and this is only for printing debug info. Because we're
  constructing a std::string from a char[] (so defined length), we
  don't need to worry about gethostname's undefined behavior for
  whether the truncation is null-terminated when the hostname
  doesn't fit in HOST_NAME_MAX. Of course, this doesn't help people
  who have -Werror set, since they'll still get a warning.

This closes #871