### PR TITLE
Update README.md to stop recommending cmake command that doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ $ cd benchmark
 $ cmake -E make_directory "build"
 # Generate build system files with cmake, and download any dependencies.
 $ cmake -E chdir "build" cmake -DBENCHMARK_DOWNLOAD_DEPENDENCIES=on -DCMAKE_BUILD_TYPE=Release ../
-# or, starting with CMake 3.13, use a simpler form:
-# cmake -DCMAKE_BUILD_TYPE=Release -S . -B "build"
 # Build the library.
 $ cmake --build "build" --config Release
 ```


### PR DESCRIPTION
`cmake -DCMAKE_BUILD_TYPE=Release -S . -B "build"` produces CMake error (for googletest)
Tested with on Linux (`cmake version 3.18.4`) and OSX (`cmake version 3.20.0-rc5`)