### PR TITLE
Check BENCHMARK_ENABLE_INSTALL was set before exporting targets. Fixes #1275

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -150,6 +150,8 @@ else()
       DESTINATION ${CMAKE_INSTALL_DOCDIR})
   endif()
 
-  export (EXPORT ${targets_export_name} NAMESPACE "${namespace}"
-    FILE ${generated_dir}/${targets_export_name}.cmake)
+  if (BENCHMARK_ENABLE_INSTALL)
+    export (EXPORT ${targets_export_name} NAMESPACE "${namespace}"
+      FILE ${generated_dir}/${targets_export_name}.cmake)
+  endif()
 endif()


### PR DESCRIPTION
${targets_export_name} is undefined otherwise.