### PR TITLE
Add ubuntu-14.04 build and test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,13 +70,13 @@ jobs:
       run: sudo apt update && sudo apt -y install cmake g++-4.8 clang-3.6
 
     - name: create build environment
-      run: cmake -E make_directory ${{ runner.workspace }}/benchmark/_build
+      run: cmake -E make_directory ${{ github.workspace }}/_build
 
     - name: configure cmake
       env:
         CXX: ${{ matrix.compiler }}
       shell: bash
-      working-directory: ${{ runner.workspace }}/benchmark/_build
+      working-directory: ${{ github.workspace }}/_build
       run: >
         cmake $GITHUB_WORKSPACE
         -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
@@ -84,11 +84,11 @@ jobs:
 
     - name: build
       shell: bash
-      working-directory: ${{ runner.workspace }}/benchmark/_build
+      working-directory: ${{ github.workspace }}/_build
       run: cmake --build . --config ${{ matrix.build_type }}
 
     - name: test
       shell: bash
-      working-directory: ${{ runner.workspace }}/benchmark/_build
+      working-directory: ${{ github.workspace }}/_build
       run: ctest -C ${{ matrix.build_type }} -VV
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,6 +66,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: install required bits
+      run: sudo apt install cmake g++ clang
+
     - name: create build environment
       run: cmake -E make_directory ${{ runner.workspace }}/_build
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,6 +54,7 @@ jobs:
       run: ctest -C ${{ matrix.build_type }} -VV
 
   # TODO: add compiler g++-6 to ubuntu-14.04 job
+  # TODO: enable testing for g++-6 compiler
   ubuntu-14_04:
     name: ubuntu-14.04.${{ matrix.build_type }}.${{ matrix.compiler }}
     runs-on: [ubuntu-latest]
@@ -70,7 +71,7 @@ jobs:
       run: sudo apt update && sudo apt -y install clang-3.6 cmake3 g++-4.8 git
 
     - name: create build environment
-      run: ls -l $GITHUB_WORKSPACE && cmake -E make_directory $GITHUB_WORKSPACE/_build
+      run: cmake -E make_directory $GITHUB_WORKSPACE/_build
 
     - name: configure cmake
       env:
@@ -78,10 +79,10 @@ jobs:
       shell: bash
       working-directory: ${{ github.workspace }}/_build
       run: >
-        ls -l $GITHUB_WORKSPACE && cmake $GITHUB_WORKSPACE
-        #-DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
-        -DBENCHMARK_ENABLE_TESTING=off  # Disabled testing on compilers that don't support googletest
+        cmake $GITHUB_WORKSPACE
+        -DBENCHMARK_ENABLE_TESTING=off
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        #-DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
 
     - name: build
       shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,7 +67,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: install required bits
-      run: sudo apt update && sudo apt -y install cmake g++-4.8 clang-3.6
+      run: sudo apt update && sudo apt -y install cmake3 g++-4.8 clang-3.6
 
     - name: create build environment
       run: ls -l $GITHUB_WORKSPACE && cmake -E make_directory $GITHUB_WORKSPACE/_build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,8 +55,8 @@ jobs:
 
   # TODO: add compiler g++-6 to ubuntu-14.04 job
   ubuntu-14_04:
-    name: ubuntu-14.04.${{ matrix.build_type }}.${{ matrix.compiler }}
-    runs-on: ${{ ubuntu-latest }}
+    name: ubuntu-14_04.${{ matrix.build_type }}.${{ matrix.compiler }}
+    runs-on: [ubuntu-latest]
     strategy:
       fail-fast: false
       matrix:
@@ -75,7 +75,7 @@ jobs:
       shell: bash
       working-directory: ${{ runner.workspace }}/_build
       run: >
-        cmake $GITHUB_WORKSPACE 
+        cmake $GITHUB_WORKSPACE
         -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
@@ -88,3 +88,4 @@ jobs:
       shell: bash
       working-directory: ${{ runner.workspace }}/_build
       run: ctest -C ${{ matrix.build_type }} -VV
+

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -79,7 +79,8 @@ jobs:
       working-directory: ${{ github.workspace }}/_build
       run: >
         ls -l $GITHUB_WORKSPACE && cmake $GITHUB_WORKSPACE
-        -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+        #-DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+        -DBENCHMARK_ENABLE_TESTING=off  # Disabled testing on compilers that don't support googletest
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
     - name: build
@@ -87,8 +88,8 @@ jobs:
       working-directory: ${{ github.workspace }}/_build
       run: cmake --build . --config ${{ matrix.build_type }}
 
-    - name: test
-      shell: bash
-      working-directory: ${{ github.workspace }}/_build
-      run: ctest -C ${{ matrix.build_type }} -VV
+      # - name: test
+      #   shell: bash
+      #   working-directory: ${{ github.workspace }}/_build
+      #   run: ctest -C ${{ matrix.build_type }} -VV
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,7 +70,7 @@ jobs:
       run: sudo apt update && sudo apt -y install cmake g++-4.8 clang-3.6
 
     - name: create build environment
-      run: cmake -E make_directory ${{ github.workspace }}/_build
+      run: ls -l $GITHUB_WORKSPACE && cmake -E make_directory $GITHUB_WORKSPACE/_build
 
     - name: configure cmake
       env:
@@ -78,7 +78,7 @@ jobs:
       shell: bash
       working-directory: ${{ github.workspace }}/_build
       run: >
-        cmake $GITHUB_WORKSPACE
+        ls -l $GITHUB_WORKSPACE && cmake $GITHUB_WORKSPACE
         -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,7 +67,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: install required bits
