### PR TITLE
Add support for changing cpu affinity

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -944,6 +944,22 @@ class Benchmark {
   // Equivalent to ThreadRange(NumCPUs(), NumCPUs())
   Benchmark* ThreadPerCpu();
 
+  // Limit count of processors availbale for execution.
+  Benchmark* Processors(int num_processors);
+
+  // Pick a count of processors from range [min_processors, max_processors],
+  // min_processors and max_processors are always included.
+  Benchmark* ProcessorRange(int min_processors, int max_processors);
+
+  // Pick a count of processors from range [min_processors, max_processors],
+  // min_processors and max_processors are always included.
+  // Stride specifies the increment.
+  Benchmark* DenseProcessorRange(int min_processors, int max_processors, int stride = 1);
+
+  // Pin each thread to exactly one processor.
+  // Processors are distributed in round-robin order.
+  Benchmark* BindThreadsToProcessors();
+
   virtual void Run(State& state) = 0;
 
  protected:
@@ -972,6 +988,8 @@ class Benchmark {
   BigOFunc* complexity_lambda_;
   std::vector<Statistics> statistics_;
   std::vector<int> thread_counts_;
+  std::vector<int> processor_counts_;
+  bool bind_threads_to_processors_;
 
   Benchmark& operator=(Benchmark const&);
 };
@@ -1295,6 +1313,7 @@ struct CPUInfo {
   };
 
   int num_cpus;
+  std::vector<int> available_cpus;
   double cycles_per_second;
   std::vector<CacheInfo> caches;
   bool scaling_enabled;

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -34,6 +34,8 @@ struct BenchmarkInstance {
   double min_time;
   IterationCount iterations;
   int threads;  // Number of concurrent threads to us
+  int processors; // Number of processors to use
+  bool bind_threads_to_processors;
 
   State Run(IterationCount iters, int thread_id, internal::ThreadTimer* timer,
             internal::ThreadManager* manager) const;
@@ -46,6 +48,8 @@ bool FindBenchmarksInternal(const std::string& re,
 bool IsZero(double n);
 
 ConsoleReporter::OutputOptions GetOutputOptions(bool force_no_color = false);
+
+void SetThreadAffinity(const std::vector<int> &cpus);
 
 }  // end namespace internal
 }  // end namespace benchmark


### PR DESCRIPTION
CPU affinity mask allows to specify set of processors for each thread.
This could be used in seveal ways:

* limit cpu power to show how benchmark scales with machine size
* bind threads to processors to eliminate noise from cpu scheduler

Add mehods Processors(), ProcessorRange(), DenseProcessorRange() which
define count of available processors similar to count of threads.

Method BindThreadsToProcessors() pins each thread to exactly one processor.
When count of threads bigger than count of processors then processors are
distributed in round-robin order.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@yandex-team.ru>