### PR TITLE
Fix pedantic compilation flag violation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,9 +167,8 @@ else()
     # Disable warning when compiling tests as gtest does not use 'override'.
     add_cxx_compiler_flag(-Wsuggest-override)
   endif()
-  # Disabled until googletest (gmock) stops emitting variadic macro warnings
-  #add_cxx_compiler_flag(-pedantic)
-  #add_cxx_compiler_flag(-pedantic-errors)
+  add_cxx_compiler_flag(-pedantic)
+  add_cxx_compiler_flag(-pedantic-errors)
   add_cxx_compiler_flag(-Wshorten-64-to-32)
   add_cxx_compiler_flag(-fstrict-aliasing)
   # Disable warnings regarding deprecated parts of the library while building

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -308,7 +308,7 @@ void FlushStreams(BenchmarkReporter* reporter) {
   if (!reporter) return;
   std::flush(reporter->GetOutputStream());
   std::flush(reporter->GetErrorStream());
-};
+}
 
 // Reports in both display and file reporters.
 void Report(BenchmarkReporter* display_reporter,
@@ -333,7 +333,7 @@ void Report(BenchmarkReporter* display_reporter,
 
   FlushStreams(display_reporter);
   FlushStreams(file_reporter);
-};
+}
 
 void RunBenchmarks(const std::vector<BenchmarkInstance>& benchmarks,
                    BenchmarkReporter* display_reporter,


### PR DESCRIPTION
';' after method definition was removed.
Also, pedantic flag is now uncommented in CMakeList.txt.