### PR TITLE
Move flags inside the `benchmark` namespace

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -56,6 +56,7 @@
 #include "thread_manager.h"
 #include "thread_timer.h"
 
+namespace benchmark {
 // Print a list of benchmarks. This option overrides all other options.
 DEFINE_bool(benchmark_list_tests, false);
 
@@ -112,19 +113,18 @@ DEFINE_string(benchmark_color, "auto");
 // Valid values: 'true'/'yes'/1, 'false'/'no'/0.  Defaults to false.
 DEFINE_bool(benchmark_counters_tabular, false);
 
-// The level of verbose logging to output
-DEFINE_int32(v, 0);
-
 // List of additional perf counters to collect, in libpfm format. For more
 // information about libpfm: https://man7.org/linux/man-pages/man3/libpfm.3.html
 DEFINE_string(benchmark_perf_counters, "");
 
-namespace benchmark {
-namespace internal {
-
 // Extra context to include in the output formatted as comma-separated key-value
 // pairs. Kept internal as it's only used for parsing from env/command line.
 DEFINE_kvpairs(benchmark_context, {});
+
+// The level of verbose logging to output
+DEFINE_int32(v, 0);
+
+namespace internal {
 
 std::map<std::string, std::string>* global_context = nullptr;
 
@@ -530,6 +530,7 @@ void PrintUsageAndExit() {
           "          [--benchmark_out_format=<json|console|csv>]\n"
           "          [--benchmark_color={auto|true|false}]\n"
           "          [--benchmark_counters_tabular={true|false}]\n"
+          "          [--benchmark_perf_counters=<counter>,...]\n"
           "          [--benchmark_context=<key>=<value>,...]\n"
           "          [--v=<verbosity>]\n");
   exit(0);

--- a/src/benchmark_runner.h
+++ b/src/benchmark_runner.h
@@ -23,17 +23,13 @@
 #include "perf_counters.h"
 #include "thread_manager.h"
 
-DECLARE_double(benchmark_min_time);
-
-DECLARE_int32(benchmark_repetitions);
-
-DECLARE_bool(benchmark_report_aggregates_only);
-
-DECLARE_bool(benchmark_display_aggregates_only);
-
-DECLARE_string(benchmark_perf_counters);
-
 namespace benchmark {
+
+DECLARE_double(benchmark_min_time);
+DECLARE_int32(benchmark_repetitions);
+DECLARE_bool(benchmark_report_aggregates_only);
+DECLARE_bool(benchmark_display_aggregates_only);
+DECLARE_string(benchmark_perf_counters);
 
 namespace internal {
 

--- a/test/benchmark_random_interleaving_gtest.cc
+++ b/test/benchmark_random_interleaving_gtest.cc
@@ -8,11 +8,12 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+namespace benchmark {
+
 DECLARE_bool(benchmark_enable_random_interleaving);
 DECLARE_string(benchmark_filter);
 DECLARE_int32(benchmark_repetitions);
 
-namespace benchmark {
 namespace internal {
 namespace {
 


### PR DESCRIPTION
This avoids clashes with other libraries that might define the same flags.