### PR TITLE
Fix MSVC warning.

### DIFF
--- a/src/commandlineflags.cc
+++ b/src/commandlineflags.cc
@@ -217,8 +217,8 @@ bool IsTruthyFlagValue(const std::string& value) {
            !(v == '0' || v == 'f' || v == 'F' || v == 'n' || v == 'N');
   } else if (!value.empty()) {
     std::string value_lower(value);
-    std::transform(value_lower.begin(), value_lower.end(),
-                   value_lower.begin(), ::tolower);
+    std::transform(value_lower.begin(), value_lower.end(), value_lower.begin(),
+                   [](char c) { return static_cast<char>(::tolower(c)); });
     return !(value_lower == "false" || value_lower == "no" ||
              value_lower == "off");
   } else


### PR DESCRIPTION
This fixes the Visual Studio 2019 warning:

`C4244: '=': conversion from 'int' to 'char', possible loss of data`

When implicitly casting the return value of tolower() (int) to char.

Fixes: #932