### PR TITLE
Revert previous linker additions for FreeBSD as the problem is Bazel …

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,33 +3,12 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 licenses(["notice"])
 
 config_setting(
-    name = "freebsd",
-    constraint_values = [
-        "@platforms//os:freebsd",
-    ],
-    visibility = [":__subpackages__"],
-)
-
-config_setting(
-    name = "openbsd",
-    constraint_values = [
-        "@platforms//os:openbsd",
-    ],
-    visibility = [":__subpackages__"],
-)
-
-config_setting(
     name = "windows",
-    constraint_values = [
-        "@platforms//os:windows",
-    ],
+    values = {
+        "cpu": "x64_windows",
+    },
     visibility = [":__subpackages__"],
 )
-
-BSD_LINKOPTS = [
-    "-pthread",
-    "-lm",
-]
 
 cc_library(
     name = "benchmark",
@@ -43,8 +22,6 @@ cc_library(
     hdrs = ["include/benchmark/benchmark.h"],
     linkopts = select({
         ":windows": ["-DEFAULTLIB:shlwapi.lib"],
-        ":freebsd": BSD_LINKOPTS,
-        ":openbsd": BSD_LINKOPTS,
         "//conditions:default": ["-pthread"],
     }),
     strip_include_prefix = "include",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,9 +34,3 @@ new_local_repository(
     build_file = "@//bindings/python:python_headers.BUILD",
     path = "/usr/include/python3.6",  # May be overwritten by setup.py.
 )
-
-http_archive(
-    name = "platforms",
-    strip_prefix = "platforms-master",
-    urls = ["https://github.com/bazelbuild/platforms/archive/master.zip"],
-)


### PR DESCRIPTION
…using `/usr/bin/clang` instead of `/usr/bin/clang++` to link C++ code.

The correct fix for this and several other libraries would be getting Bazel to use `/usr/bin/clang++` to link C++ code first
and then fix any remaining linker errors.

See: https://github.com/bazelbuild/bazel/issues/12023