### PR TITLE
benchmark_runner.h: Remove superfluous semicolon

### DIFF
--- a/src/benchmark_runner.h
+++ b/src/benchmark_runner.h
@@ -64,7 +64,7 @@ class BenchmarkRunner {
 
   BenchmarkReporter::PerFamilyRunReports* GetReportsForFamily() const {
     return reports_for_family;
-  };
+  }
 
  private:
   RunResults run_results;


### PR DESCRIPTION
Some downstream projects (e.g. V8) treat warnings as errors and cannot roll
the latest changes.