### PR TITLE
fixed the param order in g++ command and fixed the path for -L

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ library will be under the build directory you created.
 ```bash
 # Example on linux after running the build steps above. Assumes the
 # `benchmark` and `build` directories are under the current directory.
-$ g++ -std=c++11 -isystem benchmark/include -Lbuild/src -lpthread \
-  -lbenchmark mybenchmark.cc -o mybenchmark
+$ g++ mybenchmark.cc -std=c++11 -isystem benchmark/include \
+  -Lbenchmark/build/src -lpthread -lbenchmark -o mybenchmark
 ```
 
 Alternatively, link against the `benchmark_main` library and remove

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ library will be under the build directory you created.
 # Example on linux after running the build steps above. Assumes the
 # `benchmark` and `build` directories are under the current directory.
 $ g++ mybenchmark.cc -std=c++11 -isystem benchmark/include \
-  -Lbenchmark/build/src -lpthread -lbenchmark -o mybenchmark
+  -Lbenchmark/build/src -lbenchmark -lpthread -o mybenchmark
 ```
 
 Alternatively, link against the `benchmark_main` library and remove


### PR DESCRIPTION
The old parameter order in g++ command gives error when compiles. And the path after -L in that same line is not consistent with the one used above that section.