### PR TITLE
Destructor not returning is expected in some cases

### DIFF
--- a/src/check.h
+++ b/src/check.h
@@ -22,7 +22,7 @@ BENCHMARK_NORETURN inline void CallAbortHandler() {
   GetAbortHandler()();
   std::abort();  // fallback to enforce noreturn
 }
-    
+
 // CheckHandler is the class constructed by failing CHECK macros. CheckHandler
 // will log information about the failures and abort when it is destructed.
 class CheckHandler {
@@ -36,15 +36,15 @@ class CheckHandler {
   LogType& GetLog() { return log_; }
 
 #if defined (COMPILER_MSVC)
-#pragma warning(push)
-#pragma warning(disable:4722)
+  #pragma warning(push)
+  #pragma warning(disable:4722)
 #endif
   BENCHMARK_NORETURN ~CheckHandler() BENCHMARK_NOEXCEPT_OP(false) {
     log_ << std::endl;
     CallAbortHandler();
   }
 #if defined (COMPILER_MSVC)
-#pragma warning(pop)
+  #pragma warning(pop)
 #endif
 
   CheckHandler& operator=(const CheckHandler&) = delete;

--- a/src/check.h
+++ b/src/check.h
@@ -35,15 +35,15 @@ class CheckHandler {
 
   LogType& GetLog() { return log_; }
 
-#if defined (COMPILER_MSVC)
+#if defined(COMPILER_MSVC)
 #pragma warning(push)
-#pragma warning(disable:4722)
+#pragma warning(disable : 4722)
 #endif
   BENCHMARK_NORETURN ~CheckHandler() BENCHMARK_NOEXCEPT_OP(false) {
     log_ << std::endl;
     CallAbortHandler();
   }
-#if defined (COMPILER_MSVC)
+#if defined(COMPILER_MSVC)
 #pragma warning(pop)
 #endif
 

--- a/src/check.h
+++ b/src/check.h
@@ -22,7 +22,7 @@ BENCHMARK_NORETURN inline void CallAbortHandler() {
   GetAbortHandler()();
   std::abort();  // fallback to enforce noreturn
 }
-
+    
 // CheckHandler is the class constructed by failing CHECK macros. CheckHandler
 // will log information about the failures and abort when it is destructed.
 class CheckHandler {
@@ -35,10 +35,17 @@ class CheckHandler {
 
   LogType& GetLog() { return log_; }
 
+#if defined (COMPILER_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4722)
+#endif
   BENCHMARK_NORETURN ~CheckHandler() BENCHMARK_NOEXCEPT_OP(false) {
     log_ << std::endl;
     CallAbortHandler();
   }
+#if defined (COMPILER_MSVC)
+#pragma warning(pop)
+#endif
 
   CheckHandler& operator=(const CheckHandler&) = delete;
   CheckHandler(const CheckHandler&) = delete;

--- a/src/check.h
+++ b/src/check.h
@@ -36,15 +36,15 @@ class CheckHandler {
   LogType& GetLog() { return log_; }
 
 #if defined (COMPILER_MSVC)
-  #pragma warning(push)
-  #pragma warning(disable:4722)
+#pragma warning(push)
+#pragma warning(disable:4722)
 #endif
   BENCHMARK_NORETURN ~CheckHandler() BENCHMARK_NOEXCEPT_OP(false) {
     log_ << std::endl;
     CallAbortHandler();
   }
 #if defined (COMPILER_MSVC)
-  #pragma warning(pop)
+#pragma warning(pop)
 #endif
 
   CheckHandler& operator=(const CheckHandler&) = delete;


### PR DESCRIPTION
Address what appears to be the final part of #826 

Per https://github.com/google/benchmark/issues/826#issuecomment-851995549 we are safe to ignore the warning
in this case.

It is unfortunate that the declspec used for the BENCHMARK_NORETURN macro does not cause the compiler to elide
this warning, as one might imagine it should.