### PR TITLE
fix(gcc 11+): include <limits>

### DIFF
--- a/src/benchmark_register.h
+++ b/src/benchmark_register.h
@@ -3,7 +3,7 @@
 
 #include <limits>
 #include <vector>
-
+#include <limits>
 #include "check.h"
 
 namespace benchmark {


### PR DESCRIPTION
I received this warning while compiling:

./src/benchmark_register.h:22:30: error: ‘numeric_limits’ is not a member of ‘std’

Line 22: static const T kmax = std::numeric_limits<T>::max();

Found newer gcc and clang requires explicit include of \<limits\>, so I added the #include and everything compiles.

Stackoverflow related to it [here](https://stackoverflow.com/questions/4798936/numeric-limits-was-not-declared-in-this-scope-no-matching-function-for-call-t).