### PR TITLE
Googletest renamed master to main today.

### DIFF
--- a/cmake/GoogleTest.cmake.in
+++ b/cmake/GoogleTest.cmake.in
@@ -38,7 +38,7 @@ else()
     ExternalProject_Add(
       googletest
       GIT_REPOSITORY    https://github.com/google/googletest.git
-      GIT_TAG           master
+      GIT_TAG           main
       PREFIX            "${CMAKE_BINARY_DIR}"
       STAMP_DIR         "${CMAKE_BINARY_DIR}/stamp"
       DOWNLOAD_DIR      "${CMAKE_BINARY_DIR}/download"


### PR DESCRIPTION
"master" does not exist anymore, it was changed to "main". As a result cmake throws an error when trying to checkout master.