### PR TITLE
Remove warnings for internal use of CSVReporter

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -284,10 +284,10 @@ void RunBenchmarks(const std::vector<BenchmarkInstance>& benchmarks,
 }
 
 // Disable deprecated warnings temporarily because we need to reference
-// CSVReporter but don't want to trigger -Werror=-Wdeprecated
+// CSVReporter but don't want to trigger -Werror=-Wdeprecated-declarations
 #ifdef __GNUC__
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 std::unique_ptr<BenchmarkReporter> CreateReporter(

--- a/test/output_test_helper.cc
+++ b/test/output_test_helper.cc
@@ -374,10 +374,10 @@ int SetSubstitutions(
 }
 
 // Disable deprecated warnings temporarily because we need to reference
-// CSVReporter but don't want to trigger -Werror=-Wdeprecated
+// CSVReporter but don't want to trigger -Werror=-Wdeprecated-declarations
 #ifdef __GNUC__
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 void RunOutputTests(int argc, char* argv[]) {
   using internal::GetTestCaseList;


### PR DESCRIPTION
In a previous commit[1], diagnostic pragmas were used to avoid this
warning. However, the incorrect warning flag was indicated, leaving the
warning in place. -Wdeprecated is for deprecated features while
-Wdeprecated-declarations for deprecated functions, variables, and
types[2].

Tested via `bazel build //:benchmark` with (no warning) and without (got warning) this change.

[1] c408461983dd3adf49d450d7db926fc46f1d99a0
[2] https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html