### PR TITLE
Fix dependency typo and unpin cibuildwheel version in wheel building …

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,7 @@ jobs:
         env:
           CIBW_BUILD: 'cp36-* cp37-* cp38-* cp39-*'
         run: |
-          pip install cibuildwheelcibuildwheel==2.0.0a2
+          pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
 
       - name: Upload wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,21 +19,15 @@ jobs:
       - name: Build and check sdist
         run: |
           python setup.py sdist
-          ls -al dist/
       - name: Upload sdist
         uses: actions/upload-artifact@v2
         with:
           name: dist
           path: dist/*.tar.gz
 
-  build_wheels:
-    name: Build google-benchmark wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      # let runner finish even if there is a failure
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+  build_linux:
+    name: Build google-benchmark manylinux wheels
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out Google Benchmark
@@ -44,9 +38,86 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Build Python wheels on ${{ matrix.os }}
+      # TODO: Bazel does not seem to work in an emulated Docker environment, see
+      # https://github.com/bazelbuild/bazel/issues/11379
+#      - name: Set up QEMU
+#        uses: docker/setup-qemu-action@v1
+#        with:
+#          platforms: all
+
+      - name: Build Python wheels on ubuntu-latest
         env:
-          CIBW_BUILD: 'cp36-* cp37-* cp38-* cp39-*'
+          CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'
+          CIBW_SKIP: "*-musllinux_*"
+          # Bazel repo only exists on CentOS 7 for x86 and ppc, so no manylinux2010
+          # TODO: Build ppc64le, aarch64 using some other trick
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_ARCHS_LINUX: x86_64
+          CIBW_BEFORE_ALL: >
+            curl -O --retry-delay 5 --retry 5 https://copr.fedorainfracloud.org/coprs/vbatts/bazel/repo/epel-7/vbatts-bazel-epel-7.repo &&
+            cp vbatts-bazel-epel-7.repo /etc/yum.repos.d/bazel.repo &&
+            yum install -y bazel4
+          # TODO: Test bindings afterwards
+        run: |
+          pip install cibuildwheel
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Upload Linux wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: wheelhouse/*.whl
+
+  build_macos:
+    name: Build google-benchmark macOS wheels
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out Google Benchmark
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Build Python wheels on macOS
+        env:
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'
+          # ARM64 requires Python 3.8 minimum
+          CIBW_SKIP: 'cp37-*-arm64'
+          # TODO: Test bindings afterwards
+        run: |
+          pip install cibuildwheel
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Upload macOS wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: wheelhouse/*.whl
+
+  build_wheels:
+    name: Build google-benchmark wheels on Windows
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out Google Benchmark
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Build Python wheels on Windows
+        env:
+          CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'
+          CIBW_ARCHS_WINDOWS: AMD64
+          # otherwise, pip crashes the job by trying to remove an in-use bazel DLL
+          PIP_NO_CLEAN: true
+          # TODO: Test bindings afterwards
         run: |
           pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
@@ -55,4 +126,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: dist
-          path: ./wheelhouse/*.whl
+          path: wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,6 +2,9 @@ name: Build and upload Python wheels
 
 on:
   workflow_dispatch:
+  release:
+    types:
+      - published
 
 jobs:
   build_sdist:
@@ -57,7 +60,7 @@ jobs:
             curl -O --retry-delay 5 --retry 5 https://copr.fedorainfracloud.org/coprs/vbatts/bazel/repo/epel-7/vbatts-bazel-epel-7.repo &&
             cp vbatts-bazel-epel-7.repo /etc/yum.repos.d/bazel.repo &&
             yum install -y bazel4
-          # TODO: Test bindings afterwards
+          CIBW_TEST_COMMAND: python {project}/bindings/python/google_benchmark/example.py
         run: |
           pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
@@ -87,7 +90,8 @@ jobs:
           CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'
           # ARM64 requires Python 3.8 minimum
           CIBW_SKIP: 'cp37-*-arm64'
-          # TODO: Test bindings afterwards
+          CIBW_TEST_COMMAND: python {project}/bindings/python/google_benchmark/example.py
+          CIBW_TEST_SKIP: "*_arm64"
         run: |
           pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
@@ -98,7 +102,7 @@ jobs:
           name: dist
           path: wheelhouse/*.whl
 
-  build_wheels:
+  build_windows:
     name: Build google-benchmark wheels on Windows
     runs-on: windows-latest
 
@@ -117,7 +121,7 @@ jobs:
           CIBW_ARCHS_WINDOWS: AMD64
           # otherwise, pip crashes the job by trying to remove an in-use bazel DLL
           PIP_NO_CLEAN: true
-          # TODO: Test bindings afterwards
+          CIBW_TEST_COMMAND: python {project}/bindings/python/google_benchmark/example.py
         run: |
           pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -8,10 +8,23 @@
     * `git log $(git describe --abbrev=0 --tags)..HEAD` gives you the list of
       commits between the last annotated tag and HEAD
     * Pick the most interesting.
-* Create one last commit that updates the version saved in `CMakeLists.txt` to the release version you're creating. (This version will be used if benchmark is installed from the archive you'll be creating in the next step.)
+* Create one last commit that updates the version saved in `CMakeLists.txt` and the
+  `__version__` variable in `bindings/python/google_benchmark/__init__.py`to the release
+  version you're creating. (This version will be used if benchmark is installed from the
+  archive you'll be creating in the next step.)
 
 ```
-project (benchmark VERSION 1.5.3 LANGUAGES CXX)
+project (benchmark VERSION 1.6.0 LANGUAGES CXX)
+```
+
+```python
+# bindings/python/google_benchmark/__init__.py
+
+# ...
+
+__version__ = "1.6.0"  # <-- change this to the release version you are creating
+
+# ...
 ```
 
 * Create a release through github's interface

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import posixpath
+import platform
 import re
 import shutil
 import sys
@@ -89,6 +90,8 @@ class BuildBazelExtension(build_ext.build_ext):
             # Link with python*.lib.
             for library_dir in self.library_dirs:
                 bazel_argv.append("--linkopt=/LIBPATH:" + library_dir)
+        elif sys.platform == "darwin" and platform.machine() == "x86_64":
+            bazel_argv.append("--macos_minimum_os=10.9")
 
         self.spawn(bazel_argv)
 


### PR DESCRIPTION
…action.

Apologies for abandoning the Python wheels, I got sidetracked by some things over the last few months. In its current form, the wheel building action did not work due to a careless typo by me, that is fixed with this commit.

I started a first hail-mary workflow run in my fork just a few minutes ago. The results can be found [here](
https://github.com/nicholasjng/benchmark/actions/runs/1385963105). In short, as a summary:
* macOS builds succeed (Python 3.6-3.9, macOS 11.0, x86 64-bit)
* Linux builds fail, presumably due to an environment misconfiguration (it fails to locate Bazel in the first place).
* Windows builds fail due to a linker error coming from pybind11 (?).

So that is currently 1/3. If someone has experience with setting up Bazel inside GitHub Actions (specifically Linux and Windows), I would love to get some direction on this.

cc @yashk2810 (who caught the typo [here](https://github.com/google/benchmark/pull/1180#discussion_r727229147))