### PR TITLE
Fix RegisterBenchmark example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,7 +1167,7 @@ int main(int argc, char** argv) {
   for (auto& test_input : { /* ... */ })
       benchmark::RegisterBenchmark(test_input.name(), BM_test, test_input);
   benchmark::Initialize(&argc, argv);
-  benchmark::RunSpecifiedBenchmarks();
+  return benchmark::RunSpecifiedBenchmarks();
 }
 ```
 


### PR DESCRIPTION
This change fixes the `RegisterBenchmark` example in the Readme file to return the result of `RunSpecifiedBenchmarks()`.
If this return is omitted, the program will always exit with status 0, even if one of the benchmarks failed (e.g. by using `state.SkipWithError(...)`).