### PR TITLE
Fix broken conan build for arm targets (#892)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -51,7 +51,10 @@ class GoogleBenchmarkConan(ConanFile):
 
         # See https://github.com/google/benchmark/pull/638 for Windows 32 build explanation
         if self.settings.os != "Windows":
-            cmake.definitions["BENCHMARK_BUILD_32_BITS"] = "ON" if "64" not in str(self.settings.arch) else "OFF"
+            if self.settings.compiler == "gcc":
+                cmake.definitions["BENCHMARK_BUILD_32_BITS"] = "OFF"
+            else:
+                cmake.definitions["BENCHMARK_BUILD_32_BITS"] = "ON" if "64" not in str(self.settings.arch) else "OFF"
             cmake.definitions["BENCHMARK_USE_LIBCXX"] = "ON" if (str(self.settings.compiler.libcxx) == "libc++") else "OFF"
         else:
             cmake.definitions["BENCHMARK_USE_LIBCXX"] = "OFF"


### PR DESCRIPTION
This fixes issue #892.

Building via conan for an arm platform (e. g. arch=armv8) doesn't work.

When compiling on an arm platform, "arch" is typically set to "armv#" where # denotes the version. Since there is no "64" contained in "arch" (as in "x86_64" on a PC), the code in conanfile.py sets the option "BENCHMARK_BUILD_32_BITS" to ON, which later adds the compiler option "-m32". This option is not supported by gcc and the build fails accordingly.

The check for the "64" substring in "arch" makes no sense for gcc, so I made it conditional.