### PR TITLE
Fix perf counter argument parsing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,6 +43,7 @@ Matt Clarkson <mattyclarkson@gmail.com>
 Maxim Vafin <maxvafin@gmail.com>
 MongoDB Inc.
 Nick Hutchinson <nshutchinson@gmail.com>
+Norman Heino <norman.heino@gmail.com>
 Oleksandr Sochka <sasha.sochka@gmail.com>
 Ori Livneh <ori.livneh@gmail.com>
 Paul Redmond <paul.redmond@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -62,6 +62,7 @@ Lei Xu <eddyxu@gmail.com>
 Matt Clarkson <mattyclarkson@gmail.com>
 Maxim Vafin <maxvafin@gmail.com>
 Nick Hutchinson <nshutchinson@gmail.com>
+Norman Heino <norman.heino@gmail.com>
 Oleksandr Sochka <sasha.sochka@gmail.com>
 Ori Livneh <ori.livneh@gmail.com>
 Pascal Leroy <phl@google.com>

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -169,7 +169,7 @@ std::vector<std::string> StrSplit(const std::string& str, char delim) {
   size_t first = 0;
   size_t next = str.find(delim);
   for (; next != std::string::npos;
-       first = next + 1, next = str.find(first, delim)) {
+       first = next + 1, next = str.find(delim, first)) {
     ret.push_back(str.substr(first, next - first));
   }
   ret.push_back(str.substr(first));

--- a/test/string_util_gtest.cc
+++ b/test/string_util_gtest.cc
@@ -154,8 +154,8 @@ TEST(StringUtilTest, StrSplit) {
   EXPECT_EQ(benchmark::StrSplit("", ','), std::vector<std::string>{});
   EXPECT_EQ(benchmark::StrSplit("hello", ','),
             std::vector<std::string>({"hello"}));
-  EXPECT_EQ(benchmark::StrSplit("hello,there", ','),
-            std::vector<std::string>({"hello", "there"}));
+  EXPECT_EQ(benchmark::StrSplit("hello,there,is,more", ','),
+            std::vector<std::string>({"hello", "there", "is", "more"}));
 }
 
 }  // end namespace


### PR DESCRIPTION
This fixes a bug where providing multiple perf counters via `--benchmark_perf_counters` does not parse correctly:

    % ./benchmark_bin --benchmark_perf_counters=instructions,cache-misses,branch-misses
    ...
    Unknown counter name: cache-misses,branch-misses