### PR TITLE
Add Setup/Teardown option on Benchmark.

### DIFF
--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -113,11 +113,11 @@ PYBIND11_MODULE(_benchmark, m) {
           "complexity",
           (Benchmark * (Benchmark::*)(benchmark::BigO)) & Benchmark::Complexity,
           py::return_value_policy::reference,
-          py::arg("complexity") = benchmark::oAuto)
-      .def("setup", &Benchmark::Setup,
-           py::return_value_policy::reference_internal)
-      .def("teardown", &Benchmark::Teardown,
-           py::return_value_policy::reference_internal);
+          py::arg("complexity") = benchmark::oAuto);
+  //      .def("setup", &Benchmark::Setup,
+  //      py::return_value_policy::reference_internal)
+  // .def("teardown", &Benchmark::Teardown,
+  //       py::return_value_policy::reference_internal);
 
   using benchmark::Counter;
   py::class_<Counter> py_counter(m, "Counter");

--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -114,9 +114,13 @@ PYBIND11_MODULE(_benchmark, m) {
           (Benchmark * (Benchmark::*)(benchmark::BigO)) & Benchmark::Complexity,
           py::return_value_policy::reference,
           py::arg("complexity") = benchmark::oAuto)
-      .def("setup", &Benchmark::Setup, py::return_value_policy::reference)
-      .def("teardown", &Benchmark::Teardown,
-           py::return_value_policy::reference);
+      .def("setup",
+           (Benchmark * (Benchmark::*)(benchmark::State&)) & Benchmark::Setup,
+           py::return_value_policy::reference)
+      .def(
+          "teardown",
+          (Benchmark * (Benchmark::*)(benchmark::State&)) & Benchmark::Teardown,
+          py::return_value_policy::reference);
 
   using benchmark::Counter;
   py::class_<Counter> py_counter(m, "Counter");

--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -114,9 +114,10 @@ PYBIND11_MODULE(_benchmark, m) {
           (Benchmark * (Benchmark::*)(benchmark::BigO)) & Benchmark::Complexity,
           py::return_value_policy::reference,
           py::arg("complexity") = benchmark::oAuto)
-      .def("setup", &Benchmark::Setup, py::return_value_policy::reference)
+      .def("setup", &Benchmark::Setup,
+           py::return_value_policy::reference_internal)
       .def("teardown", &Benchmark::Teardown,
-           py::return_value_policy::reference);
+           py::return_value_policy::reference_internal);
 
   using benchmark::Counter;
   py::class_<Counter> py_counter(m, "Counter");

--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -113,7 +113,10 @@ PYBIND11_MODULE(_benchmark, m) {
           "complexity",
           (Benchmark * (Benchmark::*)(benchmark::BigO)) & Benchmark::Complexity,
           py::return_value_policy::reference,
-          py::arg("complexity") = benchmark::oAuto);
+          py::arg("complexity") = benchmark::oAuto)
+      .def("setup", &Benchmark::Setup, py::return_value_policy::reference)
+      .def("teardown", &Benchmark::Teardown,
+           py::return_value_policy::reference);
 
   using benchmark::Counter;
   py::class_<Counter> py_counter(m, "Counter");

--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -114,13 +114,9 @@ PYBIND11_MODULE(_benchmark, m) {
           (Benchmark * (Benchmark::*)(benchmark::BigO)) & Benchmark::Complexity,
           py::return_value_policy::reference,
           py::arg("complexity") = benchmark::oAuto)
-      .def("setup",
-           (Benchmark * (Benchmark::*)(benchmark::State&)) & Benchmark::Setup,
-           py::return_value_policy::reference)
-      .def(
-          "teardown",
-          (Benchmark * (Benchmark::*)(benchmark::State&)) & Benchmark::Teardown,
-          py::return_value_policy::reference);
+      .def("setup", &Benchmark::Setup, py::return_value_policy::reference)
+      .def("teardown", &Benchmark::Teardown,
+           py::return_value_policy::reference);
 
   using benchmark::Counter;
   py::class_<Counter> py_counter(m, "Counter");

--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -114,10 +114,6 @@ PYBIND11_MODULE(_benchmark, m) {
           (Benchmark * (Benchmark::*)(benchmark::BigO)) & Benchmark::Complexity,
           py::return_value_policy::reference,
           py::arg("complexity") = benchmark::oAuto);
