### PR TITLE
Shrink the tz_offset size to 41.

### DIFF
--- a/src/timers.cc
+++ b/src/timers.cc
@@ -190,8 +190,16 @@ std::string LocalDateTimeString() {
   std::size_t timestamp_len;
   long int offset_minutes;
   char tz_offset_sign = '+';
-  // Long enough buffers to avoid format-overflow warnings
-  char tz_offset[128];
+  // tz_offset is set in one of three ways:
+  // * strftime with %z - This either returns empty or the ISO 8601 time.  The maximum length an
+  //   ISO 8601 string can be is 7 (e.g. -03:30, plus trailing zero).
+  // * snprintf with %c%02li:%02li - The maximum length is 41 (one for %c, up to 19 for %02li,
+  //   one for :, up to 19 %02li, plus trailing zero).
+  // * A fixed string of "-00:00".  The maximum length is 7 (-00:00, plus trailing zero).
+  //
+  // Thus, the maximum size this needs to be is 41.
+  char tz_offset[41];
+  // Long enough buffer to avoid format-overflow warnings
   char storage[128];
 
 #if defined(BENCHMARK_OS_WINDOWS)


### PR DESCRIPTION
When building with gcc TSan on, and in Debug mode, we see a warning
like:

benchmark/src/timers.cc: In function ‘std::string benchmark::LocalDateTimeString()’:
src/timers.cc:241:15: warning: ‘char* strncat(char*, const char*, size_t)’ output may be truncated copying 108 bytes from a string of length 127 [-Wstringop-truncation]
  241 |   std::strncat(storage, tz_offset, sizeof(storage) - timestamp_len - 1);
      |   ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

While this is essentially a false positive (we never expect
the number of bytes in tz_offset to be too large), the compiler can't
actually tell that.  Shrink the size of tz_offset to a smaller, but still safe
size to eliminate this warning.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I was able to reproduce this problem in the current codebase with the following procedure:

```
mkdir build
cd build
cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-O2 -fsanitize=thread -fno-omit-frame-pointer" -DBENCHMARK_ENABLE_GTEST_TESTS=OFF
make -j10
```

After this patch, I no longer see this problem.  I also verified that the warning from #980 (hi @brianwolfe!) is still fixed.