### PR TITLE
timers: silence format overflow warning

### DIFF
--- a/src/timers.cc
+++ b/src/timers.cc
@@ -213,9 +213,8 @@ std::string LocalDateTimeString() {
       tz_offset_sign = '-';
     }
 
-    // Apply % 100 to hour to guarantee range [0, 99].
-    tz_len = ::sprintf(tz_offset, "%c%02li:%02li", tz_offset_sign,
-        (offset_minutes / 100) % 100, offset_minutes % 100);
+    tz_len = ::snprintf(tz_offset, sizeof(tz_offset), "%c%02li:%02li",
+        tz_offset_sign, (offset_minutes / 100), offset_minutes % 100);
     CHECK(tz_len == 6);
     ((void)tz_len); // Prevent unused variable warning in optimized build.
   } else {

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -212,8 +212,10 @@ std::string LocalDateTimeString() {
       offset_minutes *= -1;
       tz_offset_sign = '-';
     }
+
+    // Apply % 100 to hour to guarantee range [0, 99].
     tz_len = ::sprintf(tz_offset, "%c%02li:%02li", tz_offset_sign,
-        offset_minutes / 100, offset_minutes % 100);
+        (offset_minutes / 100) % 100, offset_minutes % 100);
     CHECK(tz_len == 6);
     ((void)tz_len); // Prevent unused variable warning in optimized build.
   } else {


### PR DESCRIPTION
A previous PR https://github.com/google/benchmark/pull/965 created an overflow warning in some compilers because the hour field for the timezone offset is not explicitly limited to the range [0, 99]. Expanded the buffer size to avoid all related compiler warnings. I don't think this runs where we would be constrained on stack size, so this should be fine.

@bdice @jrhemstad @LebedevRI 