### PR TITLE
Alias CMake Targets. Fixes #921

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,6 +33,7 @@ Ismael Jimenez Martinez <ismael.jimenez.martinez@gmail.com>
 Jern-Kuan Leong <jernkuan@gmail.com>
 JianXiong Zhou <zhoujianxiong2@gmail.com>
 Joao Paulo Magalhaes <joaoppmagalhaes@gmail.com>
+Jordan Williams <jwillikers@protonmail.com>
 Jussi Knuuttila <jussi.knuuttila@gmail.com>
 Kaito Udagawa <umireon@gmail.com>
 Kishan Kumar <kumar.kishan@outlook.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -50,6 +50,7 @@ Jern-Kuan Leong <jernkuan@gmail.com>
 JianXiong Zhou <zhoujianxiong2@gmail.com>
 Joao Paulo Magalhaes <joaoppmagalhaes@gmail.com>
 John Millikin <jmillikin@stripe.com>
+Jordan Williams <jwillikers@protonmail.com>
 Jussi Knuuttila <jussi.knuuttila@gmail.com>
 Kai Wolf <kai.wolf@gmail.com>
 Kaito Udagawa <umireon@gmail.com>

--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ BENCHMARK(BM_StringCopy);
 BENCHMARK_MAIN();
 ```
 
-To run the benchmark, compile and link against the `benchmark` library
-(libbenchmark.a/.so). If you followed the build steps above, this
-library will be under the build directory you created.
+To run the benchmark, compile and link against the `benchmark` library (libbenchmark.a/.so).
+When using CMake, it is recommended to link against the provided `benchmark::benchmark` target.
+If you followed the build steps above, this library will be under the build directory you created.
 
 ```bash
 # Example on linux after running the build steps above. Assumes the
@@ -190,6 +190,7 @@ $ g++ mybenchmark.cc -std=c++11 -isystem benchmark/include \
 
 Alternatively, link against the `benchmark_main` library and remove
 `BENCHMARK_MAIN();` above to get the same behavior.
+As with the `benchmark` library, a `benchmark::benchmark_main` CMake target is provided.
 
 The compiled executable will run all benchmarks by default. Pass the `--help`
 flag for option information or see the guide below.

--- a/README.md
+++ b/README.md
@@ -177,8 +177,9 @@ BENCHMARK(BM_StringCopy);
 BENCHMARK_MAIN();
 ```
 
-To run the benchmark, compile and link against the `benchmark` library (libbenchmark.a/.so).
-If you followed the build steps above, this library will be under the build directory you created.
+To run the benchmark, compile and link against the `benchmark` library
+(libbenchmark.a/.so). If you followed the build steps above, this library will 
+be under the build directory you created.
 
 ```bash
 # Example on linux after running the build steps above. Assumes the
@@ -193,13 +194,18 @@ Alternatively, link against the `benchmark_main` library and remove
 The compiled executable will run all benchmarks by default. Pass the `--help`
 flag for option information or see the guide below.
 
-#### Usage with CMake
-If using CMake, it is recommended to link against the project-provided `benchmark::benchmark` and `benchmark::benchmark_main` targets using `target_link_libraries`.
-It is possible to use ```find_package``` to import an installed version of the library.
+### Usage with CMake
+
+If using CMake, it is recommended to link against the project-provided
+`benchmark::benchmark` and `benchmark::benchmark_main` targets using
+`target_link_libraries`.
+It is possible to use ```find_package``` to import an installed version of the
+library.
 ```cmake
 find_package(benchmark REQUIRED)
 ```
-Alternatively, ```add_subdirectory``` will incorporate the library directly in to one's CMake project.
+Alternatively, ```add_subdirectory``` will incorporate the library directly in
+to one's CMake project.
 ```cmake
 add_subdirectory(benchmark)
 ```

--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ BENCHMARK_MAIN();
 ```
 
 To run the benchmark, compile and link against the `benchmark` library (libbenchmark.a/.so).
-When using CMake, it is recommended to link against the provided `benchmark::benchmark` target.
 If you followed the build steps above, this library will be under the build directory you created.
 
 ```bash
