### PR TITLE
Fix realtime measurement for multi-threaded benchmarks

### DIFF
--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -122,9 +122,9 @@ void RunInThread(const BenchmarkInstance* b, IterationCount iters,
   {
     MutexLock l(manager->GetBenchmarkMutex());
     internal::ThreadManager::Result& results = manager->results;
-    results.iterations += st.iterations();
+    results.iterations = st.iterations();
     results.cpu_time_used += timer.cpu_time_used();
-    results.real_time_used += timer.real_time_used();
+    results.real_time_used = std::max(results.real_time_used, timer.real_time_used());
     results.manual_time_used += timer.manual_time_used();
     results.complexity_n += st.complexity_length_n();
     internal::Increment(&results.counters, st.counters);
@@ -227,8 +227,7 @@ class BenchmarkRunner {
     // And get rid of the manager.
     manager.reset();
 
-    // Adjust real/manual time stats since they were reported per thread.
-    i.results.real_time_used /= b.threads;
+    // Adjust manual time stats since they were reported per thread.
     i.results.manual_time_used /= b.threads;
     // If we were measuring whole-process CPU usage, adjust the CPU time too.
     if (b.measure_process_cpu_time) i.results.cpu_time_used /= b.threads;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -128,6 +128,9 @@ add_test(NAME user_counters_test COMMAND user_counters_test --benchmark_min_time
 compile_output_test(internal_threading_test)
 add_test(NAME internal_threading_test COMMAND internal_threading_test --benchmark_min_time=0.01)
 
+compile_output_test(threaded_timer_test)
+add_test(NAME threaded_timer_test COMMAND threaded_timer_test --benchmark_min_time=0.01)
+
 compile_output_test(report_aggregates_only_test)
 add_test(NAME report_aggregates_only_test COMMAND report_aggregates_only_test --benchmark_min_time=0.01)
 

--- a/test/internal_threading_test.cc
+++ b/test/internal_threading_test.cc
@@ -3,28 +3,9 @@
 
 #include <chrono>
 #include <thread>
-#include "../src/timers.h"
 #include "benchmark/benchmark.h"
 #include "output_test.h"
-
-static const std::chrono::duration<double, std::milli> time_frame(50);
-static const double time_frame_in_sec(
-    std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1, 1>>>(
-        time_frame)
-        .count());
-
-void MyBusySpinwait() {
-  const auto start = benchmark::ChronoClockNow();
-
-  while (true) {
-    const auto now = benchmark::ChronoClockNow();
-    const auto elapsed = now - start;
-
-    if (std::chrono::duration<double, std::chrono::seconds::period>(elapsed) >=
-        time_frame)
-      return;
-  }
-}
+#include "spinning.h"
 
 // ========================================================================= //
 // --------------------------- TEST CASES BEGIN ---------------------------- //

--- a/test/spinning.h
+++ b/test/spinning.h
@@ -1,0 +1,29 @@
+#ifndef TEST_SPINNING_H
+#define TEST_SPINNING_H
+
+#include <chrono>
+#include "../src/timers.h"
+
+static const std::chrono::duration<double, std::milli> time_frame(50);
+static const double time_frame_in_sec(
+    std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1, 1>>>(
+        time_frame)
+        .count());
+
+void TimedBusySpinwait(const std::chrono::duration<double, std::milli>& tf) {
+  const auto start = benchmark::ChronoClockNow();
+
+  while (true) {
+    const auto now = benchmark::ChronoClockNow();
+    const auto elapsed = now - start;
+
+    if (std::chrono::duration<double, std::chrono::seconds::period>(elapsed) >= tf)
+      return;
+  }
+}
+
+inline void MyBusySpinwait() {
+  TimedBusySpinwait(time_frame);
+}
+
+#endif  // TEST_SPINNING_H

--- a/test/threaded_timer_test.cc
+++ b/test/threaded_timer_test.cc
@@ -1,0 +1,51 @@
+
+#undef NDEBUG
+
+#include <chrono>
+#include <thread>
+#include "benchmark/benchmark.h"
+#include "output_test.h"
+#include "spinning.h"
+
+// ========================================================================= //
+// --------------------------- TEST CASES BEGIN ---------------------------- //
+// ========================================================================= //
+
+// ========================================================================= //
+// BM_MainThread
+
+void BM_UnbalancedThreads(benchmark::State& state) {
+  const std::chrono::duration<double, std::milli> tf(
+    state.thread_index == 0 ? 100 : 20);
+  const double tf_in_sec(
+    std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1, 1>>>(
+        tf).count());
+
+  for (auto _ : state) {
+    TimedBusySpinwait(tf);
+    state.SetIterationTime(tf_in_sec);
+  }
+}
+
+BENCHMARK(BM_UnbalancedThreads)->Iterations(1)->ThreadRange(1, 4);
+BENCHMARK(BM_UnbalancedThreads)->Iterations(1)->ThreadRange(1, 4)->UseRealTime();
+
+void CheckTimings(Results const& e) {
+  // check that the real time is between 100 and 110 ms
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", GE, 1e08, 0.01);
+  CHECK_FLOAT_RESULT_VALUE(e, "real_time", LT, 1.1e08, 0.01);
+
+  // check that the cpu time is in an reasonable interval
+  double min_cpu_time = ((e.NumThreads() - 1) * 20 + 100) * 1e06;
+  double max_cpu_time = ((e.NumThreads() - 1) * 30 + 110) * 1e06;
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", GE, min_cpu_time, 0.01);
+  CHECK_FLOAT_RESULT_VALUE(e, "cpu_time", LT, max_cpu_time, 0.01);
+}
+
+CHECK_BENCHMARK_RESULTS("BM_UnbalancedThreads", &CheckTimings);
+
+// ========================================================================= //
+// ---------------------------- TEST CASES END ----------------------------- //
+// ========================================================================= //
+
+int main(int argc, char* argv[]) { RunOutputTests(argc, argv); }


### PR DESCRIPTION
I tried to quick-fix the wall-clock time (real time) as discussed in PR #946. This is a prerequiste for adding some tests in PR #1027.
However, the changes now seriously overlap with PR #946 (esp. the change in line https://github.com/google/benchmark/blob/5c25ad3acb24802943935783aadd5e035e6edbf0/src/benchmark_runner.cc#L125).

I realized, that a lot of design questions must be answered before we can go on with #946 and this one.

1. Do we allow a different iteration count across threads. (IMHO no and I'd check this) If yes: what results are reported then? What are their meanings?
2. How is manual timing handled in multi-threaded benchmarks? IMHO the current implementation does not match the comment at https://github.com/google/benchmark/blob/5c25ad3acb24802943935783aadd5e035e6edbf0/include/benchmark/benchmark.h#L553-L554 IMHO and according to the comment it should be handled similar to real time.
3. Which values are written in which mode and what is their meaning? (default/real time/manual time * default/ProcessCPUTime)

@koct9i : Maybe you can use my tests as a template for your PR.