### PR TITLE
Add multiple compiler support to build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,8 @@ jobs:
         build_type: ['Release', 'Debug']
         include:
           - extra_flags: "-m32"
-            build_32_bits: true
+            build_32_bits: on
+          - build_32_bits: off
     steps:
     - uses: actions/checkout@v2
 
@@ -38,7 +39,7 @@ jobs:
         -DBENCHMARK_BUILD_32_BITS=${{ matrix.build_32_bits }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DCMAKE_C_FLAGS="${{ matrix.extra_flags }}"
-        -DCMAKE_CXX_FLAGS="{{ matrix.extra_flags }} ${{ matrix.extra_cxx_flags }}"
+        -DCMAKE_CXX_FLAGS="${{ matrix.extra_flags }} ${{ matrix.extra_cxx_flags }}"
 
     - name: build
       shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,11 @@ on:
     branches: [ master ]
 
 jobs:
+  # TODO: add job using container ubuntu:14.04 with and without g++-6
+  # TODO: add 32-bit builds (g++ and clang++) for ubuntu (requires g++-multilib and libc6:i386)
+  # TODO: add coverage build (requires lcov)
+  # TODO: add clang + libc++ builds for ubuntu
+  # TODO: add clang + ubsan/asan/msan + libc++ builds for ubuntu
   job:
     name: ${{ matrix.os }}.${{ matrix.build_type }}.${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,17 +9,14 @@ on:
 jobs:
   job:
     # TODO(dominic): Extend this to include compiler and set through env: CC/CXX.
-    name: ${{ matrix.os }}.${{ matrix.build_type }}
+    name: ${{ matrix.os }}.${{ matrix.build_type }}.${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-16.04, ubuntu-20.04, macos-latest, windows-latest]
         build_type: ['Release', 'Debug']
-        include:
-          - extra_flags: "-m32"
-            build_32_bits: on
-          - build_32_bits: off
+        compiler: [g++, clang++]
     steps:
     - uses: actions/checkout@v2
 
@@ -27,19 +24,15 @@ jobs:
       run: cmake -E make_directory ${{ runner.workspace }}/_build
 
     - name: configure cmake
-      #env:
-        #EXTRA_FLAGS: ${{ matrix.extra_flags }}
-        #EXTRA_CXX_FLAGS: ${{ matrix.extra_cxx_flags }}
-        #BUILD_32_BITS: ${{ matrix.build_32_bits }}
+      env:
+        CXX: ${{ matrix.compiler }}
       shell: bash
       working-directory: ${{ runner.workspace }}/_build
       run: >
         cmake $GITHUB_WORKSPACE 
         -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
-        -DBENCHMARK_BUILD_32_BITS=${{ matrix.build_32_bits }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DCMAKE_C_FLAGS="${{ matrix.extra_flags }}"
-        -DCMAKE_CXX_FLAGS="${{ matrix.extra_flags }} ${{ matrix.extra_cxx_flags }}"
+        -DCMAKE_CXX_COMPILER=`which ${{ matrix.compiler }}`
 
     - name: build
       shell: bash
@@ -49,4 +42,4 @@ jobs:
     - name: test
       shell: bash
       working-directory: ${{ runner.workspace }}/_build
-      run: ctest -C ${{ matrix.build_type }} -VV
+      run: ctest --config ${{ matrix.build_type }} -VV

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-16.04, ubuntu-20.04, macos-latest, windows-latest]
         build_type: ['Release', 'Debug']
+        include:
+          - extra_flags: "-m32"
+            build_32_bits: true
     steps:
     - uses: actions/checkout@v2
 
@@ -23,9 +26,19 @@ jobs:
       run: cmake -E make_directory ${{ runner.workspace }}/_build
 
     - name: configure cmake
+      #env:
+        #EXTRA_FLAGS: ${{ matrix.extra_flags }}
+        #EXTRA_CXX_FLAGS: ${{ matrix.extra_cxx_flags }}
+        #BUILD_32_BITS: ${{ matrix.build_32_bits }}
       shell: bash
       working-directory: ${{ runner.workspace }}/_build
-      run: cmake -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+      run: >
+        cmake $GITHUB_WORKSPACE 
+              -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+              -DBENCHMARK_BUILD_32_BITS=${{ matrix.build_32_bits }}
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+              -DCMAKE_C_FLAGS="${{ matrix.extra_flags }}"
+              -DCMAKE_CXX_FLAGS="{{ matrix.extra_flags }} ${{ matrix.extra_cxx_flags }}"
 
     - name: build
       shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,6 @@ jobs:
         cmake $GITHUB_WORKSPACE 
         -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DCMAKE_CXX_COMPILER=`which ${{ matrix.compiler }}`
 
     - name: build
       shell: bash
@@ -48,4 +47,4 @@ jobs:
     - name: test
       shell: bash
       working-directory: ${{ runner.workspace }}/_build
-      run: ctest --config ${{ matrix.build_type }} -VV
+      run: ctest -C ${{ matrix.build_type }} -VV

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,9 +13,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-16.04, ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-16.04, ubuntu-20.04, macos-latest]
         build_type: ['Release', 'Debug']
         compiler: [g++, clang++]
+        include:
+          - displayTargetName: windows-latest-release
+            os: windows-latest
+            build_type: 'Release'
+          - displayTargetName: windows-latest-debug
+            os: windows-latest
+            build_type: 'Debug'
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,11 +34,11 @@ jobs:
       working-directory: ${{ runner.workspace }}/_build
       run: >
         cmake $GITHUB_WORKSPACE 
-              -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
-              -DBENCHMARK_BUILD_32_BITS=${{ matrix.build_32_bits }}
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-              -DCMAKE_C_FLAGS="${{ matrix.extra_flags }}"
-              -DCMAKE_CXX_FLAGS="{{ matrix.extra_flags }} ${{ matrix.extra_cxx_flags }}"
+        -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+        -DBENCHMARK_BUILD_32_BITS=${{ matrix.build_32_bits }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DCMAKE_C_FLAGS="${{ matrix.extra_flags }}"
+        -DCMAKE_CXX_FLAGS="{{ matrix.extra_flags }} ${{ matrix.extra_cxx_flags }}"
 
     - name: build
       shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   job:
-    # TODO(dominic): Extend this to include compiler and set through env: CC/CXX.
     name: ${{ matrix.os }}.${{ matrix.build_type }}.${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Adding another matrix entry for ubuntu/macos to build under both g++ and clang++