### PR TITLE
Fix for gcc with asm volatile. replaced m with g specifier

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Joao Paulo Magalhaes <joaoppmagalhaes@gmail.com>
 Jussi Knuuttila <jussi.knuuttila@gmail.com>
 Kaito Udagawa <umireon@gmail.com>
 Kishan Kumar <kumar.kishan@outlook.com>
+Klaus Leppkes <klaus.leppkes@gmail.com>
 Lei Xu <eddyxu@gmail.com>
 Matt Clarkson <mattyclarkson@gmail.com>
 Maxim Vafin <maxvafin@gmail.com>

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -311,15 +311,15 @@ BENCHMARK_UNUSED static int stream_init_anchor = InitializeStreams();
 #ifndef BENCHMARK_HAS_NO_INLINE_ASSEMBLY
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
-  asm volatile("" : : "r,m"(value) : "memory");
+  asm volatile("" : : "r,g"(value) : "memory");
 }
 
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
 #if defined(__clang__)
-  asm volatile("" : "+r,m"(value) : : "memory");
+  asm volatile("" : "+r,g"(value) : : "memory");
 #else
-  asm volatile("" : "+m,r"(value) : : "memory");
+  asm volatile("" : "+g,r"(value) : : "memory");
 #endif
 }
 


### PR DESCRIPTION
... to also allow registers to be covered.
Corresponding Issue: https://github.com/google/benchmark/issues/903
GCC discussion:  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92597