### PR TITLE
Add bazel target for benchmark_release

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,8 +10,8 @@ config_setting(
     visibility = [":__subpackages__"],
 )
 
-cc_library(
-    name = "benchmark",
+filegroup(
+    name = "benchmark_srcs",
     srcs = glob(
         [
             "src/*.cc",
@@ -19,7 +19,25 @@ cc_library(
         ],
         exclude = ["src/benchmark_main.cc"],
     ),
+)
+
+cc_library(
+    name = "benchmark",
+    srcs = [":benchmark_srcs"],
     hdrs = ["include/benchmark/benchmark.h"],
+    linkopts = select({
+        ":windows": ["-DEFAULTLIB:shlwapi.lib"],
+        "//conditions:default": ["-pthread"],
+    }),
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "benchmark_release",
+    srcs = [":benchmark_srcs"],
+    hdrs = ["include/benchmark/benchmark.h"],
+    defines = ["NDEBUG"],
     linkopts = select({
         ":windows": ["-DEFAULTLIB:shlwapi.lib"],
         "//conditions:default": ["-pthread"],


### PR DESCRIPTION
Fixes google#1077

Bazel clients currently cannot build the benchmark library in Release
mode. This commit adds a new target ":benchmark_release" to enable this.