### PR TITLE
Deduplicate test function name in python bindings example

### DIFF
--- a/bindings/python/google_benchmark/example.py
+++ b/bindings/python/google_benchmark/example.py
@@ -102,7 +102,7 @@ def with_options(state):
 
 @benchmark.register(name="sum_million_microseconds")
 @benchmark.option.unit(benchmark.kMicrosecond)
-def with_options(state):
+def with_options2(state):
     while state:
         sum(range(1_000_000))
 


### PR DESCRIPTION
This appears to be the source of unclean termination of the test on some
versions of python related to object dereferencing.