### PR TITLE
Fix build error on Clang 13 on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ if (MSVC)
   string(REGEX REPLACE "[-/]W[1-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  add_definitions(-D_CRT_USE_BUILTIN_OFFSETOF)
 
   if (NOT BENCHMARK_ENABLE_EXCEPTIONS)
     add_cxx_compiler_flag(-EHs-)


### PR DESCRIPTION
By default, MSVC's `stddef.h` header defines an `offsetof` macro containing a `reinterpret_cast`. This breaks building `benchmark.cc` on Clang 13 on Windows, because a `reinterpret_cast` is not allowed within a `static_assert`. Defining the `_CRT_USE_BUILTIN_OFFSETOF` uses a builtin for `offsetof` instead of the macro, which allows the file to build again.

Fixes #1277.