### PR TITLE
Fix for #1150 (memory leak)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Ismael Jimenez Martinez <ismael.jimenez.martinez@gmail.com>
 Jern-Kuan Leong <jernkuan@gmail.com>
 JianXiong Zhou <zhoujianxiong2@gmail.com>
 Joao Paulo Magalhaes <joaoppmagalhaes@gmail.com>
+Joe Rowell <joerowell4@gmail.com>
 Jordan Williams <jwillikers@protonmail.com>
 Jussi Knuuttila <jussi.knuuttila@gmail.com>
 Kaito Udagawa <umireon@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -52,6 +52,7 @@ Ismael Jimenez Martinez <ismael.jimenez.martinez@gmail.com>
 Jern-Kuan Leong <jernkuan@gmail.com>
 JianXiong Zhou <zhoujianxiong2@gmail.com>
 Joao Paulo Magalhaes <joaoppmagalhaes@gmail.com>
+Joe Rowell <joerowell4@gmail.com>
 John Millikin <jmillikin@stripe.com>
 Jordan Williams <jwillikers@protonmail.com>
 Jussi Knuuttila <jussi.knuuttila@gmail.com>

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -706,8 +706,8 @@ std::vector<double> GetLoadAvg() {
 }  // end namespace
 
 const CPUInfo& CPUInfo::Get() {
-  static const CPUInfo* info = new CPUInfo();
-  return *info;
+  static const CPUInfo info{};
+  return info;
 }
 
 CPUInfo::CPUInfo()
@@ -718,8 +718,8 @@ CPUInfo::CPUInfo()
       load_avg(GetLoadAvg()) {}
 
 const SystemInfo& SystemInfo::Get() {
-  static const SystemInfo* info = new SystemInfo();
-  return *info;
+  static const SystemInfo info{};
+  return info;
 }
 
 SystemInfo::SystemInfo() : name(GetSystemName()) {}


### PR DESCRIPTION
This is a fix for issue #1150.

This pull request simply replaces the heap allocations (via ```new```) with a value semantic allocation (i.e the objects are treated as stack variables). This fixes the memory leak, and achieves the same semantics: rather than the pointer being static, the object is (which I suspect was the intended usage anyway).

