### PR TITLE
Travis-ci: fix PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ sudo: required
 dist: trusty
 language: cpp
 
-env:
-  global:
-    - /usr/local/bin:$PATH
-
 matrix:
   include:
     - compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -165,7 +165,7 @@ matrix:
         - BUILD_32_BITS=ON
         - EXTRA_FLAGS="-m32"
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.4
       compiler: gcc
       env:
         - COMPILER=g++-7 C_COMPILER=gcc-7  BUILD_TYPE=Debug


### PR DESCRIPTION
Line "- /usr/local/bin:$PATH" is misformatted.
It must be something like "- PATH=/usr/local/bin:$PATH".

It seems something changed in tarvis-ci month ago and now this leads to:

Setting environment variables from .travis.yml
$ export PATH=

Defailt PATH is /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
so already containts /usr/local/bin.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@yandex-team.ru>