### PR TITLE
Rename 'mftbl' to 'mftb'

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -74,6 +74,7 @@ Robert Guo <robert.guo@mongodb.com>
 Roman Lebedev <lebedev.ri@gmail.com>
 Sayan Bhattacharjee <aero.sayan@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>
+Steven Wan <wan.yu@ibm.com>
 Tobias Ulvgård <tobias.ulvgard@dirac.se>
 Tom Madams <tom.ej.madams@gmail.com> <tmadams@google.com>
 Yixuan Qiu <yixuanq@gmail.com>

--- a/src/cycleclock.h
+++ b/src/cycleclock.h
@@ -92,7 +92,7 @@ inline BENCHMARK_ALWAYS_INLINE int64_t Now() {
   uint32_t tbl, tbu0, tbu1;
   asm volatile(
       "mftbu %0\n"
-      "mftbl %1\n"
+      "mftb %1\n"
       "mftbu %2"
       : "=r"(tbu0), "=r"(tbl), "=r"(tbu1));
   tbl &= -static_cast<int32_t>(tbu0 == tbu1);


### PR DESCRIPTION
AIX does not recognize `mftbl`. Since `mftb` and `mftbl` are equivalent, rename `mftbl` to `mftb` instead. This should fix https://github.com/google/benchmark/issues/1068.