### PR TITLE
Bazel qnx

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,17 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 licenses(["notice"])
 
 config_setting(
+    name = "qnx",
+    constraint_values = ["@platforms//os:qnx"],
+    values = {
+        "cpu": "x64_qnx",
+    },
+    visibility = [":__subpackages__"],
+)
+
+config_setting(
     name = "windows",
+    constraint_values = ["@platforms//os:windows"],
     values = {
         "cpu": "x64_windows",
     },

--- a/README.md
+++ b/README.md
@@ -227,6 +227,11 @@ can link to pthread by adding `-pthread` to your linker command. Note, you can
 also use `-lpthread`, but there are potential issues with ordering of command
 line parameters if you use that.
 
+On QNX, the pthread library is part of libc and usually included automatically
+(see
+[`pthread_create()`](https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.lib_ref/topic/p/pthread_create.html)).
+There's no separate pthread library to link.
+
 ### Building with Visual Studio 2015 or 2017
 
 The `shlwapi` library (`-lshlwapi`) is required to support a call to `CPUInfo` which reads the registry. Either add `shlwapi.lib` under `[ Configuration Properties > Linker > Input ]`, or use the following:


### PR DESCRIPTION
On QNX, pthread is part of libc. There's no separate pthread library to link. See section "Library" in the [`pthread_create()`](https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.lib_ref/topic/p/pthread_create.html) reference manual of QNX.

I added `values = { "cpu": "x64_qnx" }` to the config setting `qnx` and `constraint_values = ["@platforms//os:windows"]` to the config setting `windows` to establish consistency for both config settings.

Resolves https://github.com/google/benchmark/issues/1191