-      run: sudo apt install cmake g++-4.8 clang-3.6
+      run: sudo apt update && sudo apt install cmake g++-4.8 clang-3.6
 
     - name: create build environment
       run: cmake -E make_directory ${{ runner.workspace }}/_build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,9 +58,8 @@ jobs:
     name: ubuntu-14.04.${{ matrix.build_type }}.${{ matrix.compiler }}
     runs-on: ${{ ubuntu-latest }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        os: [linux]
         build_type: ['Release', 'Debug']
         compiler: [g++, clang++]
     container: ubuntu:14.04

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,7 +55,7 @@ jobs:
 
   # TODO: add compiler g++-6 to ubuntu-14.04 job
   ubuntu-14_04:
-    name: ubuntu-14_04.${{ matrix.build_type }}.${{ matrix.compiler }}
+    name: ubuntu-14.04.${{ matrix.build_type }}.${{ matrix.compiler }}
     runs-on: [ubuntu-latest]
     strategy:
       fail-fast: false
@@ -70,13 +70,13 @@ jobs:
       run: sudo apt update && sudo apt -y install cmake g++-4.8 clang-3.6
 
     - name: create build environment
-      run: cmake -E make_directory ${{ runner.workspace }}/_build
+      run: cmake -E make_directory ${{ runner.workspace }}/benchmark/_build
 
     - name: configure cmake
       env:
         CXX: ${{ matrix.compiler }}
       shell: bash
-      working-directory: ${{ runner.workspace }}/_build
+      working-directory: ${{ runner.workspace }}/benchmark/_build
       run: >
         cmake $GITHUB_WORKSPACE
         -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
@@ -84,11 +84,11 @@ jobs:
 
     - name: build
       shell: bash
-      working-directory: ${{ runner.workspace }}/_build
+      working-directory: ${{ runner.workspace }}/benchmark/_build
       run: cmake --build . --config ${{ matrix.build_type }}
 
     - name: test
       shell: bash
-      working-directory: ${{ runner.workspace }}/_build
+      working-directory: ${{ runner.workspace }}/benchmark/_build
       run: ctest -C ${{ matrix.build_type }} -VV
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,7 +67,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: install required bits
-      run: sudo apt update && sudo apt -y install cmake3 g++-4.8 clang-3.6
+      run: sudo apt update && sudo apt -y install clang-3.6 cmake3 g++-4.8 git
 
     - name: create build environment
       run: ls -l $GITHUB_WORKSPACE && cmake -E make_directory $GITHUB_WORKSPACE/_build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,7 +54,7 @@ jobs:
       run: ctest -C ${{ matrix.build_type }} -VV
 
   # TODO: add compiler g++-6 to ubuntu-14.04 job
-  ubuntu-14.04:
+  ubuntu-14_04:
     name: ubuntu-14.04.${{ matrix.build_type }}.${{ matrix.compiler }}
     runs-on: ${{ ubuntu-latest }}
     strategy:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,7 +67,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: install required bits
-      run: sudo apt update && sudo apt install cmake g++-4.8 clang-3.6
+      run: sudo apt update && sudo apt -y install cmake g++-4.8 clang-3.6
 
     - name: create build environment
       run: cmake -E make_directory ${{ runner.workspace }}/_build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,7 +67,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: install required bits
-      run: sudo apt install cmake g++ clang
+      run: sudo apt install cmake g++-4.8 clang-3.6
 
     - name: create build environment
       run: cmake -E make_directory ${{ runner.workspace }}/_build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: ['Release', 'Debug']
-        compiler: [g++, clang++]
+        compiler: [g++-4.8, clang++-3.6]
     container: ubuntu:14.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,6 @@ on:
     branches: [ master ]
 
 jobs:
-  # TODO: add job using container ubuntu:14.04 with and without g++-6
   # TODO: add 32-bit builds (g++ and clang++) for ubuntu (requires g++-multilib and libc6:i386)
   # TODO: add coverage build (requires lcov)
   # TODO: add clang + libc++ builds for ubuntu
@@ -28,6 +27,43 @@ jobs:
           - displayTargetName: windows-latest-debug
             os: windows-latest
             build_type: 'Debug'
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: create build environment
+      run: cmake -E make_directory ${{ runner.workspace }}/_build
+
+    - name: configure cmake
+      env:
+        CXX: ${{ matrix.compiler }}
+      shell: bash
+      working-directory: ${{ runner.workspace }}/_build
+      run: >
+        cmake $GITHUB_WORKSPACE
+        -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+    - name: build
+      shell: bash
+      working-directory: ${{ runner.workspace }}/_build
+      run: cmake --build . --config ${{ matrix.build_type }}
+
+    - name: test
+      shell: bash
+      working-directory: ${{ runner.workspace }}/_build
+      run: ctest -C ${{ matrix.build_type }} -VV
+
+  # TODO: add compiler g++-6 to ubuntu-14.04 job
+  ubuntu-14.04:
+    name: ubuntu-14.04.${{ matrix.build_type }}.${{ matrix.compiler }}
+    runs-on: ${{ ubuntu-latest }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [linux]
+        build_type: ['Release', 'Debug']
+        compiler: [g++, clang++]
+    container: ubuntu:14.04
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Uses an ubuntu:14.04 docker container and builds the project with out-of-the-box `g++-4.8` and `clang++-3.6`. This ensures that users of the library can build and use the library on Ubuntu Trusty LTS.

Tests are disabled as googletest requires more modern compilers (#1136) which means that developers on Ubuntu Trusty LTS must find a way to install more modern compilers.

Future work will add modern compilers to this CI configuration and enable tests for them.