### PR TITLE
Revert "Add d postfix to Debug libraries"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,6 @@ set_target_properties(benchmark PROPERTIES
   OUTPUT_NAME "benchmark"
   VERSION ${GENERIC_LIB_VERSION}
   SOVERSION ${GENERIC_LIB_SOVERSION}
-  DEBUG_POSTFIX "d"
 )
 target_include_directories(benchmark PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
@@ -61,7 +60,6 @@ set_target_properties(benchmark_main PROPERTIES
   OUTPUT_NAME "benchmark_main"
   VERSION ${GENERIC_LIB_VERSION}
   SOVERSION ${GENERIC_LIB_SOVERSION}
-  DEBUG_POSTFIX "d"
 )
 target_include_directories(benchmark PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>


### PR DESCRIPTION
This reverts commit 5ce2429af7a8481581896afaa480552cc7584808.

Reverts https://github.com/google/benchmark/pull/923
Reopens https://github.com/google/benchmark/issues/922
Fixes https://github.com/google/benchmark/issues/928
Closes https://github.com/google/benchmark/pull/930

See discussion in https://github.com/google/benchmark/issues/928
this broke pkg-config support, since there we don't account
for the suffix, nor is it trivial to do so.