@@ -190,10 +189,24 @@ $ g++ mybenchmark.cc -std=c++11 -isystem benchmark/include \
 
 Alternatively, link against the `benchmark_main` library and remove
 `BENCHMARK_MAIN();` above to get the same behavior.
-As with the `benchmark` library, a `benchmark::benchmark_main` CMake target is provided.
 
 The compiled executable will run all benchmarks by default. Pass the `--help`
 flag for option information or see the guide below.
+
+#### Usage with CMake
+If using CMake, it is recommended to link against the project-provided `benchmark::benchmark` and `benchmark::benchmark_main` targets using `target_link_libraries`.
+It is possible to use ```find_package``` to import an installed version of the library.
+```cmake
+find_package(benchmark REQUIRED)
+```
+Alternatively, ```add_subdirectory``` will incorporate the library directly in to one's CMake project.
+```cmake
+add_subdirectory(benchmark)
+```
+Either way, link to the library as follows.
+```cmake
+target_link_libraries(MyTarget benchmark::benchmark)
+```
 
 ## Platform Specific Build Instructions
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,7 +66,7 @@ set_target_properties(benchmark_main PROPERTIES
 target_include_directories(benchmark PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
     )
-target_link_libraries(benchmark_main benchmark)
+target_link_libraries(benchmark_main benchmark::benchmark)
 
 
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ foreach(item ${BENCHMARK_MAIN})
 endforeach()
 
 add_library(benchmark ${SOURCE_FILES})
+add_library(benchmark::benchmark ALIAS benchmark)
 set_target_properties(benchmark PROPERTIES
   OUTPUT_NAME "benchmark"
   VERSION ${GENERIC_LIB_VERSION}
@@ -55,6 +56,7 @@ endif()
 
 # Benchmark main library
 add_library(benchmark_main "benchmark_main.cc")
+add_library(benchmark::benchmark_main ALIAS benchmark_main)
 set_target_properties(benchmark_main PROPERTIES
   OUTPUT_NAME "benchmark_main"
   VERSION ${GENERIC_LIB_VERSION}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,17 +38,17 @@ add_library(output_test_helper STATIC output_test_helper.cc output_test.h)
 
 macro(compile_benchmark_test name)
   add_executable(${name} "${name}.cc")
-  target_link_libraries(${name} benchmark ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(${name} benchmark::benchmark ${CMAKE_THREAD_LIBS_INIT})
 endmacro(compile_benchmark_test)
 
 macro(compile_benchmark_test_with_main name)
   add_executable(${name} "${name}.cc")
-  target_link_libraries(${name} benchmark_main)
+  target_link_libraries(${name} benchmark::benchmark_main)
 endmacro(compile_benchmark_test_with_main)
 
 macro(compile_output_test name)
   add_executable(${name} "${name}.cc" output_test.h)
-  target_link_libraries(${name} output_test_helper benchmark
+  target_link_libraries(${name} output_test_helper benchmark::benchmark
           ${BENCHMARK_CXX_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 endmacro(compile_output_test)
 
@@ -178,7 +178,7 @@ add_test(NAME complexity_benchmark COMMAND complexity_test --benchmark_min_time=
 if (BENCHMARK_ENABLE_GTEST_TESTS)
   macro(compile_gtest name)
     add_executable(${name} "${name}.cc")
-    target_link_libraries(${name} benchmark
+    target_link_libraries(${name} benchmark::benchmark
         gmock_main ${CMAKE_THREAD_LIBS_INIT})
   endmacro(compile_gtest)
 


### PR DESCRIPTION
This adds two CMake alias targets `benchmark::benchmark` and `benchmark::benchmark_main` to facilitate more convenient / less error-prone linking within CMake. See issue #921  

I updated targets to link to the aliased targets internally, so as to take advantaged of the added safety CMake provides when linking against namespaced targets.

Additionally, I added a section according to the suggestion from @keith-bennett-gbg describing how to use 'find_package' and 'add_subdirectory' to incorporate the CMake project.

Fixes https://github.com/google/benchmark/issues/921