### PR TITLE
Support for building with LLVM clang-10/clang-11 on Windows.

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -381,31 +381,31 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
 // This class is used for user-defined counters.
 class Counter {
  public:
-  enum Flags : unsigned {
+  enum Flags {
     kDefaults = 0,
     // Mark the counter as a rate. It will be presented divided
     // by the duration of the benchmark.
-    kIsRate = 1U << 0U,
+    kIsRate = 1 << 0,
     // Mark the counter as a thread-average quantity. It will be
     // presented divided by the number of threads.
-    kAvgThreads = 1U << 1U,
+    kAvgThreads = 1 << 1,
     // Mark the counter as a thread-average rate. See above.
     kAvgThreadsRate = kIsRate | kAvgThreads,
     // Mark the counter as a constant value, valid/same for *every* iteration.
     // When reporting, it will be *multiplied* by the iteration count.
-    kIsIterationInvariant = 1U << 2U,
+    kIsIterationInvariant = 1 << 2,
     // Mark the counter as a constant rate.
     // When reporting, it will be *multiplied* by the iteration count
     // and then divided by the duration of the benchmark.
     kIsIterationInvariantRate = kIsRate | kIsIterationInvariant,
     // Mark the counter as a iteration-average quantity.
     // It will be presented divided by the number of iterations.
-    kAvgIterations = 1U << 3U,
+    kAvgIterations = 1 << 3,
     // Mark the counter as a iteration-average rate. See above.
     kAvgIterationsRate = kIsRate | kAvgIterations,
 
     // In the end, invert the result. This is always done last!
-    kInvert = 1U << 31U
+    kInvert = 1 << 31
   };
 
   enum OneK {

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -381,7 +381,7 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
 // This class is used for user-defined counters.
 class Counter {
  public:
-  enum Flags {
+  enum Flags : unsigned {
     kDefaults = 0,
     // Mark the counter as a rate. It will be presented divided
     // by the duration of the benchmark.


### PR DESCRIPTION
# Issue:
Benchmark does not compile with LLVM clang-10/clang-11 on Windows.

## Relevant Compiler Output:
```
In file included from benchmark/src/benchmark_name.cc:15:
benchmark/include/benchmark/benchmark.h:408:5: error: enumerator value is not representable in the underlying type 'int' [-Werror,-Wmicrosoft-enum-value]
    kInvert = 1U << 31U
    ^
1 error generated.
```

## Reason For Issue:
  The enum `Flags` on line 384 of `benchmark/include/benchmark/benchmark.h`.
  The issue arises due to the pull request https://github.com/google/benchmark/pull/850 being merged in. \
  As I currently understand, the underlying type of an `enum` is somewhat implementation-defined, which is assumed by the previously mentioned line / pull request. This is described [here](https://timsong-cpp.github.io/cppwp/n4659/dcl.enum#7).

## Fix:
  Let the compiler decide the underlying type for the `Flags` enum by removing the unsigned specification of `U`.

## More Information:
- Platform:
  - Windows-10.0.19042
- Architecture:
  - amd64
- (Known) Affected Compilers: 
  - [Windows LLVM Clang-10.0.0](https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/LLVM-11.1.0-win64.exe)
  - [Windows LLVM Clang-11.0.0](https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/LLVM-10.0.0-win64.exe)
- (Known) Working Compilers Post Patch: 
  - [Windows LLVM Clang-10.0.0](https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/LLVM-11.1.0-win64.exe)
  - [Windows LLVM Clang-11.0.0](https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/LLVM-10.0.0-win64.exe)
  - Linux Clang-10
