### PR TITLE
benchmark.h: make Run() implementation override

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1008,7 +1008,7 @@ class FunctionBenchmark : public Benchmark {
   FunctionBenchmark(const char* name, Function* func)
       : Benchmark(name), func_(func) {}
 
-  virtual void Run(State& st);
+  virtual void Run(State& st) override;
 
  private:
   Function* func_;
@@ -1018,7 +1018,7 @@ class FunctionBenchmark : public Benchmark {
 template <class Lambda>
 class LambdaBenchmark : public Benchmark {
  public:
-  virtual void Run(State& st) { lambda_(st); }
+  virtual void Run(State& st) override { lambda_(st); }
 
  private:
   template <class OLambda>
@@ -1070,7 +1070,7 @@ class Fixture : public internal::Benchmark {
  public:
   Fixture() : internal::Benchmark("") {}
 
-  virtual void Run(State& st) {
+  virtual void Run(State& st) override {
     this->SetUp(st);
     this->BenchmarkCase(st);
     this->TearDown(st);
@@ -1508,8 +1508,8 @@ class ConsoleReporter : public BenchmarkReporter {
         prev_counters_(),
         printed_header_(false) {}
 
-  virtual bool ReportContext(const Context& context);
-  virtual void ReportRuns(const std::vector<Run>& reports);
+  virtual bool ReportContext(const Context& context) override;
+  virtual void ReportRuns(const std::vector<Run>& reports) override;
 
  protected:
   virtual void PrintRunData(const Run& report);
@@ -1524,9 +1524,9 @@ class ConsoleReporter : public BenchmarkReporter {
 class JSONReporter : public BenchmarkReporter {
  public:
   JSONReporter() : first_report_(true) {}
-  virtual bool ReportContext(const Context& context);
-  virtual void ReportRuns(const std::vector<Run>& reports);
-  virtual void Finalize();
+  virtual bool ReportContext(const Context& context) override;
+  virtual void ReportRuns(const std::vector<Run>& reports) override;
+  virtual void Finalize() override;
 
  private:
   void PrintRunData(const Run& report);
@@ -1539,8 +1539,8 @@ class BENCHMARK_DEPRECATED_MSG(
     : public BenchmarkReporter {
  public:
   CSVReporter() : printed_header_(false) {}
-  virtual bool ReportContext(const Context& context);
-  virtual void ReportRuns(const std::vector<Run>& reports);
+  virtual bool ReportContext(const Context& context) override;
+  virtual void ReportRuns(const std::vector<Run>& reports) override;
 
  private:
   void PrintRunData(const Run& report);


### PR DESCRIPTION
This prevent to trigger an error with recent GCC (gcc 9.x) with -Werror=suggest-override flag

see
````
gbenchmark/include/benchmark/benchmark.h:1005:16: error: ‘virtual void benchmark::internal::FunctionBenchmark::Run(benchmark::State&)’ can be marked override [-Werror=suggest-override]
 1005 |   virtual void Run(State& st);
      |                ^~~
compilation terminated due to -Wfatal-errors.
cc1plus: some warnings being treated as errors
````