### PR TITLE
remove dead-stores in complexity fitting, fixes clang-13 build

### DIFF
--- a/src/complexity.cc
+++ b/src/complexity.cc
@@ -82,14 +82,12 @@ std::string GetBigOString(BigO complexity) {
 LeastSq MinimalLeastSq(const std::vector<int64_t>& n,
                        const std::vector<double>& time,
                        BigOFunc* fitting_curve) {
-  double sigma_gn_squared = 0.0;
   double sigma_time = 0.0;
   double sigma_time_gn = 0.0;
 
   // Calculate least square fitting parameter
   for (size_t i = 0; i < n.size(); ++i) {
     double gn_i = fitting_curve(n[i]);
-    sigma_gn_squared += gn_i * gn_i;
     sigma_time += time[i];
     sigma_time_gn += time[i] * gn_i;
   }


### PR DESCRIPTION
This PR removes a dead-stores/unused variables from the complexity calculation.
`clang-13` detected this through its unused variable warning. Without this fix the project does not build due to `-Werror`.