### PR TITLE
Remove bazelbuild/rules_cc dependency

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])
 
 config_setting(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,13 +3,6 @@ workspace(name = "com_github_google_benchmark")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "rules_cc",
-    strip_prefix = "rules_cc-a508235df92e71d537fcbae0c7c952ea6957a912",
-    urls = ["https://github.com/bazelbuild/rules_cc/archive/a508235df92e71d537fcbae0c7c952ea6957a912.zip"],
-    sha256 = "d7dc12c1d5bc1a87474de8e3d17b7731a4dcebcfb8aa3990fe8ac7734ef12f2f",
-)
-
-http_archive(
     name = "com_google_absl",
     sha256 = "f41868f7a938605c92936230081175d1eae87f6ea2c248f41077c8f88316f111",
     strip_prefix = "abseil-cpp-20200225.2",


### PR DESCRIPTION
It seems according to [1] that bazelbuild/rules_cc has been put on hold
and that the recommended way for now, is to use the native cc rules.

[1]: https://github.com/bazelbuild/rules_go/pull/2950