### PR TITLE
Ctest support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@ endforeach()
 
 project (benchmark CXX)
 
-option(BENCHMARK_ENABLE_TESTING "Enable testing of the benchmark library." ON)
+include(CTest)
+
+#option(BENCHMARK_ENABLE_TESTING "Enable testing of the benchmark library." ON)
 option(BENCHMARK_ENABLE_EXCEPTIONS "Enable the use of exceptions in the benchmark library." ON)
 option(BENCHMARK_ENABLE_LTO "Enable link time optimisation of the benchmark library." OFF)
 option(BENCHMARK_USE_LIBCXX "Build and test using libc++ as the standard library." OFF)
@@ -268,8 +270,8 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 # Build the targets
 add_subdirectory(src)
 
-if (BENCHMARK_ENABLE_TESTING)
-  enable_testing()
+if (BUILD_TESTING)
+  #enable_testing()
   if (BENCHMARK_ENABLE_GTEST_TESTS AND
       NOT (TARGET gtest AND TARGET gtest_main AND
            TARGET gmock AND TARGET gmock_main))

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ On a unix system, the build directory should now look something like this:
 Next, you can run the tests to check the build.
 
 ```bash
-$ cmake --build "build" --config Release --target test
+$ cmake -E chdir "build" ctest ../
 ```
 
 If you want to install the library globally, also run:

--- a/cmake/GoogleTest.cmake.in
+++ b/cmake/GoogleTest.cmake.in
@@ -31,7 +31,7 @@ if(EXISTS "${GOOGLETEST_PATH}"            AND IS_DIRECTORY "${GOOGLETEST_PATH}" 
   )
 else()
   if(NOT ALLOW_DOWNLOADING_GOOGLETEST)
-    message(SEND_ERROR "Did not find Google Test sources! Either pass correct path in GOOGLETEST_PATH, or enable ALLOW_DOWNLOADING_GOOGLETEST, or disable BENCHMARK_ENABLE_GTEST_TESTS / BENCHMARK_ENABLE_TESTING.")
+    message(SEND_ERROR "Did not find Google Test sources! Either pass correct path in GOOGLETEST_PATH, or enable BENCHMARK_DOWNLOAD_DEPENDENCIES, or disable BENCHMARK_ENABLE_GTEST_TESTS / BUILD_TESTING.")
   else()
     message(WARNING "Did not find Google Test sources! Fetching from web...")
     ExternalProject_Add(

--- a/conanfile.py
+++ b/conanfile.py
@@ -44,7 +44,6 @@ class GoogleBenchmarkConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
 
-        cmake.definitions["BENCHMARK_ENABLE_TESTING"] = "OFF"
         cmake.definitions["BENCHMARK_ENABLE_GTEST_TESTS"] = "OFF"
         cmake.definitions["BENCHMARK_ENABLE_LTO"] = "ON" if self.options.enable_lto else "OFF"
         cmake.definitions["BENCHMARK_ENABLE_EXCEPTIONS"] = "ON" if self.options.enable_exceptions else "OFF"
@@ -55,6 +54,8 @@ class GoogleBenchmarkConan(ConanFile):
             cmake.definitions["BENCHMARK_USE_LIBCXX"] = "ON" if (str(self.settings.compiler.libcxx) == "libc++") else "OFF"
         else:
             cmake.definitions["BENCHMARK_USE_LIBCXX"] = "OFF"
+
+        cmake.definitions["BUILD_TESTING"] = "OFF"
 
         cmake.configure(build_folder=self._build_subfolder)
         return cmake


### PR DESCRIPTION
Fixes #1023 

Remove `enable_testing()` in favour of including ctest. This also removes the `BENCHMARK_ENABLE_TESTING` option in favour of the cmake built-in `BUILD_TESTING`.