### PR TITLE
Add method Explicit(), taking a list of Args, to be used one at a time.

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -788,6 +788,7 @@ class Benchmark {
 
   // Run this benchmark once with "x" as the extra argument passed
   // to the function.
+  // Note: Rather than call Arg() repeatedly, use Explicit() below.
   // REQUIRES: The function passed to the constructor must accept an arg1.
   Benchmark* Arg(int64_t x);
 
@@ -804,9 +805,11 @@ class Benchmark {
   // REQUIRES: The function passed to the constructor must accept an arg1.
   Benchmark* DenseRange(int64_t start, int64_t limit, int step = 1);
 
+#if defined(BENCHMARK_HAS_CXX11)
   // Run this benchmark once for every value in list.
   // REQUIRES: The function passed to the constructor must accept an arg1.
   Benchmark* Explicit(std::initializer_list<int64_t> list);
+#endif
 
   // Run this benchmark once with "args" as the extra arguments passed
   // to the function.

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -804,6 +804,10 @@ class Benchmark {
   // REQUIRES: The function passed to the constructor must accept an arg1.
   Benchmark* DenseRange(int64_t start, int64_t limit, int step = 1);
 
+  // Run this benchmark once for every value in list.
+  // REQUIRES: The function passed to the constructor must accept an arg1.
+  Benchmark* Explicit(std::initializer_list<int64_t> list);
+
   // Run this benchmark once with "args" as the extra arguments passed
   // to the function.
   // REQUIRES: The function passed to the constructor must accept arg1, arg2 ...

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -283,6 +283,14 @@ Benchmark* Benchmark::Arg(int64_t x) {
   return this;
 }
 
+Benchmark* Benchmark::Explicit(std::initializer_list<int64_t> arglist) {
+  CHECK(ArgsCnt() == -1 || ArgsCnt() == 1);
+  for (int64_t i : arglist) {
+    args_.push_back({i});
+  }
+  return this;
+}
+
 Benchmark* Benchmark::Unit(TimeUnit unit) {
   time_unit_ = unit;
   return this;

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -283,6 +283,7 @@ Benchmark* Benchmark::Arg(int64_t x) {
   return this;
 }
 
+#if defined(BENCHMARK_HAS_CXX11)
 Benchmark* Benchmark::Explicit(std::initializer_list<int64_t> arglist) {
   CHECK(ArgsCnt() == -1 || ArgsCnt() == 1);
   for (int64_t i : arglist) {
@@ -290,6 +291,7 @@ Benchmark* Benchmark::Explicit(std::initializer_list<int64_t> arglist) {
   }
   return this;
 }
+#endif
 
 Benchmark* Benchmark::Unit(TimeUnit unit) {
   time_unit_ = unit;

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -176,7 +176,7 @@ static void BM_ParallelMemset(benchmark::State& state) {
     delete test_vector;
   }
 }
-BENCHMARK(BM_ParallelMemset)->Arg(10 << 20)->ThreadRange(1, 4);
+BENCHMARK(BM_ParallelMemset)->Explicit({10 << 20})->ThreadRange(1, 4);
 
 static void BM_ManualTiming(benchmark::State& state) {
   int64_t slept_for = 0;

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -176,7 +176,7 @@ static void BM_ParallelMemset(benchmark::State& state) {
     delete test_vector;
   }
 }
-BENCHMARK(BM_ParallelMemset)->Explicit({10 << 20})->ThreadRange(1, 4);
+BENCHMARK(BM_ParallelMemset)->Arg(10 << 20)->ThreadRange(1, 4);
 
 static void BM_ManualTiming(benchmark::State& state) {
   int64_t slept_for = 0;
@@ -217,6 +217,36 @@ void BM_non_template_args(benchmark::State& state, int, double) {
   while(state.KeepRunning()) {}
 }
 BENCHMARK_CAPTURE(BM_non_template_args, basic_test, 0, 0);
+
+static void BM_ExplicitlySpecifiedArgs(benchmark::State& state) {
+  // The only purpose of this benchmark is to verify that the incoming
+  // Arg values (aka state.range(0)) are the ones we expect, in the
+  // order we expect them in.
+  static int last_arg = 0;
+  if (last_arg != state.range(0)) {
+    switch (state.range(0)) {
+      case 6:
+        assert(last_arg == 0);
+        break;
+      case 9:
+        assert(last_arg == 6);
+        break;
+      case 4:
+        assert(last_arg == 9);
+        break;
+      case 2:
+        assert(last_arg == 4);
+        break;
+      default:
+        assert(false);  // unexpected arg
+        break;
+    }
+  }
+  for (auto _ : state) {
+    last_arg = state.range(0);
+  }
+}
+BENCHMARK(BM_ExplicitlySpecifiedArgs)->Explicit({6, 9, 4, 2});
 
 #endif  // BENCHMARK_HAS_CXX11
 

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -222,7 +222,8 @@ static void BM_ExplicitlySpecifiedArgs(benchmark::State& state) {
   // The only purpose of this benchmark is to verify that the incoming
   // Arg values (aka state.range(0)) are the ones we expect, in the
   // order we expect them in.
-  static int last_arg = 0;
+- static int last_arg = 0;
++ static int64_t last_arg = 0;
   if (last_arg != state.range(0)) {
     switch (state.range(0)) {
       case 6:

--- a/test/benchmark_test.cc
+++ b/test/benchmark_test.cc
@@ -222,8 +222,7 @@ static void BM_ExplicitlySpecifiedArgs(benchmark::State& state) {
   // The only purpose of this benchmark is to verify that the incoming
   // Arg values (aka state.range(0)) are the ones we expect, in the
   // order we expect them in.
-- static int last_arg = 0;
-+ static int64_t last_arg = 0;
+  static int64_t last_arg = 0;
   if (last_arg != state.range(0)) {
     switch (state.range(0)) {
       case 6:


### PR DESCRIPTION
Old code: BENCHMARK(BM_SortedArrayLinearSearch)->Arg(3)->Arg(7)->Arg(15)->Arg(31)->Arg(63);
New code: BENCHMARK(BM_SortedArrayLinearSearch)->Explicit({3, 7, 15, 31, 63});