### PR TITLE
Fix Range when starting at zero

### DIFF
--- a/src/benchmark_register.h
+++ b/src/benchmark_register.h
@@ -87,7 +87,7 @@ void AddRange(std::vector<T>* dst, T lo, T hi, int mult) {
   }
 
   // Treat 0 as a special case (see discussion on #762).
-  if (lo <= 0 && hi >= 0) {
+  if (lo < 0 && hi >= 0) {
     dst->push_back(0);
   }
 

--- a/test/benchmark_gtest.cc
+++ b/test/benchmark_gtest.cc
@@ -90,6 +90,12 @@ TEST(AddRangeTest, ZeroOnlyRange) {
   EXPECT_THAT(dst, testing::ElementsAre(0));
 }
 
+TEST(AddRangeTest, ZeroStartingRange) {
+  std::vector<int> dst;
+  AddRange(&dst, 0, 2, 2);
+  EXPECT_THAT(dst, testing::ElementsAre(0, 1, 2));
+}
+
 TEST(AddRangeTest, NegativeRange64) {
   std::vector<int64_t> dst;
   AddRange<int64_t>(&dst, -4, 4, 2);


### PR DESCRIPTION
The existing behavior results in the `0` value being added twice. Since `lo` is always added to `dst`, we never want to explicitly add `0` if `lo` is equal to `0`.