### PR TITLE
Fix un-initted error in test and fix change the API previously proposed to use std::string instead of raw char*

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -290,15 +290,15 @@ void Shutdown();
 bool ReportUnrecognizedArguments(int argc, char** argv);
 
 // Returns the current value of --benchmark_filter.
-const char* GetBenchmarkFilter();
+std::string GetBenchmarkFilter();
 
 // Generate a list of benchmarks matching the specified --benchmark_filter flag
 // and if --benchmark_list_tests is specified return after printing the name
 // of each matching benchmark. Otherwise run each matching benchmark and
 // report the results.
 //
-// spec : Specify the benchmarks to run. If users do not specify this arg or
-//        if it has value of NULL, then the value of FLAGS_benchmark_filter
+// spec : Specify the benchmarks to run. If users do not specify this arg,
+//        then the value of FLAGS_benchmark_filter
 //        will be used.
 //
 // The second and third overload use the specified 'display_reporter' and
@@ -308,12 +308,18 @@ const char* GetBenchmarkFilter();
 //  'file_reporter' is ignored.
 //
 // RETURNS: The number of matching benchmarks.
-size_t RunSpecifiedBenchmarks(const char* spec = NULL);
+size_t RunSpecifiedBenchmarks();
+size_t RunSpecifiedBenchmarks(std::string spec);
+
+size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter);
 size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
-                              const char* spec = NULL);
+                              std::string spec);
+
+size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
+                              BenchmarkReporter* file_reporter);
 size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
                               BenchmarkReporter* file_reporter,
-                              const char* spec = NULL);
+                              std::string spec);
 
 // If a MemoryManager is registered (via RegisterMemoryManager()),
 // it can be used to collect and report allocation metrics for a run of the

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -429,20 +429,33 @@ ConsoleReporter::OutputOptions GetOutputOptions(bool force_no_color) {
 
 }  // end namespace internal
 
-size_t RunSpecifiedBenchmarks(const char* spec) {
+size_t RunSpecifiedBenchmarks() {
+  return RunSpecifiedBenchmarks(nullptr, nullptr, FLAGS_benchmark_filter);
+}
+
+size_t RunSpecifiedBenchmarks(std::string spec) {
   return RunSpecifiedBenchmarks(nullptr, nullptr, spec);
 }
 
+size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter) {
+  return RunSpecifiedBenchmarks(display_reporter, nullptr,
+                                FLAGS_benchmark_filter);
+}
+
 size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
-                              const char* spec) {
+                              std::string spec) {
   return RunSpecifiedBenchmarks(display_reporter, nullptr, spec);
 }
 
 size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
+                              BenchmarkReporter* file_reporter) {
+  return RunSpecifiedBenchmarks(display_reporter, file_reporter,
+                                FLAGS_benchmark_filter);
+}
+
+size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
                               BenchmarkReporter* file_reporter,
-                              const char* spec_str) {
-  std::string spec =
-      spec_str != nullptr ? std::string(spec_str) : FLAGS_benchmark_filter;
+                              std::string spec) {
   if (spec.empty() || spec == "all")
     spec = ".";  // Regexp that matches all benchmarks
 
@@ -498,9 +511,7 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
   return benchmarks.size();
 }
 
-const char* GetBenchmarkFilter() {
-  return FLAGS_benchmark_filter.c_str();
-}
+std::string GetBenchmarkFilter() { return FLAGS_benchmark_filter; }
 
 void RegisterMemoryManager(MemoryManager* manager) {
   internal::memory_manager = manager;

--- a/test/spec_arg_test.cc
+++ b/test/spec_arg_test.cc
@@ -55,7 +55,7 @@ static void BM_Chosen(benchmark::State& state) {
 BENCHMARK(BM_Chosen);
 
 int main(int argc, char** argv) {
-  const char* const flag = "BM_NotChosen";
+  const std::string flag = "BM_NotChosen";
 
   // Verify that argv specify --benchmark_filter=BM_NotChosen.
   bool found = false;
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
 
   // Check that the current flag value is reported accurately via the
   // GetBenchmarkFilter() function.
-  if (strcmp(flag, benchmark::GetBenchmarkFilter()) != 0) {
+  if (flag != benchmark::GetBenchmarkFilter()) {
     std::cerr
         << "Seeing different value for flags. GetBenchmarkFilter() returns ["
         << benchmark::GetBenchmarkFilter() << "] expected flag=[" << flag


### PR DESCRIPTION
Code changes:
- Change return value of GetBenchmarkFilter() to std::string
- Similarly, change the type of `spec` to std::string

This does not actually change the contract of the API. The default value for the `spec` arg is still FLAGS_benchmark_filter. 

Reasons: 
Sanjay rejected the change to the internal library (specifically against the `const char*` type) - he suggested using either string_view or std::string instead.  Since we want the header to be cxx03 compat, std::string is the only option here.


Test change:
- Fixed errors found by -Werror,-Wsometimes-uninitialized (`found` was not initted in the #else branch) 
- Updated tests accordingly with the API change.

Sorry for this back-and-forth but coordinating and getting approvals from two different group of people with different objectives is tricky sometimes.

@dominichamon 