### PR TITLE
src/benchmark_register.h: add missing <limits> inclusion

### DIFF
--- a/src/benchmark_register.h
+++ b/src/benchmark_register.h
@@ -1,6 +1,7 @@
 #ifndef BENCHMARK_REGISTER_H
 #define BENCHMARK_REGISTER_H
 
+#include <limits>
 #include <vector>
 
 #include "check.h"


### PR DESCRIPTION
Noticed missing header when was building llvm with gcc-11:

```
llvm-project/llvm/utils/benchmark/src/benchmark_register.h:17:30:
  error: 'numeric_limits' is not a member of 'std'
   17 |   static const T kmax = std::numeric_limits<T>::max();
      |                              ^~~~~~~~~~~~~~
```