### PR TITLE
Fixed pkg-config on other than Ubuntu GNU/Linux distributions.

### DIFF
--- a/cmake/benchmark.pc.in
+++ b/cmake/benchmark.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/lib
-includedir=${prefix}/include
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: Google microbenchmark framework


### PR DESCRIPTION
Fixed installation on other than Ubuntu GNU/Linux distributions.

Fedora and other GNU/Linux distributions use different $libdir prefixes. Now it can be installed on any GNU/Linux distributions.