### PR TITLE
Fix StrSplit empty string case

### DIFF
--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -164,6 +164,7 @@ std::string StrFormat(const char* format, ...) {
 }
 
 std::vector<std::string> StrSplit(const std::string& str, char delim) {
+  if (str.empty()) return {};
   std::vector<std::string> ret;
   size_t first = 0;
   size_t next = str.find(delim);

--- a/test/string_util_gtest.cc
+++ b/test/string_util_gtest.cc
@@ -151,7 +151,7 @@ TEST(StringUtilTest, stod) {
 }
 
 TEST(StringUtilTest, StrSplit) {
-  EXPECT_EQ(benchmark::StrSplit("", ','), std::vector<std::string>{""});
+  EXPECT_EQ(benchmark::StrSplit("", ','), std::vector<std::string>{});
   EXPECT_EQ(benchmark::StrSplit("hello", ','),
             std::vector<std::string>({"hello"}));
   EXPECT_EQ(benchmark::StrSplit("hello,there", ','),


### PR DESCRIPTION
This also fixes #1134. 

Because StrSplit was returning a vector with an empty string, it was treated by PerfCounters::Create as a legitimate ask
for setting up a counter with that name. The empty vector is (correctly) understood by PerfCounters as "just return NoCounters()".