-  //      .def("setup", &Benchmark::Setup,
-  //      py::return_value_policy::reference_internal)
-  // .def("teardown", &Benchmark::Teardown,
-  //       py::return_value_policy::reference_internal);
 
   using benchmark::Counter;
   py::class_<Counter> py_counter(m, "Counter");

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -244,10 +244,10 @@ information about the machine on which the benchmarks are run.
 
 ## Setup/Teardown
 
-Global setup/teardown specific to each benchmark group can be done by
+Global setup/teardown specific to each benchmark can be done by
 passing a callback to Setup/Teardown:
 
-The setup/teardown callbacks will be invoked once for every group.
+The setup/teardown callbacks will be invoked once for each benchmark.
 If the benchmark is multi-threaded (will run in k threads), they will be invoked exactly once before
 each run with k threads.
 If the benchmark uses different size groups of threads, the above will be true for each size group.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -18,6 +18,8 @@
 
 [Runtime and Reporting Considerations](#runtime-and-reporting-considerations)
 
+[Setup/Teardown] (#setup-teardown)
+
 [Passing Arguments](#passing-arguments)
 
 [Custom Benchmark Name](#custom-benchmark-name)
@@ -237,6 +239,38 @@ times and statistical results across these repetitions will also be reported.
 
 As well as the per-benchmark entries, a preamble in the report will include
 information about the machine on which the benchmarks are run.
+
+<a name="setup-teardown" />
+
+## Setup/Teardown
+
+Global setup/teardown specific to each benchmark group can be done by
+passing a callback to Setup/Teardown:
+
+The setup/teardown callbacks will be invoked once for every group.
+If the benchmark is multi-threaded (will run in k threads), they will be invoked exactly once before
+each run with k threads.
+If the benchmark uses different size groups of threads, the above will be true for each size group.
+
+Eg.,
+
+```c++
+static void DoSetup(const benchmark::State& state) {
+}
+
+static void DoTeardown(const benchmark::State& state) {
+}
+
+static void BM_func(benchmark::State& state) {...}
+
+BENCHMARK(BM_func)->Arg(1)->Arg(3)->Threads(16)->Threads(32)->Setup(DoSetup)->Teardonw(DoTeardown);
+
+```
+
+In this example, `DoSetup` and `DoTearDown` will be invoked 4 times each,
+specifically, once for each of this family:
+ - BM_func_Arg_1_Threads_16, BM_func_Arg_1_Threads_32
+ - BM_func_Arg_3_Threads_16, BM_func_Arg_3_Threads_32
 
 <a name="passing-arguments" />
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -263,7 +263,7 @@ static void DoTeardown(const benchmark::State& state) {
 
 static void BM_func(benchmark::State& state) {...}
 
-BENCHMARK(BM_func)->Arg(1)->Arg(3)->Threads(16)->Threads(32)->Setup(DoSetup)->Teardonw(DoTeardown);
+BENCHMARK(BM_func)->Arg(1)->Arg(3)->Threads(16)->Threads(32)->Setup(DoSetup)->Teardown(DoTeardown);
 
 ```
 

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1118,8 +1118,8 @@ class Benchmark {
   std::vector<int> thread_counts_;
 
   typedef void (*callback_function)(const benchmark::State&);
-  callback_function setup_ = NULL;
-  callback_function teardown_ = NULL;
+  callback_function setup_;
+  callback_function teardown_;
 
   Benchmark& operator=(Benchmark const&);
 };

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1118,8 +1118,8 @@ class Benchmark {
   std::vector<int> thread_counts_;
 
   typedef void (*callback_function)(const benchmark::State&);
-  callback_function setup_ = nullptr;
-  callback_function teardown_ = nullptr;
+  callback_function setup_ = NULL;
+  callback_function teardown_ = NULL;
 
   Benchmark& operator=(Benchmark const&);
 };

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -978,7 +978,8 @@ class Benchmark {
   // If the benchmark uses different size groups of threads (e.g. via
   // ThreadRange), the above will be true for each size group.
   //
-  // The callback will be passed the number of threads for this benchmark run.
+  // The callback will be passed a State object, which includes the number
+  // of threads, thread-index, benchmark arguments, etc.
   //
   // The callback must not be NULL or self-deleting.
   Benchmark* Setup(void (*setup)(const benchmark::State&));

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -189,7 +189,6 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 
 #if defined(BENCHMARK_HAS_CXX11)
 #include <atomic>
-#include <functional>
 #include <initializer_list>
 #include <type_traits>
 #include <utility>
@@ -969,7 +968,6 @@ class Benchmark {
     return Ranges(ranges);
   }
 
-#if defined(BENCHMARK_HAS_CXX11)
   // Have "setup" and/or "teardown" invoked once for every benchmark run.
   // If the benchmark is multi-threaded (will run in k threads concurrently),
   // the setup callback will be be invoked exactly once (not k times) before
@@ -982,11 +980,9 @@ class Benchmark {
   //
   // The callback will be passed the number of threads for this benchmark run.
   //
-  // The callback must not be self-deleting.  The Benchmark
-  // object takes ownership of the callback std::function object.
-  Benchmark* SetUp(std::function<void(benchmark::State&)>);
-  Benchmark* TearDown(std::function<void(benchmark::State&)>);
-#endif
+  // The callback must not be NULL or self-deleting.
+  Benchmark* Setup(void (*setup)(benchmark::State&));
+  Benchmark* Teardown(void (*teardown)(benchmark::State&));
 
   // Pass this benchmark object to *func, which can customize
   // the benchmark by calling various methods like Arg, Args,
@@ -1118,10 +1114,11 @@ class Benchmark {
   BigOFunc* complexity_lambda_;
   std::vector<Statistics> statistics_;
   std::vector<int> thread_counts_;
-#if defined(BENCHMARK_HAS_CXX11)
-  std::function<void(benchmark::State&)> setup_;
-  std::function<void(benchmark::State&)> teardown_;
-#endif
+
+  typedef void (*callback_function)(benchmark::State&);
+  callback_function setup_;
+  callback_function teardown_;
+
   Benchmark& operator=(Benchmark const&);
 };
 

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -189,6 +189,7 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 
 #if defined(BENCHMARK_HAS_CXX11)
 #include <atomic>
+#include <functional>
 #include <initializer_list>
 #include <type_traits>
 #include <utility>
@@ -968,6 +969,25 @@ class Benchmark {
     return Ranges(ranges);
   }
 
+#if defined(BENCHMARK_HAS_CXX11)
+  // Have "setup" and/or "teardown" invoked once for every benchmark run.
+  // If the benchmark is multi-threaded (will run in k threads concurrently),
+  // the setup callback will be be invoked exactly once (not k times) before
+  // each run with k threads. Time allowing (e.g. for a short benchmark), there
+  // may be multiple such runs per benchmark, each run with its own
+  // "setup"/"teardown".
+  //
+  // If the benchmark uses different size groups of threads (e.g. via
+  // ThreadRange), the above will be true for each size group.
+  //
+  // The callback will be passed the number of threads for this benchmark run.
+  //
+  // The callback must not be self-deleting.  The Benchmark
+  // object takes ownership of the callback std::function object.
+  Benchmark* SetUp(std::function<void(benchmark::State&)>);
+  Benchmark* TearDown(std::function<void(benchmark::State&)>);
+#endif
+
   // Pass this benchmark object to *func, which can customize
   // the benchmark by calling various methods like Arg, Args,
   // Threads, etc.
@@ -1098,7 +1118,10 @@ class Benchmark {
   BigOFunc* complexity_lambda_;
   std::vector<Statistics> statistics_;
   std::vector<int> thread_counts_;
-
+#if defined(BENCHMARK_HAS_CXX11)
+  std::function<void(benchmark::State&)> setup_;
+  std::function<void(benchmark::State&)> teardown_;
+#endif
   Benchmark& operator=(Benchmark const&);
 };
 

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -981,8 +981,8 @@ class Benchmark {
   // The callback will be passed the number of threads for this benchmark run.
   //
   // The callback must not be NULL or self-deleting.
-  Benchmark* Setup(void (*setup)(benchmark::State&));
-  Benchmark* Teardown(void (*teardown)(benchmark::State&));
+  Benchmark* Setup(void (*setup)(const benchmark::State&));
+  Benchmark* Teardown(void (*teardown)(const benchmark::State&));
 
   // Pass this benchmark object to *func, which can customize
   // the benchmark by calling various methods like Arg, Args,
@@ -1115,7 +1115,7 @@ class Benchmark {
   std::vector<Statistics> statistics_;
   std::vector<int> thread_counts_;
 
-  typedef void (*callback_function)(benchmark::State&);
+  typedef void (*callback_function)(const benchmark::State&);
   callback_function setup_;
   callback_function teardown_;
 

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1118,8 +1118,8 @@ class Benchmark {
   std::vector<int> thread_counts_;
 
   typedef void (*callback_function)(const benchmark::State&);
-  callback_function setup_;
-  callback_function teardown_;
+  callback_function setup_ = nullptr;
+  callback_function teardown_ = nullptr;
 
   Benchmark& operator=(Benchmark const&);
 };

--- a/src/benchmark_api_internal.cc
+++ b/src/benchmark_api_internal.cc
@@ -79,10 +79,8 @@ BenchmarkInstance::BenchmarkInstance(Benchmark* benchmark, int family_idx,
     name_.threads = StrFormat("threads:%d", threads_);
   }
 
-#if defined(BENCHMARK_HAS_CXX11)
-  setup_(benchmark.setup_);
-  teardown_(benchmark.teardown_);
-#endif
+  setup_ = benchmark_.setup_;
+  teardown_ = benchmark_.teardown_;
 }
 
 State BenchmarkInstance::Run(
@@ -96,29 +94,19 @@ State BenchmarkInstance::Run(
 }
 
 void BenchmarkInstance::Setup() const {
-#if defined(BENCHMARK_HAS_CXX11)
-  State st(/*iters*/ 1, args_, /*thread_id*/ 0, threads_, nullptr, nullptr,
-           nullptr);
-  // FIXME: Perhaps use an optional<std::function> here to distinguish
-  // no-setup VS NULL setup.
-  // (ie., people *could* try to set a NULL callback to do something weird ...)
   if (setup_) {
+    State st(/*iters*/ 1, args_, /*thread_id*/ 0, threads_, nullptr, nullptr,
+             nullptr);
     setup_(st);
   }
-#endif
 }
 
 void BenchmarkInstance::Teardown() const {
-#if defined(BENCHMARK_HAS_CXX11)
-  State st(/*iters*/ 1, args_, /*thread_id*/ 0, threads_, nullptr, nullptr,
-           nullptr);
-  // TODO(vyng): Perhaps use an optional<std::function> here to distinguish
-  // no-setup VS NULL setup.
-  // (ie., people *could* try to set a NULL callback to do something weird ...)
   if (teardown_) {
+    State st(/*iters*/ 1, args_, /*thread_id*/ 0, threads_, nullptr, nullptr,
+             nullptr);
     teardown_(st);
   }
-#endif
 }
 }  // namespace internal
 }  // namespace benchmark

--- a/src/benchmark_api_internal.cc
+++ b/src/benchmark_api_internal.cc
@@ -78,6 +78,11 @@ BenchmarkInstance::BenchmarkInstance(Benchmark* benchmark, int family_idx,
   if (!benchmark_.thread_counts_.empty()) {
     name_.threads = StrFormat("threads:%d", threads_);
   }
+
+#if defined(BENCHMARK_HAS_CXX11)
+  setup_(benchmark.setup_);
+  teardown_(benchmark.teardown_);
+#endif
 }
 
 State BenchmarkInstance::Run(
@@ -90,5 +95,30 @@ State BenchmarkInstance::Run(
   return st;
 }
 
+void BenchmarkInstance::Setup() const {
+#if defined(BENCHMARK_HAS_CXX11)
+  State st(/*iters*/ 1, args_, /*thread_id*/ 0, threads_, nullptr, nullptr,
+           nullptr);
+  // FIXME: Perhaps use an optional<std::function> here to distinguish
+  // no-setup VS NULL setup.
+  // (ie., people *could* try to set a NULL callback to do something weird ...)
+  if (setup_) {
+    setup_(st);
+  }
+#endif
+}
+
+void BenchmarkInstance::Teardown() const {
+#if defined(BENCHMARK_HAS_CXX11)
+  State st(/*iters*/ 1, args_, /*thread_id*/ 0, threads_, nullptr, nullptr,
+           nullptr);
+  // TODO(vyng): Perhaps use an optional<std::function> here to distinguish
+  // no-setup VS NULL setup.
+  // (ie., people *could* try to set a NULL callback to do something weird ...)
+  if (teardown_) {
+    teardown_(st);
+  }
+#endif
+}
 }  // namespace internal
 }  // namespace benchmark

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -11,6 +11,10 @@
 #include "benchmark/benchmark.h"
 #include "commandlineflags.h"
 
+#if defined(BENCHMARK_HAS_CXX11)
+#include <functional>
+#endif
+
 namespace benchmark {
 namespace internal {
 
@@ -38,6 +42,8 @@ class BenchmarkInstance {
   double min_time() const { return min_time_; }
   IterationCount iterations() const { return iterations_; }
   int threads() const { return threads_; }
+  void Setup() const;
+  void Teardown() const;
 
   State Run(IterationCount iters, int thread_id, internal::ThreadTimer* timer,
             internal::ThreadManager* manager,
@@ -62,6 +68,11 @@ class BenchmarkInstance {
   double min_time_;
   IterationCount iterations_;
   int threads_;  // Number of concurrent threads to us
+
+#if defined(BENCHMARK_HAS_CXX11)
+  std::function<void(benchmark::State&)> setup_;
+  std::function<void(benchmark::State&)> teardown_;
+#endif
 };
 
 bool FindBenchmarksInternal(const std::string& re,

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -11,10 +11,6 @@
 #include "benchmark/benchmark.h"
 #include "commandlineflags.h"
 
-#if defined(BENCHMARK_HAS_CXX11)
-#include <functional>
-#endif
-
 namespace benchmark {
 namespace internal {
 
@@ -69,10 +65,9 @@ class BenchmarkInstance {
   IterationCount iterations_;
   int threads_;  // Number of concurrent threads to us
 
-#if defined(BENCHMARK_HAS_CXX11)
-  std::function<void(benchmark::State&)> setup_;
-  std::function<void(benchmark::State&)> teardown_;
-#endif
+  typedef void (*callback_function)(benchmark::State&);
+  callback_function setup_;
+  callback_function teardown_;
 };
 
 bool FindBenchmarksInternal(const std::string& re,

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -65,7 +65,7 @@ class BenchmarkInstance {
   IterationCount iterations_;
   int threads_;  // Number of concurrent threads to us
 
-  typedef void (*callback_function)(benchmark::State&);
+  typedef void (*callback_function)(const benchmark::State&);
   callback_function setup_;
   callback_function teardown_;
 };

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -66,8 +66,8 @@ class BenchmarkInstance {
   int threads_;  // Number of concurrent threads to us
 
   typedef void (*callback_function)(const benchmark::State&);
-  callback_function setup_;
-  callback_function teardown_;
+  callback_function setup_ = nullptr;
+  callback_function teardown_ = nullptr;
 };
 
 bool FindBenchmarksInternal(const std::string& re,

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -321,6 +321,16 @@ Benchmark* Benchmark::Apply(void (*custom_arguments)(Benchmark* benchmark)) {
   return this;
 }
 
+#if defined(BENCHMARK_HAS_CXX11)
+Benchmark* Benchmark::SetUp(std::function<void(benchmark::State&)> setup) {
+  setup_(std::move(setup));
+  return this;
+}
+Benchmark* TearDown(std::function<void(benchmark::State&)> teardown) {
+  teardown_(std::move(teardown));
+}
+#endif
+
 Benchmark* Benchmark::RangeMultiplier(int multiplier) {
   BM_CHECK(multiplier > 1);
   range_multiplier_ = multiplier;

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -211,7 +211,9 @@ Benchmark::Benchmark(const char* name)
       use_real_time_(false),
       use_manual_time_(false),
       complexity_(oNone),
-      complexity_lambda_(nullptr) {
+      complexity_lambda_(nullptr),
+      setup_(nullptr),
+      teardown_(nullptr) {
   ComputeStatistics("mean", StatisticsMean);
   ComputeStatistics("median", StatisticsMedian);
   ComputeStatistics("stddev", StatisticsStdDev);

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -321,13 +321,13 @@ Benchmark* Benchmark::Apply(void (*custom_arguments)(Benchmark* benchmark)) {
   return this;
 }
 
-Benchmark* Benchmark::Setup(void (*setup)(benchmark::State&)) {
+Benchmark* Benchmark::Setup(void (*setup)(const benchmark::State&)) {
   BM_CHECK(setup != nullptr);
   setup_ = setup;
   return this;
 }
 
-Benchmark* Benchmark::Teardown(void (*teardown)(benchmark::State&)) {
+Benchmark* Benchmark::Teardown(void (*teardown)(const benchmark::State&)) {
   BM_CHECK(teardown != nullptr);
   teardown_ = teardown;
   return this;

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -321,15 +321,17 @@ Benchmark* Benchmark::Apply(void (*custom_arguments)(Benchmark* benchmark)) {
   return this;
 }
 
-#if defined(BENCHMARK_HAS_CXX11)
-Benchmark* Benchmark::SetUp(std::function<void(benchmark::State&)> setup) {
-  setup_(std::move(setup));
+Benchmark* Benchmark::Setup(void (*setup)(benchmark::State&)) {
+  BM_CHECK(setup != nullptr);
+  setup_ = setup;
   return this;
 }
-Benchmark* TearDown(std::function<void(benchmark::State&)> teardown) {
-  teardown_(std::move(teardown));
+
+Benchmark* Benchmark::Teardown(void (*teardown)(benchmark::State&)) {
+  BM_CHECK(teardown != nullptr);
+  teardown_ = teardown;
+  return this;
 }
-#endif
 
 Benchmark* Benchmark::RangeMultiplier(int multiplier) {
   BM_CHECK(multiplier > 1);

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -279,6 +279,7 @@ void BenchmarkRunner::DoOneRepetition() {
   // is *only* calculated for the *first* repetition, and other repetitions
   // simply use that precomputed iteration count.
   for (;;) {
+    b.Setup();
     i = DoNIterations();
 
     // Do we consider the results to be significant?
@@ -290,6 +291,7 @@ void BenchmarkRunner::DoOneRepetition() {
                                          has_explicit_iteration_count ||
                                          ShouldReportIterationResults(i);
 
+    b.Tearndown();
     if (results_are_significant) break;  // Good, let's report them!
 
     // Nope, bad iteration. Let's re-estimate the hopefully-sufficient

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -291,7 +291,7 @@ void BenchmarkRunner::DoOneRepetition() {
                                          has_explicit_iteration_count ||
                                          ShouldReportIterationResults(i);
 
-    b.Tearndown();
+    b.Teardown();
     if (results_are_significant) break;  // Good, let's report them!
 
     // Nope, bad iteration. Let's re-estimate the hopefully-sufficient

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -318,10 +318,12 @@ void BenchmarkRunner::DoOneRepetition() {
     memory_manager->Start();
     std::unique_ptr<internal::ThreadManager> manager;
     manager.reset(new internal::ThreadManager(1));
+    b.Setup();
     RunInThread(&b, memory_iterations, 0, manager.get(),
                 perf_counters_measurement_ptr);
     manager->WaitForAllThreads();
     manager.reset();
+    b.Teardown();
 
     BENCHMARK_DISABLE_DEPRECATED_WARNING
     memory_manager->Stop(memory_result);

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -281,6 +281,7 @@ void BenchmarkRunner::DoOneRepetition() {
   for (;;) {
     b.Setup();
     i = DoNIterations();
+    b.Teardown();
 
     // Do we consider the results to be significant?
     // If we are doing repetitions, and the first repetition was already done,
@@ -291,7 +292,6 @@ void BenchmarkRunner::DoOneRepetition() {
                                          has_explicit_iteration_count ||
                                          ShouldReportIterationResults(i);
 
-    b.Teardown();
     if (results_are_significant) break;  // Good, let's report them!
 
     // Nope, bad iteration. Let's re-estimate the hopefully-sufficient

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,6 +59,9 @@ add_test(NAME benchmark COMMAND benchmark_test --benchmark_min_time=0.01)
 compile_benchmark_test(spec_arg_test)
 add_test(NAME spec_arg COMMAND spec_arg_test --benchmark_filter=BM_NotChosen)
 
+compile_benchmark_test(benchmark_setup_teardown_test)
+add_test(NAME benchmark_setup_teardown COMMAND benchmark_setup_teardown_test)
+
 compile_benchmark_test(filter_test)
 macro(add_filter_test name filter expect)
   add_test(NAME ${name} COMMAND filter_test --benchmark_min_time=0.01 --benchmark_filter=${filter} ${expect})

--- a/test/benchmark_setup_teardown_test.cc
+++ b/test/benchmark_setup_teardown_test.cc
@@ -8,8 +8,6 @@
 
 #include "benchmark/benchmark.h"
 
-#ifdef BENCHMARK_HAS_CXX11
-
 // Test that Setup() and Teardown() are called exactly once
 // for each benchmark run (single-threaded).
 namespace single {
@@ -79,22 +77,15 @@ int main(int argc, char** argv) {
   size_t ret = benchmark::RunSpecifiedBenchmarks(".");
   assert(ret > 0);
 
-  // Setup/Teardown is called once for each arg group.
-  // (There were 3,5,7,4)
+  // Setup/Teardown is called once for each arg group (1,3,5,7).
   assert(single::setup_call == 4);
   assert(single::teardown_call == 4);
 
+  // 3 group of threads calling this function (3,5,10).
   assert(concurrent::setup_call.load(std::memory_order_relaxed) == 3);
   assert(concurrent::teardown_call.load(std::memory_order_relaxed) == 3);
-
-  // 3 group of threads calling this function.
   assert((5 + 10 + 15) ==
          concurrent::func_call.load(std::memory_order_relaxed));
 
   return 0;
 }
-
-#else
-// Do nothing
-int main(int, char**) { return 0; }
-#endif  // BENCHMARK_HAS_CXX11

--- a/test/benchmark_setup_teardown_test.cc
+++ b/test/benchmark_setup_teardown_test.cc
@@ -16,14 +16,14 @@ namespace single {
 static int setup_call = 0;
 static int teardown_call = 0;
 }  // namespace single
-static void DoSetup1(benchmark::State& state) {
+static void DoSetup1(const benchmark::State& state) {
   ++single::setup_call;
 
   // Setup/Teardown should never be called with any thread_idx != 0.
   assert(state.thread_index() == 0);
 }
 
-static void DoTeardown1(benchmark::State& state) {
+static void DoTeardown1(const benchmark::State& state) {
   ++single::teardown_call;
   assert(state.thread_index() == 0);
 }
@@ -49,12 +49,12 @@ static std::atomic<int> teardown_call(0);
 static std::atomic<int> func_call(0);
 }  // namespace concurrent
 
-static void DoSetup2(benchmark::State& state) {
+static void DoSetup2(const benchmark::State& state) {
   concurrent::setup_call.fetch_add(1, std::memory_order_acquire);
   assert(state.thread_index() == 0);
 }
 
-static void DoTeardown2(benchmark::State& state) {
+static void DoTeardown2(const benchmark::State& state) {
   concurrent::teardown_call.fetch_add(1, std::memory_order_acquire);
   assert(state.thread_index() == 0);
 }

--- a/test/benchmark_setup_teardown_test.cc
+++ b/test/benchmark_setup_teardown_test.cc
@@ -71,9 +71,7 @@ BENCHMARK(BM_concurrent)
     ->Threads(10)
     ->Threads(15);
 
-// Test that setup/teardown is repeated for each repetition.
-// Also testing interaction with Fixture::Setup/Teardown
-
+// Testing interaction with Fixture::Setup/Teardown
 namespace fixture_interaction {
 int setup = 0;
 int fixture_setup = 0;
@@ -107,6 +105,7 @@ BENCHMARK_REGISTER_F(FIXTURE_BECHMARK_NAME, BM_WithFixture)
     ->Setup(DoSetupWithFixture)
     ->Iterations(100);
 
+// Testing repetitions.
 namespace repetitions {
 int setup = 0;
 }
@@ -125,7 +124,8 @@ BENCHMARK(BM_WithRep)
     ->Arg(5)
     ->Arg(7)
     ->Setup(DoSetupWithRepetitions)
-    ->Repetitions(5);
+    ->Iterations(100)
+    ->Repetitions(4);
 
 int main(int argc, char** argv) {
   benchmark::Initialize(&argc, argv);
@@ -148,7 +148,7 @@ int main(int argc, char** argv) {
   // Fixture::Setup is called everytime the bm routine is run.
   assert(fixture_interaction::fixture_setup == 14);
 
-  // Setup is call once for each repetion * num_arg =  4 * 4 = 16.
+  // Setup is call once for each repetition * num_arg =  4 * 4 = 16.
   assert(repetitions::setup == 16);
 
   return 0;

--- a/test/benchmark_setup_teardown_test.cc
+++ b/test/benchmark_setup_teardown_test.cc
@@ -26,7 +26,6 @@ static void DoTeardown1(const benchmark::State& state) {
   assert(state.thread_index() == 0);
 }
 
-static int func_c = 0;
 static void BM_with_setup(benchmark::State& state) {
   for (auto s : state) {
   }

--- a/test/benchmark_setup_teardown_test.cc
+++ b/test/benchmark_setup_teardown_test.cc
@@ -1,0 +1,88 @@
+#include <atomic>
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <string>
+
+#include "benchmark/benchmark.h"
+
+#ifdef BENCHMARK_HAS_CXX11
+
+// Test that Setup() and Teardown() are called exactly once
+// for each benchmark run (single-threaded).
+namespace single {
+static int setup_call = 0;
+static int teardown_call = 0;
+}  // namespace single
+static void DoSetup1(benchmark::State& state) {
+  ++single::setup_call;
+
+  // Setup/Teardown should never be called with any thread_idx != 0.
+  assert(state.thread_index() == 0);
+}
+
+static void DoTeardown1(benchmark::State& state) {
+  ++single::teardown_call;
+  assert(state.thread_index() == 0);
+}
+
+static void BM_with_setup(benchmark::State& state) {
+  for (auto s : state) {
+  }
+}
+BENCHMARK(BM_with_setup)
+    ->Arg(1)
+    ->Arg(3)
+    ->Arg(5)
+    ->Setup(DoSetup1)
+    ->Teardown(DoTeardown1);
+
+// Test that Setup() and Teardown() are called once for each group of threads.
+namespace concurrent {
+static std::atomic<int> setup_call(0);
+static std::atomic<int> teardown_call(0);
+static std::atomic<int> func_call(0);
+}  // namespace concurrent
+
+static void DoSetup2(benchmark::State& state) {
+  concurrent::setup_call.fetch_add(1, std::memory_order_acquire);
+  assert(state.thread_index() == 0);
+}
+
+static void DoTeardown2(benchmark::State& state) {
+  concurrent::teardown_call.fetch_add(1, std::memory_order_acquire);
+  assert(state.thread_index() == 0);
+}
+
+static void BM_concurrent(benchmark::State& state) {
+  for (auto s : state) {
+  }
+  concurrent::func_call.fetch_add(1, std::memory_order_acquire);
+}
+
+BENCHMARK(BM_concurrent)->Threads(5)->Threads(10)->Threads(15);
+
+int main(int argc, char** argv) {
+  benchmark::Initialize(&argc, argv);
+
+  size_t ret = benchmark::RunSpecifiedBenchmarks(".");
+  assert(ret > 0);
+
+  assert(single::setup_call == 1);
+  assert(single::teardown_call == 1);
+
+  assert(concurrent::setup_call.load(memory_order_relaxed) == 3);
+  assert(concurent::teardown_call.load(memory_order_relaxed) == 3);
+
+  // 3 group of threads calling this function.
+  assert((5 + 10 + 15) == concurrent::func_call.load(memory_order_relaxed));
+
+  return 0;
+}
+
+#else
+// Do nothing
+int main(int, char**) { return 0; }
+#endif  // BENCHMARK_HAS_CXX11

--- a/test/benchmark_setup_teardown_test.cc
+++ b/test/benchmark_setup_teardown_test.cc
@@ -102,6 +102,7 @@ BENCHMARK_REGISTER_F(FIXTURE_BECHMARK_NAME, BM_WithFixture)
     ->Arg(5)
     ->Arg(7)
     ->Setup(DoSetupWithFixture)
+    ->Repetitions(1)
     ->Iterations(100);
 
 // Testing repetitions.
@@ -145,7 +146,9 @@ int main(int argc, char** argv) {
   // Setup is called 4 times, once for each arg group (1,3,5,7)
   assert(fixture_interaction::setup == 4);
   // Fixture::Setup is called everytime the bm routine is run.
-  assert(fixture_interaction::fixture_setup == 14);
+  // The exact number is indeterministic, so we just assert that
+  // it's more than setup.
+  assert(fixture_interaction::fixture_setup > fixture_interaction::setup);
 
   // Setup is call once for each repetition * num_arg =  4 * 4 = 16.
   assert(repetitions::setup == 16);


### PR DESCRIPTION
Motivations:
- feature parity with our internal library. (which has ~718 callers)
- more flexible than cordinating setup/teardown code inside the benchmark routine.