### PR TITLE
Set C++ 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ endforeach()
 
 project (benchmark VERSION 1.6.0 LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+
 option(BENCHMARK_ENABLE_TESTING "Enable testing of the benchmark library." ON)
 option(BENCHMARK_ENABLE_EXCEPTIONS "Enable the use of exceptions in the benchmark library." ON)
 option(BENCHMARK_ENABLE_LTO "Enable link time optimisation of the benchmark library." OFF)


### PR DESCRIPTION
On MacOs I got this error:

/Users/gerardozinno/repos/parallel-cellular-automata/tests/ext/benchmark/test/skip_with_error_test.cc:122:5: error: use of the 'maybe_unused' attribute is a
      C++17 extension [-Werror,-Wc++17-extensions]
  [[maybe_unused]] bool first_iter = true;

So I simply and only added `set(CMAKE_CXX_STANDARD 17)` on line 17 of the CMakeLists.txt, everything worked fine after that and the framework compiled without any problem
