### PR TITLE
special treatment for DoNotOptimize using gcc with double long double

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -323,6 +323,21 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
 #endif
 }
 
+#ifdef __GNUC__
+/*special overload for gcc. Issue with double and long double encounterd
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92597
+"+g" is internally turned into "=g" and "0" and so ends up matching too, but "+m,r" is internally turned into "=m,r" "m,0" rather than
+"=m,r" "0,0" and so the memory can be different and is in this case, the input (i.e. %1) is .rodata memory with the constant and output (i.e. %0) is some stack slot.*/
+inline void DoNotOptimize(long double& value) {
+	asm volatile("" : "+g,r"(value) : : "memory");
+}
+inline void DoNotOptimize(double& value) {
+	asm volatile("" : "+g,r"(value) : : "memory");
+}
+
+#endif	//__GNUC__
+
+
 // Force the compiler to flush pending writes to global memory. Acts as an
 // effective read/write barrier
 inline BENCHMARK_ALWAYS_INLINE void ClobberMemory() {

--- a/test/donotoptimize_assembly_test.cc
+++ b/test/donotoptimize_assembly_test.cc
@@ -162,12 +162,6 @@ extern "C" void test_pointer_lvalue() {
   benchmark::DoNotOptimize(xp);
 }
 
-/*test_double_lvalue:
-	movq	.LC0(%rip), %rax
-	movq	%rax, -8(%rsp)
-	leaq	-8(%rsp), %rax
-	ret*/
-
 // CHECK-LABEL: test_double_lvalue
 extern "C" void test_double_lvalue() {
   // CHECK: movq [[SRC:.*]], %rax
@@ -179,14 +173,6 @@ extern "C" void test_double_lvalue() {
   double *xp = &x;
   benchmark::DoNotOptimize(xp);
 }
-
-/*
-test_long_double_lvalue:
-	flds	.LC1(%rip)
-	leaq	-24(%rsp), %rax
-	fstpt	-24(%rsp)
-	ret
-*/
 
 // CHECK-LABEL: test_long_double_lvalue
 extern "C" void test_long_double_lvalue() {

--- a/test/donotoptimize_assembly_test.cc
+++ b/test/donotoptimize_assembly_test.cc
@@ -161,3 +161,44 @@ extern "C" void test_pointer_lvalue() {
   int *xp = &x;
   benchmark::DoNotOptimize(xp);
 }
+
+/*test_double_lvalue:
+	movq	.LC0(%rip), %rax
+	movq	%rax, -8(%rsp)
+	leaq	-8(%rsp), %rax
+	ret*/
+
+// CHECK-LABEL: test_double_lvalue
+extern "C" void test_double_lvalue() {
+  // CHECK: movq [[SRC:.*]], %rax
+  // CHECK: movq %rax,  [[DEST:.*]]
+  // CHECK: leaq [[DEST]], %rax
+  // CHECK-CLANG: movq %rax, -{{[0-9]+}}(%[[REG:[a-z+]+]])
+  // CHECKX: ret
+  double x = 42.0;
+  double *xp = &x;
+  benchmark::DoNotOptimize(xp);
+}
+
+/*
+test_long_double_lvalue:
+	flds	.LC1(%rip)
+	leaq	-24(%rsp), %rax
+	fstpt	-24(%rsp)
+	ret
+*/
+
+// CHECK-LABEL: test_long_double_lvalue
+extern "C" void test_long_double_lvalue() {
+  // CHECK: flds [[SRC:.*]]
+  // CHECK: leaq -{{[0-9]+}}(%[[REG:[a-z+]+]]), %rax
+  // CHECK: fstpt -{{[0-9]+}}(%[[REG:[a-z+]+]])
+  // CHECK-CLANG: movq %rax, -{{[0-9]+}}(%[[REG:[a-z+]+]])
+  // CHECKX: ret
+  long double x = 42.0l;
+  long double *xp = &x;
+  benchmark::DoNotOptimize(xp);
+}
+
+
+


### PR DESCRIPTION
1.) I added 2 tests with assembly check into donotoptimize_assembly_test.cc.
2.) I tested successfully with g++ 9.2 and clang++9 on my machine.
3.) Using Intel C++ (ICC) 19.0.5.281 20190815, the current master as this branch fails:
	 63 - run_donotoptimize_assembly_test_CHECK (Failed)
	 64 - run_state_assembly_test_CHECK (Failed)
	 65 - run_clobber_memory_assembly_test_CHECK (Failed)
