### PR TITLE
timestamp: use rfc3339-formatted timestamps in output

### DIFF
--- a/src/timers.cc
+++ b/src/timers.cc
@@ -215,11 +215,12 @@ std::string LocalDateTimeString() {
     tz_len = ::sprintf(tz_offset, "%c%02li:%02li", tz_offset_sign,
         offset_minutes / 100, offset_minutes % 100);
     CHECK(tz_len == 6);
+    ((void)tz_len); // Prevent unused variable warning in optimized build.
   } else {
     // Unknown offset. RFC3339 specifies that unknown local offsets should be
     // written as UTC time with -00:00 timezone.
 #if defined(BENCHMARK_OS_WINDOWS)
-    // potential race condition if another thread calls localtime or gmtime
+    // Potential race condition if another thread calls localtime or gmtime.
     timeinfo_p = ::gmtime(&now);
 #else
     ::gmtime_r(&now, &timeinfo);
@@ -231,6 +232,7 @@ std::string LocalDateTimeString() {
   timestamp_len = std::strftime(storage, sizeof(storage), "%Y-%m-%dT%H:%M:%S",
       timeinfo_p);
   CHECK(timestamp_len == kTimestampLen);
+  ((void)timestamp_len); // Prevent unused variable warning in optimized build.
 
   std::strncat(storage, tz_offset, kTzOffsetLen + 1);
   return std::string(storage);

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -188,22 +188,9 @@ std::string DateTimeString(bool local) {
   std::size_t written;
 
   if (local) {
-#if defined(BENCHMARK_OS_WINDOWS)
-    written =
-        std::strftime(storage, sizeof(storage), "%x %X", ::localtime(&now));
-#else
-    std::tm timeinfo;
-    ::localtime_r(&now, &timeinfo);
-    written = std::strftime(storage, sizeof(storage), "%F %T", &timeinfo);
-#endif
+    written = std::strftime(storage, sizeof(storage), "%FT%T%z", ::localtime(&now));
   } else {
-#if defined(BENCHMARK_OS_WINDOWS)
-    written = std::strftime(storage, sizeof(storage), "%x %X", ::gmtime(&now));
-#else
-    std::tm timeinfo;
-    ::gmtime_r(&now, &timeinfo);
-    written = std::strftime(storage, sizeof(storage), "%F %T", &timeinfo);
-#endif
+    written = std::strftime(storage, sizeof(storage), "%FT%TZ", ::gmtime(&now));
   }
   CHECK(written < kStorageSize);
   ((void)written);  // prevent unused variable in optimized mode.

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -178,27 +178,18 @@ double ThreadCPUUsage() {
 #endif
 }
 
-namespace {
-
-std::string DateTimeString(bool local) {
+std::string LocalDateTimeString() {
   typedef std::chrono::system_clock Clock;
   std::time_t now = Clock::to_time_t(Clock::now());
   const std::size_t kStorageSize = 128;
   char storage[kStorageSize];
   std::size_t written;
 
-  if (local) {
-    written = std::strftime(storage, sizeof(storage), "%FT%T%z", ::localtime(&now));
-  } else {
-    written = std::strftime(storage, sizeof(storage), "%FT%TZ", ::gmtime(&now));
-  }
+  written = std::strftime(storage, sizeof(storage), "%FT%T%z", ::localtime(&now));
+
   CHECK(written < kStorageSize);
   ((void)written);  // prevent unused variable in optimized mode.
   return std::string(storage);
 }
-
-}  // end namespace
-
-std::string LocalDateTimeString() { return DateTimeString(true); }
 
 }  // end namespace benchmark

--- a/test/reporter_output_test.cc
+++ b/test/reporter_output_test.cc
@@ -15,7 +15,7 @@ ADD_CASES(TC_ConsoleOut, {{"^[-]+$", MR_Next},
 static int AddContextCases() {
   AddCases(TC_ConsoleErr,
            {
-               {"%int[-/]%int[-/]%intT%int:%int:%int[-+]%int%int$", MR_Default},
+               {"^%int-%int-%intT%int:%int:%int[-+]%int:%int$", MR_Default},
                {"Running .*/reporter_output_test(\\.exe)?$", MR_Next},
                {"Run on \\(%int X %float MHz CPU s?\\)", MR_Next},
            });

--- a/test/reporter_output_test.cc
+++ b/test/reporter_output_test.cc
@@ -15,7 +15,7 @@ ADD_CASES(TC_ConsoleOut, {{"^[-]+$", MR_Next},
 static int AddContextCases() {
   AddCases(TC_ConsoleErr,
            {
-               {"%int[-/]%int[-/]%int %int:%int:%int$", MR_Default},
+               {"%int[-/]%int[-/]%intT%int:%int:%int[-+]%int%int$", MR_Default},
                {"Running .*/reporter_output_test(\\.exe)?$", MR_Next},
                {"Run on \\(%int X %float MHz CPU s?\\)", MR_Next},
            });


### PR DESCRIPTION
See: https://github.com/google/benchmark/issues/825.

Replace localized timestamps with machine-readable IETF RFC 3339 format
timestamps. This is an attempt to make the output timestamps easily
machine-readable. ISO8601 specifies standards for time interchange
formats. IETF RFC 3339: https://tools.ietf.org/html/rfc3339 defines a
subset of these for use in the internet. The general form for these
timestamps is:

YYYY-MM-DDTHH:mm:SS[+-]hhmm

This replaces the localized time formats that are currently being used
in the benchmark output to prioritize interchangeability and
machine-readability.

This might break existing programs that rely on the particular date-time
format. This might also may make times less human readable. RFC3339 was
intended to balance human readability and simplicity for machine
readability, but it is primarily intended as an internal representation.

Feel free to close this, ask for changes, or whatever. Just seems like it might be nice to
make some timestamps easier to deal with.