### PR TITLE
Fix links to further doc in user_guide.md

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -38,9 +38,9 @@
 
 [Setting the Time Unit](#setting-the-time-unit)
 
-[Random Interleaving](docs/random_interleaving.md)
+[Random Interleaving](random_interleaving.md)
 
-[User-Requested Performance Counters](docs/perf_counters.md)
+[User-Requested Performance Counters](perf_counters.md)
 
 [Preventing Optimization](#preventing-optimization)
 
@@ -183,7 +183,7 @@ BM_memcpy/32k       1834 ns       1837 ns     357143
 ## Result comparison
 
 It is possible to compare the benchmarking results.
-See [Additional Tooling Documentation](docs/tools.md)
+See [Additional Tooling Documentation](tools.md)
 
 <a name="extra-context" />
 


### PR DESCRIPTION
Refactoring in 201b981a moved most of the documentation from `README.md` to `docs/user_guide.md`. Some links from `README.md` to other `docs/*.md` files ended up unchanged in `docs/user_guide.md`. Those links were now broken as they did not link from outside the `docs` directory anymore, but from inside it. Removing the leading `docs/` for these links fixes this.