### PR TITLE
add error handling in ThreadCPUUsage when GetThreadTimes failed

### DIFF
--- a/src/timers.cc
+++ b/src/timers.cc
@@ -146,9 +146,10 @@ double ThreadCPUUsage() {
   FILETIME exit_time;
   FILETIME kernel_time;
   FILETIME user_time;
-  GetThreadTimes(this_thread, &creation_time, &exit_time, &kernel_time,
-                 &user_time);
-  return MakeTime(kernel_time, user_time);
+  if (GetThreadTimes(this_thread, &creation_time, &exit_time, &kernel_time,
+                 &user_time) 
+    return MakeTime(kernel_time, user_time);
+  DiagnoseAndExit("GetThreadTimes() failed");
 #elif defined(BENCHMARK_OS_MACOSX)
   // FIXME We want to use clock_gettime, but its not available in MacOS 10.11.
   // See https://github.com/google/benchmark/pull/292


### PR DESCRIPTION
In ThreadCPUUsage function, the GetThreadTimes may fail, it should add some error handling just like what the function ProcessCPUUsage did.