### PR TITLE
Allow UseRealTime() to take an optional parameter

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -949,7 +949,7 @@ class Benchmark {
   // (wall) time will be used to control how many iterations are run, and in the
   // printing of items/second or MB/seconds values.
   // If not called, the CPU time used by the benchmark will be used.
-  Benchmark* UseRealTime();
+  Benchmark* UseRealTime(bool value = true);
 
   // If a benchmark must measure time manually (e.g. if GPU execution time is
   // being


### PR DESCRIPTION
Internally, we have a few users who would like to call this function conditionally (ie, based one some flag)
And because this function is usually called on the `BENCHMARK()` instantiation macro it's quite awkward to conditionalised the `UseRealTime` right now.

Making it taking a parameter will make it easier.
Eg.,
`BENCHMARK(BM_MyTest)->UseRealTime(GetFlags(FLAGS_someflags));`

(Similar changes will be proposed to the internal API)