### PR TITLE
Bind more State methods/attributes to Python

### DIFF
--- a/bindings/python/google_benchmark/__init__.py
+++ b/bindings/python/google_benchmark/__init__.py
@@ -29,10 +29,12 @@ Example usage:
 
 from absl import app
 from google_benchmark import _benchmark
+from google_benchmark._benchmark import Counter
 
 __all__ = [
     "register",
     "main",
+    "Counter",
 ]
 
 __version__ = "0.1.0"

--- a/bindings/python/google_benchmark/__init__.py
+++ b/bindings/python/google_benchmark/__init__.py
@@ -41,27 +41,27 @@ __version__ = "0.1.0"
 
 
 def register(f=None, *, name=None):
-  if f is None:
-    return lambda f: register(f, name=name)
-  if name is None:
-    name = f.__name__
-  _benchmark.RegisterBenchmark(name, f)
-  return f
+    if f is None:
+        return lambda f: register(f, name=name)
+    if name is None:
+        name = f.__name__
+    _benchmark.RegisterBenchmark(name, f)
+    return f
 
 
 def _flags_parser(argv):
-  argv = _benchmark.Initialize(argv)
-  return app.parse_flags_with_usage(argv)
+    argv = _benchmark.Initialize(argv)
+    return app.parse_flags_with_usage(argv)
 
 
 def _run_benchmarks(argv):
-  if len(argv) > 1:
-    raise app.UsageError('Too many command-line arguments.')
-  return _benchmark.RunSpecifiedBenchmarks()
+    if len(argv) > 1:
+        raise app.UsageError("Too many command-line arguments.")
+    return _benchmark.RunSpecifiedBenchmarks()
 
 
 def main(argv=None):
-  return app.run(_run_benchmarks, argv=argv, flags_parser=_flags_parser)
+    return app.run(_run_benchmarks, argv=argv, flags_parser=_flags_parser)
 
 
 # Methods for use with custom main function.

--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -1,6 +1,7 @@
 // Benchmark for Python.
 
 #include "benchmark/benchmark.h"
