### PR TITLE
Avoid errors due to "default label in switch which covers all enumeration values" in Windows codepath

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -344,6 +344,7 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizesWindows() {
     C.num_sharing = static_cast<int>(B.count());
     C.level = Cache->Level;
     C.size = Cache->Size;
+    C.type = "Unknown";
     switch (Cache->Type) {
       case CacheUnified:
         C.type = "Unified";
@@ -356,9 +357,6 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizesWindows() {
         break;
       case CacheTrace:
         C.type = "Trace";
-        break;
-      default:
-        C.type = "Unknown";
         break;
     }
     res.push_back(C);


### PR DESCRIPTION
This applies a fix that used to exist in LLVM's downstream copy of
this library, from
https://github.com/llvm/llvm-project/commit/948ce4e6edec6ad3cdf1911fc3e8e9569140d4ff.

I presume this warning isn't present if built with MSVC or Clang-cl,
but it's printed in MinGW mode. As the benchmark library adds
-Werror, this is a fatal error when builtin MinGW mode.