### PR TITLE
Treat Benchmark::ArgName like Benchmark::Arg

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1069,8 +1069,8 @@ class Benchmark {
 
   std::string name_;
   AggregationReportMode aggregation_report_mode_;
-  std::vector<std::string> arg_names_;       // Args for all benchmark runs
-  std::vector<std::vector<int64_t> > args_;  // Args for all benchmark runs
+  std::vector<std::vector<std::string>> arg_names_;  // Args for all benchmark runs
+  std::vector<std::vector<int64_t> > args_;          // Args for all benchmark runs
   TimeUnit time_unit_;
   int range_multiplier_;
   double min_time_;

--- a/src/benchmark_api_internal.cc
+++ b/src/benchmark_api_internal.cc
@@ -29,14 +29,16 @@ BenchmarkInstance::BenchmarkInstance(Benchmark* benchmark, int family_idx,
       threads_(thread_count) {
   name_.function_name = benchmark_.name_;
 
+  const auto* arg_names = per_family_instance_idx < benchmark->arg_names_.size() ?
+          &(benchmark->arg_names_[per_family_instance_idx]) : nullptr;
   size_t arg_i = 0;
   for (const auto& arg : args) {
     if (!name_.args.empty()) {
       name_.args += '/';
     }
 
-    if (arg_i < benchmark->arg_names_.size()) {
-      const auto& arg_name = benchmark_.arg_names_[arg_i];
+    if (arg_names && arg_i < arg_names->size()) {
+      const auto& arg_name = arg_names->operator[](arg_i);
       if (!arg_name.empty()) {
         name_.args += StrFormat("%s:", arg_name.c_str());
       }

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -291,13 +291,13 @@ Benchmark* Benchmark::ArgsProduct(
 
 Benchmark* Benchmark::ArgName(const std::string& name) {
   BM_CHECK(ArgsCnt() == -1 || ArgsCnt() == 1);
-  arg_names_ = {name};
+  arg_names_.push_back({name});
   return this;
 }
 
 Benchmark* Benchmark::ArgNames(const std::vector<std::string>& names) {
   BM_CHECK(ArgsCnt() == -1 || ArgsCnt() == static_cast<int>(names.size()));
-  arg_names_ = names;
+  arg_names_.push_back(names);
   return this;
 }
 
@@ -443,7 +443,7 @@ void Benchmark::SetName(const char* name) { name_ = name; }
 int Benchmark::ArgsCnt() const {
   if (args_.empty()) {
     if (arg_names_.empty()) return -1;
-    return static_cast<int>(arg_names_.size());
+    return static_cast<int>(arg_names_.front().size());
   }
   return static_cast<int>(args_.front().size());
 }


### PR DESCRIPTION
Bug: #1257
Test: TODO

Benchmark::Arg creates an instance of the Benchmark which accepts a
single argument.

Similarly, Benchmark::Args creates an instance of the Benchmark which
accepts multiple arguments.

Benchmark::ArgNames works like ::Args - it must match the number of
arguments passed to Args, and it matches each Name to an Arg.

Previously, within a family of Benchmarks there was no way to name the
Arg(s) of the second (and so on) instances differently from the first
instance. Add this feature by treating ArgName like Arg - convert
Benchmark::arg_names_ to a vector of vectors (like args_). Each inner
vector corresponds to an instance.

Possible regressions:
1) If a client was depending on ArgNames to name the arguments for every
instance in a family, it will now only name the first instance. This
will still be supported by calling ArgNames multiple times with the same
values.
    - Alternatively, the library could support this use by using the
    last set of ArgNames for any further instances.
2) Previously, a client could call ArgNames or ArgName multiple times on
the same Benchmark, and only the last one would be respected. I don't
expect this to happen in practice.

Change-Id: Ide3f8cb433e219042a3506c192e8c4287ae55780