### PR TITLE
Set default option for "LTO" to "True"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project (benchmark CXX)
 
 option(BENCHMARK_ENABLE_TESTING "Enable testing of the benchmark library." ON)
 option(BENCHMARK_ENABLE_EXCEPTIONS "Enable the use of exceptions in the benchmark library." ON)
-option(BENCHMARK_ENABLE_LTO "Enable link time optimisation of the benchmark library." OFF)
+option(BENCHMARK_ENABLE_LTO "Enable link time optimisation of the benchmark library." ON)
 option(BENCHMARK_USE_LIBCXX "Build and test using libc++ as the standard library." OFF)
 if(NOT MSVC)
   option(BENCHMARK_BUILD_32_BITS "Build a 32 bit version of the library." OFF)

--- a/conanfile.py
+++ b/conanfile.py
@@ -22,7 +22,7 @@ class GoogleBenchmarkConan(ConanFile):
         "enable_lto": [True, False],
         "enable_exceptions": [True, False]
     }
-    default_options = {"shared": False, "fPIC": True, "enable_lto": False, "enable_exceptions": True}
+    default_options = {"shared": False, "fPIC": True, "enable_lto": True, "enable_exceptions": True}
 
     _build_subfolder = "."
 


### PR DESCRIPTION
Closes #1022 

Set the default option for `BENCHMARK_ENABLE_LTO` to `True`.