### PR TITLE
Add wheel and sdist building action to GH Workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,58 @@
+name: Build and upload Python wheels
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Install Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Build and check sdist
+        run: |
+          python setup.py sdist
+          ls -al dist/
+      - name: Upload sdist
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist/*.tar.gz
+
+  build_wheels:
+    name: Build google-benchmark wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # let runner finish even if there is a failure
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Check out Google Benchmark
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Build Python wheels on ${{ matrix.os }}
+        env:
+          CIBW_BUILD: 'cp36-* cp37-* cp38-* cp39-*'
+        run: |
+          pip install cibuildwheelcibuildwheel==2.0.0a2
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: ./wheelhouse/*.whl


### PR DESCRIPTION
 Working to fix #1177. I added a workflow for building wheels and an sdist and uploading it to GitHub. I set the proposed wheel building workflow to manual dispatch as of now, so it can be checked whether or not it works. 

For later, it could be worth adding a publishing job running after release/tagging/manually, but I don't know how you guys handle this for Python (it would require a PyPI token secret added to this repo for instance), so I left it out for now. Would be excited about some feedback.