### PR TITLE
Fix type conversion warnings.

### DIFF
--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -263,8 +263,9 @@ class BenchmarkRunner {
     if (multiplier <= 1.0) multiplier = 2.0;
 
     // So what seems to be the sufficiently-large iteration count? Round up.
-    const IterationCount max_next_iters =
-        std::lround(std::max(multiplier * i.iters, i.iters + 1.0));
+    const IterationCount max_next_iters = static_cast<IterationCount>(
+        std::lround(std::max(multiplier * static_cast<double>(i.iters),
+                             static_cast<double>(i.iters) + 1.0)));
     // But we do have *some* sanity limits though..
     const IterationCount next_iters = std::min(max_next_iters, kMaxIterations);
 

--- a/test/statistics_gtest.cc
+++ b/test/statistics_gtest.cc
@@ -22,7 +22,7 @@ TEST(StatisticsTest, StdDev) {
   EXPECT_DOUBLE_EQ(benchmark::StatisticsStdDev({101, 101, 101, 101}), 0.0);
   EXPECT_DOUBLE_EQ(benchmark::StatisticsStdDev({1, 2, 3}), 1.0);
   EXPECT_DOUBLE_EQ(benchmark::StatisticsStdDev({2.5, 2.4, 3.3, 4.2, 5.1}),
-                   1.1510864433221342);
+                   1.151086443322134);
 }
 
 }  // end namespace

--- a/test/statistics_gtest.cc
+++ b/test/statistics_gtest.cc
@@ -21,8 +21,8 @@ TEST(StatisticsTest, Median) {
 TEST(StatisticsTest, StdDev) {
   EXPECT_DOUBLE_EQ(benchmark::StatisticsStdDev({101, 101, 101, 101}), 0.0);
   EXPECT_DOUBLE_EQ(benchmark::StatisticsStdDev({1, 2, 3}), 1.0);
-  EXPECT_FLOAT_EQ(benchmark::StatisticsStdDev({1.5, 2.4, 3.3, 4.2, 5.1}),
-                  1.42302495);
+  EXPECT_DOUBLE_EQ(benchmark::StatisticsStdDev({2.5, 2.4, 3.3, 4.2, 5.1}),
+                   1.1510864433221342);
 }
 
 }  // end namespace


### PR DESCRIPTION
Fixes #949

Tested locally (Linux/clang), but warnings are on MSVC so may differ.