### PR TITLE
Fix potential memory leaks reported by valgrind

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -706,8 +706,8 @@ std::vector<double> GetLoadAvg() {
 }  // end namespace
 
 const CPUInfo& CPUInfo::Get() {
-  static const CPUInfo* info = new CPUInfo();
-  return *info;
+  static const CPUInfo info;
+  return info;
 }
 
 CPUInfo::CPUInfo()
@@ -718,8 +718,8 @@ CPUInfo::CPUInfo()
       load_avg(GetLoadAvg()) {}
 
 const SystemInfo& SystemInfo::Get() {
-  static const SystemInfo* info = new SystemInfo();
-  return *info;
+  static const SystemInfo info;
+  return info;
 }
 
 SystemInfo::SystemInfo() : name(GetSystemName()) {}


### PR DESCRIPTION
This is what valgrind shows:
```
MPK ==2243078== 24 bytes in 1 blocks are still reachable in loss record 1 of 4
==2243078==    at 0x484005F: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==2243078==    by 0x166473: allocate (new_allocator.h:121)
==2243078==    by 0x166473: allocate (allocator.h:173)
==2243078==    by 0x166473: allocate (alloc_traits.h:460)
==2243078==    by 0x166473: _M_allocate (stl_vector.h:346)
==2243078==    by 0x166473: _M_allocate (stl_vector.h:343)
==2243078==    by 0x166473: _M_create_storage (stl_vector.h:361)
==2243078==    by 0x166473: _Vector_base (stl_vector.h:305)
==2243078==    by 0x166473: vector (stl_vector.h:524)
==2243078==    by 0x166473: GetLoadAvg (sysinfo.cc:682)
==2243078==    by 0x166473: benchmark::CPUInfo::CPUInfo() (sysinfo.cc:707)
==2243078==    by 0x1665A4: benchmark::CPUInfo::Get() (sysinfo.cc:698)
==2243078==    by 0x15D628: benchmark::BenchmarkReporter::Context::Context() (reporter.cc:83)
==2243078==    by 0x130B13: RunBenchmarks (benchmark.cc:239)
==2243078==    by 0x130B13: benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*, benchmark::BenchmarkReporter*) (benchmark.cc:404)
==2243078==    by 0x111AB3: main (math_benchmarks.cc:217)
==2243078== 
MPK ==2243078== 32 bytes in 1 blocks are still reachable in loss record 2 of 4
==2243078==    at 0x484005F: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==2243078==    by 0x16235C: benchmark::SystemInfo::Get() (sysinfo.cc:711)
==2243078==    by 0x15D630: benchmark::BenchmarkReporter::Context::Context() (reporter.cc:83)
==2243078==    by 0x130B13: RunBenchmarks (benchmark.cc:239)
==2243078==    by 0x130B13: benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*, benchmark::BenchmarkReporter*) (benchmark.cc:404)
==2243078==    by 0x111AB3: main (math_benchmarks.cc:217)
==2243078== 
MPK ==2243078== 72 bytes in 1 blocks are still reachable in loss record 3 of 4
==2243078==    at 0x484005F: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==2243078==    by 0x166599: benchmark::CPUInfo::Get() (sysinfo.cc:698)
==2243078==    by 0x15D628: benchmark::BenchmarkReporter::Context::Context() (reporter.cc:83)
==2243078==    by 0x130B13: RunBenchmarks (benchmark.cc:239)
==2243078==    by 0x130B13: benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*, benchmark::BenchmarkReporter*) (benchmark.cc:404)
==2243078==    by 0x111AB3: main (math_benchmarks.cc:217)
==2243078== 
MPK ==2243078== 192 bytes in 1 blocks are still reachable in loss record 4 of 4
==2243078==    at 0x484005F: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==2243078==    by 0x166AA3: allocate (new_allocator.h:121)
==2243078==    by 0x166AA3: allocate (allocator.h:173)
==2243078==    by 0x166AA3: allocate (alloc_traits.h:460)
==2243078==    by 0x166AA3: _M_allocate (stl_vector.h:346)
==2243078==    by 0x166AA3: _M_allocate (stl_vector.h:343)
==2243078==    by 0x166AA3: void std::vector >::_M_realloc_insert(__gnu_cxx::__normal_iterator > >, benchmark::CPUInfo::CacheInfo const&) (vector.tcc:440)
==2243078==    by 0x165E01: push_back (stl_vector.h:1198)
==2243078==    by 0x165E01: benchmark::(anonymous namespace)::GetCacheSizesFromKVFS() (sysinfo.cc:286)
==2243078==    by 0x166447: GetCacheSizes (sysinfo.cc:414)
==2243078==    by 0x166447: benchmark::CPUInfo::CPUInfo() (sysinfo.cc:705)
==2243078==    by 0x1665A4: benchmark::CPUInfo::Get() (sysinfo.cc:698)
==2243078==    by 0x15D628: benchmark::BenchmarkReporter::Context::Context() (reporter.cc:83)
==2243078==    by 0x130B13: RunBenchmarks (benchmark.cc:239)
==2243078==    by 0x130B13: benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*, benchmark::BenchmarkReporter*) (benchmark.cc:404)
==2243078==    by 0x111AB3: main (math_benchmarks.cc:217)
==2243078== 
```