### PR TITLE
Fix cxx03 standard selection, option override in CMake 3.13+. Fixes #933

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ foreach(p
     CMP0056 # export EXE_LINKER_FLAGS to try_run
     CMP0057 # Support no if() IN_LIST operator
     CMP0063 # Honor visibility properties for all targets
+    CMP0077 # Allow option() overrides in importing projects
     )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -148,7 +148,8 @@ if (BENCHMARK_HAS_CXX03_FLAG)
   compile_benchmark_test(cxx03_test)
   set_target_properties(cxx03_test
       PROPERTIES
-      COMPILE_FLAGS "-std=c++03")
+      CXX_STANDARD 98
+      CXX_STANDARD_REQUIRED YES)
   # libstdc++ provides different definitions within <map> between dialects. When
   # LTO is enabled and -Werror is specified GCC diagnoses this ODR violation
   # causing the test to fail to compile. To prevent this we explicitly disable


### PR DESCRIPTION
This PR fixes two small CMake integration bugs when using FetchContent to import the library.

1. The cxx03 test requires a language version below C++11. This was previously enabled if the `-std=c++03` flag is recognized by the compiler. If so, the flag was added to the target via `target_compile_options`. However, importing projects can define `CXX_STANDARD` to be something higher, which takes precedence. Overriding `CXX_STANDARD` in the build here fixes that issue and achieves the same effect.
2. To be able to disable tests, importing projects will want to set `BENCHMARK_ENABLE_TESTING` to "no". However, this doesn't work without creating an identical `option()` in the importing in the importing project. Enabling CMP0077 in supported versions of CMake allows importing projects to set default values for the variables without touching the cache.