+
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
@@ -29,9 +30,8 @@ std::vector<std::string> Initialize(const std::vector<std::string>& argv) {
 }
 
 void RegisterBenchmark(const char* name, py::function f) {
-  benchmark::RegisterBenchmark(name, [f](benchmark::State& state) {
-    f(&state);
-  });
+  benchmark::RegisterBenchmark(name,
+                               [f](benchmark::State& state) { f(&state); });
 }
 
 PYBIND11_MODULE(_benchmark, m) {

--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -1,5 +1,8 @@
 // Benchmark for Python.
 
+#include <vector>
+#include <string>
+
 #include "benchmark/benchmark.h"
 
 #include "pybind11/pybind11.h"

--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -5,6 +5,7 @@
 
 #include "benchmark/benchmark.h"
 
+#include "pybind11/operators.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
@@ -42,6 +43,36 @@ PYBIND11_MODULE(_benchmark, m) {
   m.def("RegisterBenchmark", RegisterBenchmark);
   m.def("RunSpecifiedBenchmarks",
         []() { benchmark::RunSpecifiedBenchmarks(); });
+
+  using benchmark::Counter;
+  py::class_<Counter> py_counter(m, "Counter");
+
+  py::enum_<Counter::Flags>(py_counter, "Flags")
+      .value("kDefaults", Counter::Flags::kDefaults)
+      .value("kIsRate", Counter::Flags::kIsRate)
+      .value("kAvgThreads", Counter::Flags::kAvgThreads)
+      .value("kAvgThreadsRate", Counter::Flags::kAvgThreadsRate)
+      .value("kIsIterationInvariant", Counter::Flags::kIsIterationInvariant)
+      .value("kIsIterationInvariantRate",
+             Counter::Flags::kIsIterationInvariantRate)
+      .value("kAvgIterations", Counter::Flags::kAvgIterations)
+      .value("kAvgIterationsRate", Counter::Flags::kAvgIterationsRate)
+      .value("kInvert", Counter::Flags::kInvert)
+      .export_values()
+      .def(py::self | py::self);
+
+  py::enum_<Counter::OneK>(py_counter, "OneK")
+      .value("kIs1000", Counter::OneK::kIs1000)
+      .value("kIs1024", Counter::OneK::kIs1024)
+      .export_values();
+
+  py_counter  //
+      .def(py::init<double, Counter::Flags, Counter::OneK>(),
+           py::arg("value") = 0., py::arg("flags") = Counter::kDefaults,
+           py::arg("k") = Counter::kIs1000)
+      .def_readwrite("value", &Counter::value)
+      .def_readwrite("flags", &Counter::flags)
+      .def_readwrite("oneK", &Counter::oneK);
 
   py::class_<benchmark::State>(m, "State")
       .def("__bool__", &benchmark::State::KeepRunning)

--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -1,9 +1,9 @@
 // Benchmark for Python.
 
-#include <vector>
-#include <string>
-
 #include "benchmark/benchmark.h"
+
+#include <string>
+#include <vector>
 
 #include "pybind11/operators.h"
 #include "pybind11/pybind11.h"
@@ -74,9 +74,25 @@ PYBIND11_MODULE(_benchmark, m) {
       .def_readwrite("flags", &Counter::flags)
       .def_readwrite("oneK", &Counter::oneK);
 
-  py::class_<benchmark::State>(m, "State")
-      .def("__bool__", &benchmark::State::KeepRunning)
-      .def_property_readonly("keep_running", &benchmark::State::KeepRunning)
-      .def("skip_with_error", &benchmark::State::SkipWithError);
+  using benchmark::State;
+  py::class_<State>(m, "State")
+      .def("__bool__", &State::KeepRunning)
+      .def_property_readonly("keep_running", &State::KeepRunning)
+      .def("pause_timing", &State::PauseTiming)
+      .def("resume_timing", &State::ResumeTiming)
+      .def("skip_with_error", &State::SkipWithError)
+      .def_property_readonly("error_occured", &State::error_occurred)
+      .def("set_iteration_time", &State::SetIterationTime)
+      .def_property("bytes_processed", &State::bytes_processed,
+                    &State::SetBytesProcessed)
+      .def_property("complexity_n", &State::complexity_length_n,
+                    &State::SetComplexityN)
+      .def_property("items_processed", &State::items_processed,
+                    &State::SetItemsProcessed)
+      .def("set_label", (void (State::*)(const char*)) & State::SetLabel)
+      .def("range", &State::range, py::arg("pos") = 0)
+      .def_property_readonly("iterations", &State::iterations)
+      .def_readonly("thread_index", &State::thread_index)
+      .def_readonly("threads", &State::threads);
 };
 }  // namespace

--- a/bindings/python/google_benchmark/example.py
+++ b/bindings/python/google_benchmark/example.py
@@ -20,7 +20,11 @@ In the extracted directory, execute:
   python setup.py install
 """
 
+import random
+import time
+
 import google_benchmark as benchmark
+from google_benchmark import Counter
 
 
 @benchmark.register
@@ -36,12 +40,57 @@ def sum_million(state):
 
 
 @benchmark.register
+def pause_timing(state):
+    """Pause timing every iteration."""
+    while state:
+        # Construct a list of random ints every iteration without timing it
+        state.pause_timing()
+        random_list = [random.randint(0, 100) for _ in range(100)]
+        state.resume_timing()
+        # Time the in place sorting algorithm
+        random_list.sort()
+
+
+@benchmark.register
 def skipped(state):
     if True:  # Test some predicate here.
         state.skip_with_error("some error")
         return  # NOTE: You must explicitly return, or benchmark will continue.
 
     ...  # Benchmark code would be here.
+
+
+@benchmark.register
+def manual_timing(state):
+    while state:
+        # Manually count Python CPU time
+        start = time.perf_counter()  # perf_counter_ns() in Python 3.7+
+        # Somehting to benchmark
+        time.sleep(0.01)
+        end = time.perf_counter()
+        state.set_iteration_time(end - start)
+
+
+@benchmark.register
+def custom_counters(state):
+    """Collect cutom metric using benchmark.Counter."""
+    num_foo = 0.0
+    while state:
+        # Benchmark some code here
+        pass
+        # Collect some custom metric named foo
+        num_foo += 0.13
+
+    # Automatic Counter from numbers.
+    state.counters["foo"] = num_foo
+    # Set a counter as a rate.
+    state.counters["foo_rate"] = Counter(num_foo, Counter.kIsRate)
+    #  Set a counter as an inverse of rate.
+    state.counters["foo_inv_rate"] = Counter(num_foo, Counter.kIsRate | Counter.kInvert)
+    # Set a counter as a thread-average quantity.
+    state.counters["foo_avg"] = Counter(num_foo, Counter.kAvgThreads)
+    # There's also a combined flag:
+    state.counters["foo_avg_rate"] = Counter(num_foo, Counter.kAvgThreadsRate)
 
 
 if __name__ == "__main__":

--- a/bindings/python/google_benchmark/example.py
+++ b/bindings/python/google_benchmark/example.py
@@ -25,24 +25,24 @@ import google_benchmark as benchmark
 
 @benchmark.register
 def empty(state):
-  while state:
-    pass
+    while state:
+        pass
 
 
 @benchmark.register
 def sum_million(state):
-  while state:
-    sum(range(1_000_000))
+    while state:
+        sum(range(1_000_000))
 
 
 @benchmark.register
 def skipped(state):
-  if True:  # Test some predicate here.
-    state.skip_with_error('some error')
-    return  # NOTE: You must explicitly return, or benchmark will continue.
+    if True:  # Test some predicate here.
+        state.skip_with_error("some error")
+        return  # NOTE: You must explicitly return, or benchmark will continue.
 
-  ...  # Benchmark code would be here.
+    ...  # Benchmark code would be here.
 
 
-if __name__ == '__main__':
-  benchmark.main()
+if __name__ == "__main__":
+    benchmark.main()


### PR DESCRIPTION
Hi,

The following PR binds more of the `State` methods in Python.
  - Bind `Counter::Flags` and bind `operator|`
  - Bind `Counter::OneK`
  - Bind `Counter`
  - Make Counter implicitly constructible from `float`, `int`
  - Bind some more `State` methods
  - Bind `State::counters` making it possible to use `state.counters["foo"] = 42` and `state.counters["foo"] = Counter(42, Counter.kIsRate)`...

However, there remains a number of questions:
  - [ ] Explicit the naming convention for function.methods? Python typically uses `snake_case`, which seems to have been done for methods but not functions
  - [ ] Define a test strategy/framework. This is hard because `State` are not constructible without registering a benchmark and running the main function.