### PR TITLE
Revert "Add bazel target for benchmark_release"

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,8 +10,8 @@ config_setting(
     visibility = [":__subpackages__"],
 )
 
-filegroup(
-    name = "benchmark_srcs",
+cc_library(
+    name = "benchmark",
     srcs = glob(
         [
             "src/*.cc",
@@ -19,25 +19,7 @@ filegroup(
         ],
         exclude = ["src/benchmark_main.cc"],
     ),
-)
-
-cc_library(
-    name = "benchmark",
-    srcs = [":benchmark_srcs"],
     hdrs = ["include/benchmark/benchmark.h"],
-    linkopts = select({
-        ":windows": ["-DEFAULTLIB:shlwapi.lib"],
-        "//conditions:default": ["-pthread"],
-    }),
-    strip_include_prefix = "include",
-    visibility = ["//visibility:public"],
-)
-
-cc_library(
-    name = "benchmark_release",
-    srcs = [":benchmark_srcs"],
-    hdrs = ["include/benchmark/benchmark.h"],
-    defines = ["NDEBUG"],
     linkopts = select({
         ":windows": ["-DEFAULTLIB:shlwapi.lib"],
         "//conditions:default": ["-pthread"],


### PR DESCRIPTION
Reverts google/benchmark#1078

Uncondtionally adding `-DNDEBUG` will only fool the target into thinking it's build in release mode when it actually is not.
Instead, users should pass `--compilation_mode=opt` ([docs](https://github.com/google/benchmark/issues/1077#issuecomment-750495312)) when building the benchmark to build it in release mode (including enabling all compilation optimizations).

See https://github.com/google/benchmark/issues/1077#issuecomment-750495312