### PR TITLE
timers: silence strncat truncation warning

### DIFF
--- a/src/timers.cc
+++ b/src/timers.cc
@@ -235,10 +235,9 @@ std::string LocalDateTimeString() {
       timeinfo_p);
   CHECK(timestamp_len == kTimestampLen);
   // Prevent unused variable warning in optimized build.
-  ((void)timestamp_len);
   ((void)kTimestampLen);
 
-  std::strncat(storage, tz_offset, kTzOffsetLen + 1);
+  std::strncat(storage, tz_offset, sizeof(storage) - timestamp_len - 1);
   return std::string(storage);
 }
 


### PR DESCRIPTION
### Address build failure for Release builds using g++-9

g++-9 embeds the [-Wstringop-truncation](https://developers.redhat.com/blog/2018/05/24/detecting-string-truncation-with-gcc-8/) warning option in `-Wall`.  Since `-Wall` and `-Werror` are added for non-MSVC Release builds, this option will cause the compiler to choke on timers.cc:241 if benchmark is configured with `-DCMAKE_BUILD_TYPE=Release`:

```
cmake -DBENCHMARK_ENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release .. && VERBOSE=1 make
...
[  4%] Building CXX object src/CMakeFiles/benchmark.dir/timers.cc.o
cd /home/reid/projects/benchmark/build/src && /usr/bin/g++  -DHAVE_POSIX_REGEX -DHAVE_STD_REGEX -DHAVE_STEADY_CLOCK -I/home/reid/projects/benchmark/include -I/home/reid/projects/benchmark/src -I/home/reid/projects/benchmark/src/../include  -std=c++11  -Wall  -Wextra  -Wshadow  -fstrict-aliasing  -Wno-deprecated-declarations  -Wstrict-aliasing -O3 -DNDEBUG  -Werror  -Wno-deprecated   -o CMakeFiles/benchmark.dir/timers.cc.o -c /home/reid/projects/benchmark/src/timers.cc
In file included from /usr/include/string.h:494,
                 from /usr/include/c++/9/cstring:42,
                 from /home/reid/projects/benchmark/src/timers.cc:49:
In function ‘char* strncat(char*, const char*, size_t)’,
    inlined from ‘std::string benchmark::LocalDateTimeString()’ at /home/reid/projects/benchmark/src/timers.cc:241:15:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:34: error: ‘char* __builtin___strncat_chk(char*, const char*, long unsigned int, long unsigned int)’ output may be truncated copying 7 bytes from a string of length 127 [-Werror=stringop-truncation]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [src/CMakeFiles/benchmark.dir/build.make:284: src/CMakeFiles/benchmark.dir/timers.cc.o] Error 1
make[2]: Leaving directory '/media/hdd1/projects/benchmark/build'
make[1]: *** [CMakeFiles/Makefile2:123: src/CMakeFiles/benchmark.dir/all] Error 2
make[1]: Leaving directory '/media/hdd1/projects/benchmark/build'
make: *** [Makefile:130: all] Error 2

```
Adjusting the "size" argument of std::strncat to consider the remaining space in the destination buffer silences the warning and allows cmake to build to completion.