### PR TITLE
JSONReporter: don't report on scaling if we didn't get it (#1005)

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -176,6 +176,7 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #include <map>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #if defined(BENCHMARK_HAS_CXX11)
@@ -1297,7 +1298,7 @@ struct CPUInfo {
   int num_cpus;
   double cycles_per_second;
   std::vector<CacheInfo> caches;
-  bool scaling_enabled;
+  std::pair<bool /*validity*/, bool /*value*/> scaling_enabled;
   std::vector<double> load_avg;
 
   static const CPUInfo& Get();

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1295,7 +1295,7 @@ struct CPUInfo {
     int num_sharing;
   };
 
-  enum class Scaling {
+  enum Scaling {
     UNKNOWN,
     ENABLED,
     DISABLED

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1295,10 +1295,16 @@ struct CPUInfo {
     int num_sharing;
   };
 
+  enum class Scaling {
+    UNKNOWN,
+    ENABLED,
+    DISABLED
+  };
+
   int num_cpus;
   double cycles_per_second;
   std::vector<CacheInfo> caches;
-  std::pair<bool /*validity*/, bool /*value*/> scaling_enabled;
+  Scaling scaling;
   std::vector<double> load_avg;
 
   static const CPUInfo& Get();

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -122,8 +122,10 @@ bool JSONReporter::ReportContext(const Context& context) {
       << FormatKV("mhz_per_cpu",
                   RoundDouble(info.cycles_per_second / 1000000.0))
       << ",\n";
-  out << indent << FormatKV("cpu_scaling_enabled", info.scaling_enabled)
-      << ",\n";
+  if (info.scaling_enabled.first) {
+    out << indent << FormatKV("cpu_scaling_enabled", info.scaling_enabled.second)
+        << ",\n";
+  }
 
   out << indent << "\"caches\": [\n";
   indent = std::string(6, ' ');

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -122,8 +122,8 @@ bool JSONReporter::ReportContext(const Context& context) {
       << FormatKV("mhz_per_cpu",
                   RoundDouble(info.cycles_per_second / 1000000.0))
       << ",\n";
-  if (info.scaling_enabled.first) {
-    out << indent << FormatKV("cpu_scaling_enabled", info.scaling_enabled.second)
+  if (CPUInfo::Scaling::UNKNOWN != info.scaling) {
+    out << indent << FormatKV("cpu_scaling_enabled", info.scaling == CPUInfo::Scaling::ENABLED ? true : false)
         << ",\n";
   }
 

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -64,7 +64,7 @@ void BenchmarkReporter::PrintBasicContext(std::ostream *out,
     Out << "\n";
   }
 
-  if (info.scaling_enabled.first && info.scaling_enabled.second) {
+  if (CPUInfo::Scaling::ENABLED == info.scaling) {
     Out << "***WARNING*** CPU scaling is enabled, the benchmark "
            "real time measurements may be noisy and will incur extra "
            "overhead.\n";

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -64,7 +64,7 @@ void BenchmarkReporter::PrintBasicContext(std::ostream *out,
     Out << "\n";
   }
 
-  if (info.scaling_enabled) {
+  if (info.scaling_enabled.first && info.scaling_enabled.second) {
     Out << "***WARNING*** CPU scaling is enabled, the benchmark "
            "real time measurements may be noisy and will incur extra "
            "overhead.\n";

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -214,7 +214,7 @@ CPUInfo::Scaling CpuScaling(int num_cpus) {
   // We don't have a valid CPU count, so don't even bother.
   if (num_cpus <= 0) return CPUInfo::Scaling::UNKNOWN;
 #ifdef BENCHMARK_OS_QNX
-  return CPUInfo::Scaling::DISABLED;
+  return CPUInfo::Scaling::UNKNOWN;
 #endif
 #ifndef BENCHMARK_OS_WINDOWS
   // On Linux, the CPUfreq subsystem exposes CPU information as files on the
@@ -226,8 +226,9 @@ CPUInfo::Scaling CpuScaling(int num_cpus) {
         StrCat("/sys/devices/system/cpu/cpu", cpu, "/cpufreq/scaling_governor");
     if (ReadFromFile(governor_file, &res) && res != "performance") return CPUInfo::Scaling::ENABLED;
   }
-#endif
   return CPUInfo::Scaling::DISABLED;
+#endif
+  return CPUInfo::Scaling::UNKNOWN;
 }
 
 int CountSetBitsInCPUMap(std::string Val) {

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -57,6 +57,7 @@
 #include <memory>
 #include <sstream>
 #include <locale>
+#include <utility>
 
 #include "check.h"
 #include "cycleclock.h"
@@ -209,11 +210,11 @@ bool ReadFromFile(std::string const& fname, ArgT* arg) {
   return f.good();
 }
 
-bool CpuScalingEnabled(int num_cpus) {
+std::pair<bool /*validity*/, bool /*value*/> CpuScalingEnabled(int num_cpus) {
   // We don't have a valid CPU count, so don't even bother.
-  if (num_cpus <= 0) return false;
+  if (num_cpus <= 0) return std::make_pair(false, false);
 #ifdef BENCHMARK_OS_QNX
-  return false;
+  return std::make_pair(true, false);
 #endif
 #ifndef BENCHMARK_OS_WINDOWS
   // On Linux, the CPUfreq subsystem exposes CPU information as files on the
@@ -223,10 +224,10 @@ bool CpuScalingEnabled(int num_cpus) {
   for (int cpu = 0; cpu < num_cpus; ++cpu) {
     std::string governor_file =
         StrCat("/sys/devices/system/cpu/cpu", cpu, "/cpufreq/scaling_governor");
-    if (ReadFromFile(governor_file, &res) && res != "performance") return true;
+    if (ReadFromFile(governor_file, &res) && res != "performance") return make_pair(true, true);
   }
 #endif
-  return false;
+  return std::make_pair(true, false);
 }
 
 int CountSetBitsInCPUMap(std::string Val) {

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -210,11 +210,11 @@ bool ReadFromFile(std::string const& fname, ArgT* arg) {
   return f.good();
 }
 
-std::pair<bool /*validity*/, bool /*value*/> CpuScalingEnabled(int num_cpus) {
+CPUInfo::Scaling CpuScaling(int num_cpus) {
   // We don't have a valid CPU count, so don't even bother.
-  if (num_cpus <= 0) return std::make_pair(false, false);
+  if (num_cpus <= 0) return CPUInfo::Scaling::UNKNOWN;
 #ifdef BENCHMARK_OS_QNX
-  return std::make_pair(true, false);
+  return CPUInfo::Scaling::DISABLED;
 #endif
 #ifndef BENCHMARK_OS_WINDOWS
   // On Linux, the CPUfreq subsystem exposes CPU information as files on the
@@ -224,10 +224,10 @@ std::pair<bool /*validity*/, bool /*value*/> CpuScalingEnabled(int num_cpus) {
   for (int cpu = 0; cpu < num_cpus; ++cpu) {
     std::string governor_file =
         StrCat("/sys/devices/system/cpu/cpu", cpu, "/cpufreq/scaling_governor");
-    if (ReadFromFile(governor_file, &res) && res != "performance") return make_pair(true, true);
+    if (ReadFromFile(governor_file, &res) && res != "performance") return CPUInfo::Scaling::ENABLED;
   }
 #endif
-  return std::make_pair(true, false);
+  return CPUInfo::Scaling::DISABLED;
 }
 
 int CountSetBitsInCPUMap(std::string Val) {
@@ -696,7 +696,7 @@ CPUInfo::CPUInfo()
     : num_cpus(GetNumCPUs()),
       cycles_per_second(GetCPUCyclesPerSecond()),
       caches(GetCacheSizes()),
-      scaling_enabled(CpuScalingEnabled(num_cpus)),
+      scaling(CpuScaling(num_cpus)),
       load_avg(GetLoadAvg()) {}
 
 

--- a/test/reporter_output_test.cc
+++ b/test/reporter_output_test.cc
@@ -28,8 +28,7 @@ static int AddContextCases() {
              MR_Next},
             {"\"num_cpus\": %int,$", MR_Next},
             {"\"mhz_per_cpu\": %float,$", MR_Next},
-            {"\"cpu_scaling_enabled\": ", MR_Next},
-            {"\"caches\": \\[$", MR_Next}});
+            {"\"caches\": \\[$", MR_Default}});
   auto const& Info = benchmark::CPUInfo::Get();
   auto const& Caches = Info.caches;
   if (!Caches.empty()) {


### PR DESCRIPTION
1. It should have been std::optional, but it seems it would slightly increment C++ standard version to 17, so it's the pair then.
2. That JSONReporter::Context is very limited in terms of 'create different context in order to test them (dependency injection thing)', so I were unsuccessful to create meaningful test (thoughts were: stringstream->JSONReporter->Report->find strings in the output)