### PR TITLE
Add support for other multi-threading APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,60 @@ BENCHMARK(BM_test)->Range(8, 8<<10)->UseRealTime();
 
 Without `UseRealTime`, CPU time is used by default.
 
+Google/benchmark uses `std::thread` as multithreading environment per default.
+If you want to use another multithreading environment (e.g. OpenMP), you can 
+turn off the automatic threading using the `ManualThreading` function.
+```c++
+static void BM_MultiThreaded(benchmark::State& state) {
+  // Setup code here.
+  for (auto _ : state) {
+#pragma omp parallel num_threads(state.threads)
+    // Run the multithreaded test. 
+  }
+  // Teardown code here.
+}
+
+BENCHMARK(BM_MultiThreaded)->ManualThreading()->Threads(1)->Threads(2)->Threads(4);
+```
+The above example creates a parallel region in each iteration. 
+This includes the setup and teardown of the parallel region in the time measurment and it 
+adds an implicit barrier at the end of each iteration.   
+You can avoid these effects, if you run the whole loop in parallel. 
+Then you must not use the `state` object directly, but create a `ThreadState` object in each thread.
+```c++
+static void BM_MultiThreaded(benchmark::State& state) {
+  // Setup code (shared objects) here.
+#pragma omp parallel num_threads(state.threads)
+  {
+    // Thread-local setup code here.
+    for (auto _ : benchmark::ThreadState(state)) {
+      // Run the multithreaded test. 
+    }
+  }
+  // Teardown code here.
+}
+
+BENCHMARK(BM_MultiThreaded)->ManualThreading()->Threads(1)->Threads(2)->Threads(4);
+```
+If you use the `ThreadState` object and explicitly specify the number of threads, then you must 
+use `ManualThreading` and the number of created `ThreadState` objects must match the number of specified threads. 
+However, if you use `ThreadState` without explicitly specifying the number of threads, 
+then the number of threads is determined by the number of created `ThreadState` objects.
+```c++
+static void BM_MultiThreaded(benchmark::State& state) {
+  // Setup code here.
+#pragma omp parallel 
+  for (auto _ : benchmark::ThreadState(state)) {
+    // Run the multithreaded test. 
+  }
+  // Teardown code here.
+}
+
+BENCHMARK(BM_MultiThreaded);  // measures omp_get_max_threads number of threads.
+```
+Specifying `ManualThreading` is optional in this case.
+
+
 <a name="cpu-timers" />
 
 ### CPU Timers

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -34,6 +34,8 @@ struct BenchmarkInstance {
   double min_time;
   IterationCount iterations;
   int threads;  // Number of concurrent threads to us
+  bool explicit_threading;  // true: Number of threads come from a Threads() call
+  bool manual_threading;
 
   State Run(IterationCount iters, int thread_id, internal::ThreadTimer* timer,
             internal::ThreadManager* manager) const;
@@ -44,6 +46,8 @@ bool FindBenchmarksInternal(const std::string& re,
                             std::ostream* Err);
 
 bool IsZero(double n);
+
+void MergeResults(State& st, ThreadTimer* timer, ThreadManager* manager);
 
 ConsoleReporter::OutputOptions GetOutputOptions(bool force_no_color = false);
 

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -174,6 +174,8 @@ bool BenchmarkFamilies::FindBenchmarks(
         instance.complexity_lambda = family->complexity_lambda_;
         instance.statistics = &family->statistics_;
         instance.threads = num_threads;
+        instance.manual_threading = family->manual_threading_;
+        instance.explicit_threading = !family->thread_counts_.empty();
 
         // Add arguments to instance name
         size_t arg_i = 0;
@@ -268,6 +270,7 @@ Benchmark::Benchmark(const char* name)
       measure_process_cpu_time_(false),
       use_real_time_(false),
       use_manual_time_(false),
+      manual_threading_(false),
       complexity_(oNone),
       complexity_lambda_(nullptr) {
   ComputeStatistics("mean", StatisticsMean);

--- a/src/thread_manager.h
+++ b/src/thread_manager.h
@@ -46,6 +46,7 @@ class ThreadManager {
     std::string report_label_;
     std::string error_message_;
     bool has_error_ = false;
+    int thread_count = 0;
     UserCounters counters;
   };
   GUARDED_BY(GetBenchmarkMutex()) Result results;


### PR DESCRIPTION
This PR replaces the OpenMP PR. It adds more flexibility to multi-threaded benchmarks. 
You can perform scalability tests independent of std::thread. 
And by the means of ThreadState you can also open a parallel region before the iteration loop, which enables you to measure the asynchronous progress of multiple threads across iterations.
For more information see the section "Multithreaded Benchmarks" in the README.