### PR TITLE
Update user_guide.md: `thread_index` should be `thread_index()`

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -760,13 +760,13 @@ index:
 
 ```c++
 static void BM_MultiThreaded(benchmark::State& state) {
-  if (state.thread_index == 0) {
+  if (state.thread_index() == 0) {
     // Setup code here.
   }
   for (auto _ : state) {
     // Run the test as normal.
   }
-  if (state.thread_index == 0) {
+  if (state.thread_index() == 0) {
     // Teardown code here.
   }
 }


### PR DESCRIPTION
https://github.com/google/benchmark/pull/1208 changed public data member `thread_index` to accessor `thread_index()`.

This PR updates the docs. 