### PR TITLE
Add missing <cerrno> header

### DIFF
--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -1,6 +1,7 @@
 #include "string_util.h"
 
 #include <array>
+#include <cerrno>
 #include <cmath>
 #include <cstdarg>
 #include <cstdio>

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -1,7 +1,9 @@
 #include "string_util.h"
 
 #include <array>
+#ifdef BENCHMARK_STL_ANDROID_GNUSTL
 #include <cerrno>
+#endif
 #include <cmath>
 #include <cstdarg>
 #include <cstdio>


### PR DESCRIPTION
This commit fixes a current build error on Android where 'errno' is an unidentified
symbol due to a missing header