### PR TITLE
Re-enable bazel without bazelisk and with scoped build/test targets

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: build
       run: |
-        bazel build //...
+        bazel build //src/... //test/...
         
     - name: test
       run: |

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -11,18 +11,15 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-#    - name: mount bazel cache
-#      uses: actions/cache@v1
-#      with:
-#        path: "/home/runner/.cache/bazel"
-#        key: bazel
-
-#    - name: install bazelisk
-#      run: |
-#        curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64"
-#        mkdir -p "${GITHUB_WORKSPACE}/bin/"
-#        mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
-#        chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
+    - name: mount bazel cache
+      uses: actions/cache@v2.0.0
+      env:
+        cache-name: bazel-cache
+      with:
+        path: "~/.cache/bazel"
+        key: ${{ env.cache-name }}-${{ runner.os }}-${{ github.ref }}
+        restore-keys: |
+          ${{ env.cache-name }}-${{ runner.os }}-master
 
     - name: build
       run: |
@@ -30,4 +27,4 @@ jobs:
         
     - name: test
       run: |
-        bazel test //test/...
+        bazel test --test_output=errors //test/...

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: build
       run: |
-        bazel build //src/... //test/...
+        bazel build //:benchmark //:benchmark_main //test/...
         
     - name: test
       run: |

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -24,10 +24,10 @@ jobs:
 #        mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
 #        chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
 
-#    - name: build
-#      run: |
-#        "${GITHUB_WORKSPACE}/bin/bazel" build //...
+    - name: build
+      run: |
+        bazel build //...
         
-#    - name: test
-#      run: |
-#        "${GITHUB_WORKSPACE}/bin/bazel" test //test/...
+    - name: test
+      run: |
+        bazel test //test/...


### PR DESCRIPTION
bazelisk is now part of the github actions by default, so this can be much simpler.

building `//bindings/...` through bazel requires python header dependencies and we already test that independently (though not through bazel).