### PR TITLE
Set CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ option(BENCHMARK_DOWNLOAD_DEPENDENCIES "Allow the downloading and in-tree buildi
 # in cases where it is not possible to build or find a valid version of gtest.
 option(BENCHMARK_ENABLE_GTEST_TESTS "Enable building the unit tests which depend on gtest" ON)
 
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set(ENABLE_ASSEMBLY_TESTS_DEFAULT OFF)
 function(should_enable_assembly_tests)
   if(CMAKE_BUILD_TYPE)


### PR DESCRIPTION
When building on Windows with BUILD_SHARED_LIBS=ON, the symbols were
not being properly exported in the DLL. Fix this by setting
CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.

Fixes: #888 