### PR TITLE
explicitly export public symbols

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
   # TODO: add coverage build (requires lcov)
   # TODO: add clang + libc++ builds for ubuntu
   job:
-    name: ${{ matrix.os }}.${{ matrix.build_type }}.${{ matrix.compiler }}
+    name: ${{ matrix.os }}.${{ matrix.build_type }}.${{ matrix.lib }}.${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -18,18 +18,25 @@ jobs:
         os: [ubuntu-latest, ubuntu-20.04, macos-latest]
         build_type: ['Release', 'Debug']
         compiler: [g++, clang++]
-        include:
-          - displayTargetName: windows-latest-release
-            os: windows-latest
-            build_type: 'Release'
-          - displayTargetName: windows-latest-debug
-            os: windows-latest
-            build_type: 'Debug'
+        lib: ['shared', 'static']
+
     steps:
       - uses: actions/checkout@v2
 
       - name: create build environment
         run: cmake -E make_directory ${{ runner.workspace }}/_build
+
+      - name: setup cmake initial cache
+        run: touch compiler-cache.cmake
+
+      - name: setup lto
+        # Workaround for enabling -flto on old GCC versions
+        if: matrix.build_type == 'Release' && startsWith(matrix.compiler, 'g++') && matrix.os != 'macos-latest'
+        run: >
+          echo 'set (CMAKE_CXX_FLAGS -flto CACHE STRING "")' >> compiler-cache.cmake;
+          echo 'set (CMAKE_RANLIB /usr/bin/gcc-ranlib CACHE FILEPATH "")' >> compiler-cache.cmake;
+          echo 'set (CMAKE_AR /usr/bin/gcc-ar CACHE FILEPATH "")' >> compiler-cache.cmake;
+          echo 'set (CMAKE_NM /usr/bin/gcc-nm CACHE FILEPATH "")' >> compiler-cache.cmake;
 
       - name: configure cmake
         env:
@@ -37,9 +44,13 @@ jobs:
         shell: bash
         working-directory: ${{ runner.workspace }}/_build
         run: >
-          cmake $GITHUB_WORKSPACE
+          cmake -C ${{ github.workspace }}/compiler-cache.cmake
+          $GITHUB_WORKSPACE
           -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+          -DBUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DCMAKE_CXX_VISIBILITY_PRESET=hidden
+          -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON
 
       - name: build
         shell: bash
@@ -50,6 +61,57 @@ jobs:
         shell: bash
         working-directory: ${{ runner.workspace }}/_build
         run: ctest -C ${{ matrix.build_type }} -VV
+
+  msvc:
+    name: ${{ matrix.os }}.${{ matrix.build_type }}.${{ matrix.lib }}.${{ matrix.msvc }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+        run:
+            shell: powershell
+    strategy:
+      fail-fast: false
+      matrix:
+        msvc:
+          - VS-16-2019
+          - VS-17-2022
+        arch:
+          - x64
+        build_type:
+          - Debug
+          - Release
+        lib:
+          - shared
+          - static
+        include:
+          - msvc: VS-16-2019
+            os: windows-2019
+            generator: 'Visual Studio 16 2019'
+          - msvc: VS-17-2022
+            os: windows-2022
+            generator: 'Visual Studio 17 2022'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: configure cmake
+        run: >
+          cmake -S . -B _build/
+          -A ${{ matrix.arch }}
+          -G "${{ matrix.generator }}"
+          -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+          -DBUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
+
+      - name: build
+        run: cmake --build _build/ --config ${{ matrix.build_type }}
+
+      - name: setup test environment
+        # Make sure gmock and benchmark DLLs can be found
+        run: >
+            echo "$((Get-Item .).FullName)/_build/bin/${{ matrix.build_type }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append;
+            echo "$((Get-Item .).FullName)/_build/src/${{ matrix.build_type }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append;
+
+      - name: test
+        run: ctest --test-dir _build/ -C ${{ matrix.build_type }} -VV
 
   ubuntu-16_04:
     name: ubuntu-16.04.${{ matrix.build_type }}.${{ matrix.compiler }}
@@ -71,15 +133,34 @@ jobs:
       - name: create build environment
         run: cmake -E make_directory $GITHUB_WORKSPACE/_build
 
+      - name: setup cmake initial cache
+        run: touch compiler-cache.cmake
+
+      - name: setup lto
+        # Workaround for enabling -flto on old GCC versions
+        # -Wl,--no-as-needed is needed to avoid the following linker error:
+        #
+        #   /usr/lib/gcc/x86_64-linux-gnu/5/libstdc++.so: undefined reference to `pthread_create'
+        #
+        if: matrix.build_type == 'Release' && startsWith(matrix.compiler, 'g++')
+        run: >
+          echo 'set (CMAKE_CXX_FLAGS "-Wl,--no-as-needed -flto" CACHE STRING "")' >> compiler-cache.cmake;
+          echo 'set (CMAKE_RANLIB "/usr/bin/gcc-ranlib" CACHE FILEPATH "")' >> compiler-cache.cmake;
+          echo 'set (CMAKE_AR "/usr/bin/gcc-ar" CACHE FILEPATH "")' >> compiler-cache.cmake;
+          echo 'set (CMAKE_NM "/usr/bin/gcc-nm" CACHE FILEPATH "")' >> compiler-cache.cmake;
+
       - name: configure cmake
         env:
           CXX: ${{ matrix.compiler }}
         shell: bash
         working-directory: ${{ github.workspace }}/_build
         run: >
-          cmake $GITHUB_WORKSPACE
+          cmake -C ../compiler-cache.cmake ..
           -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+          -DBUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DCMAKE_CXX_VISIBILITY_PRESET=hidden
+          -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON
 
       - name: build
         shell: bash
@@ -126,16 +207,38 @@ jobs:
       - name: create build environment
         run: cmake -E make_directory $GITHUB_WORKSPACE/_build
 
+      - name: setup cmake initial cache
+        run: touch compiler-cache.cmake
+
+      - name: setup lto
+        # Workaround for enabling -flto on old GCC versions
+        # -Wl,--no-as-needed is needed to avoid the following linker error:
+        #
+        #   /usr/lib/gcc/x86_64-linux-gnu/6/libstdc++.so: undefined reference to `pthread_create'
+        #
+        if: matrix.build_type == 'Release' && startsWith(matrix.compiler, 'g++')
+        run: >
+          COMPILER=${{ matrix.compiler }};
+          VERSION=${COMPILER#g++-};
+          PREFIX=/usr/bin/gcc;
+          echo "set (CMAKE_CXX_FLAGS \"-Wl,--no-as-needed -flto\" CACHE STRING \"\")" >> compiler-cache.cmake;
+          echo "set (CMAKE_RANLIB \"$PREFIX-ranlib-$VERSION\" CACHE FILEPATH \"\")" >> compiler-cache.cmake;
+          echo "set (CMAKE_AR \"$PREFIX-ar-$VERSION\" CACHE FILEPATH \"\")" >> compiler-cache.cmake;
+          echo "set (CMAKE_NM \"$PREFIX-nm-$VERSION\" CACHE FILEPAT \"\")" >> compiler-cache.cmake;
+
       - name: configure cmake
         env:
           CXX: ${{ matrix.compiler }}
         shell: bash
         working-directory: ${{ github.workspace }}/_build
         run: >
-          cmake $GITHUB_WORKSPACE
-          -DBENCHMARK_ENABLE_TESTING=${{ matrix.run_tests }}
-          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          cmake -C ../compiler-cache.cmake ..
           -DBENCHMARK_DOWNLOAD_DEPENDENCIES=${{ matrix.run_tests }}
+          -DBENCHMARK_ENABLE_TESTING=${{ matrix.run_tests }}
+          -DBUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DCMAKE_CXX_VISIBILITY_PRESET=hidden
+          -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON
 
       - name: build
         shell: bash

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,22 @@
 licenses(["notice"])
 
+load(
+    "@com_github_google_benchmark//tools:workspace/generate_export_header.bzl",
+    "generate_export_header",
+)
+
+posix_copts = [
+    "-fvisibility=hidden",
+    "-fvisibility-inlines-hidden",
+]
+
+# Generate header to provide ABI export symbols
+generate_export_header(
+    out = "include/benchmark/export.h",
+    lib = "benchmark",
+    static_define = "BENCHMARK_STATIC_DEFINE",
+)
+
 config_setting(
     name = "qnx",
     constraint_values = ["@platforms//os:qnx"],
@@ -27,13 +44,20 @@ cc_library(
         ],
         exclude = ["src/benchmark_main.cc"],
     ),
-    hdrs = ["include/benchmark/benchmark.h"],
+    hdrs = [
+        "include/benchmark/benchmark.h",
+        "include/benchmark/export.h", # From generate_export_header
+    ],
     linkopts = select({
         ":windows": ["-DEFAULTLIB:shlwapi.lib"],
         "//conditions:default": ["-pthread"],
     }),
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": posix_copts,
+    }),
 )
 
 cc_library(
@@ -43,6 +67,10 @@ cc_library(
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [":benchmark"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": posix_copts,
+    }),
 )
 
 cc_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,10 @@ option(BENCHMARK_USE_BUNDLED_GTEST "Use bundled GoogleTest. If disabled, the fin
 
 option(BENCHMARK_ENABLE_LIBPFM "Enable performance counters provided by libpfm" OFF)
 
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+# Export only public symbols
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+
 if(MSVC)
     # As of CMake 3.18, CMAKE_SYSTEM_PROCESSOR is not set properly for MSVC and
     # cross-compilation (e.g. Host=x86_64, target=aarch64) requires using the
@@ -123,10 +126,11 @@ set(GENERIC_LIB_VERSION ${VERSION})
 string(SUBSTRING ${VERSION} 0 1 GENERIC_LIB_SOVERSION)
 
 # Import our CMake modules
-include(CheckCXXCompilerFlag)
 include(AddCXXCompilerFlag)
-include(CXXFeatureCheck)
+include(CheckCXXCompilerFlag)
 include(CheckLibraryExists)
+include(CXXFeatureCheck)
+include(GenerateExportHeader)
 
 check_library_exists(rt shm_open "" HAVE_LIB_RT)
 

--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -1,5 +1,7 @@
 // Benchmark for Python.
 
+#include "benchmark/benchmark.h"
+
 #include <map>
 #include <string>
 #include <vector>
@@ -8,8 +10,6 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 #include "pybind11/stl_bind.h"
-
-#include "benchmark/benchmark.h"
 
 PYBIND11_MAKE_OPAQUE(benchmark::UserCounters);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,10 +22,15 @@ add_library(benchmark::benchmark ALIAS benchmark)
 set_target_properties(benchmark PROPERTIES
   OUTPUT_NAME "benchmark"
   VERSION ${GENERIC_LIB_VERSION}
-  SOVERSION ${GENERIC_LIB_SOVERSION}
+  SOVERSION 2
 )
 target_include_directories(benchmark PUBLIC
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+)
+
+generate_export_header(benchmark
+  EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/benchmark/export.h)
 
 # libpfm, if available
 if (HAVE_LIBPFM)
@@ -59,7 +64,8 @@ add_library(benchmark::benchmark_main ALIAS benchmark_main)
 set_target_properties(benchmark_main PROPERTIES
   OUTPUT_NAME "benchmark_main"
   VERSION ${GENERIC_LIB_VERSION}
-  SOVERSION ${GENERIC_LIB_SOVERSION}
+  SOVERSION 2
+  DEFINE_SYMBOL benchmark_EXPORTS
 )
 target_link_libraries(benchmark_main PUBLIC benchmark::benchmark)
 
@@ -107,6 +113,7 @@ if (BENCHMARK_ENABLE_INSTALL)
 
   install(
     DIRECTORY "${PROJECT_SOURCE_DIR}/include/benchmark"
+              "${PROJECT_BINARY_DIR}/include/benchmark"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN "*.*h")
 

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -126,7 +126,7 @@ BM_DEFINE_int32(v, 0);
 
 namespace internal {
 
-std::map<std::string, std::string>* global_context = nullptr;
+BENCHMARK_EXPORT std::map<std::string, std::string>* global_context = nullptr;
 
 // FIXME: wouldn't LTO mess this up?
 void UseCharPointer(char const volatile*) {}

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -76,6 +76,7 @@ bool FindBenchmarksInternal(const std::string& re,
 
 bool IsZero(double n);
 
+BENCHMARK_EXPORT
 ConsoleReporter::OutputOptions GetOutputOptions(bool force_no_color = false);
 
 }  // end namespace internal

--- a/src/benchmark_main.cc
+++ b/src/benchmark_main.cc
@@ -15,3 +15,13 @@
 #include "benchmark/benchmark.h"
 
 BENCHMARK_MAIN();
+
+// MSVC does not allow the definition of dllimport. Thus, define it here instead
+// inline in a macro.
+int main(int argc, char** argv) {
+  ::benchmark::Initialize(&argc, argv);
+  if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1;
+  ::benchmark::RunSpecifiedBenchmarks();
+  ::benchmark::Shutdown();
+  return 0;
+}

--- a/src/check.cc
+++ b/src/check.cc
@@ -1,0 +1,11 @@
+#include "check.h"
+
+namespace benchmark {
+namespace internal {
+
+static AbortHandlerT* handler = &std::abort;
+
+AbortHandlerT*& GetAbortHandler() { return handler; }
+
+}  // namespace internal
+}  // namespace benchmark

--- a/src/check.h
+++ b/src/check.h
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <ostream>
 
+#include "benchmark/export.h"
 #include "internal_macros.h"
 #include "log.h"
 
@@ -13,10 +14,8 @@ namespace internal {
 
 typedef void(AbortHandlerT)();
 
-inline AbortHandlerT*& GetAbortHandler() {
-  static AbortHandlerT* handler = &std::abort;
-  return handler;
-}
+BENCHMARK_EXPORT
+AbortHandlerT*& GetAbortHandler();
 
 BENCHMARK_NORETURN inline void CallAbortHandler() {
   GetAbortHandler()();

--- a/src/commandlineflags.h
+++ b/src/commandlineflags.h
@@ -5,28 +5,33 @@
 #include <map>
 #include <string>
 
+#include "benchmark/export.h"
+
 // Macro for referencing flags.
 #define FLAG(name) FLAGS_##name
 
 // Macros for declaring flags.
-#define BM_DECLARE_bool(name) extern bool FLAG(name)
-#define BM_DECLARE_int32(name) extern int32_t FLAG(name)
-#define BM_DECLARE_double(name) extern double FLAG(name)
-#define BM_DECLARE_string(name) extern std::string FLAG(name)
+#define BM_DECLARE_bool(name) BENCHMARK_EXPORT extern bool FLAG(name)
+#define BM_DECLARE_int32(name) BENCHMARK_EXPORT extern int32_t FLAG(name)
+#define BM_DECLARE_double(name) BENCHMARK_EXPORT extern double FLAG(name)
+#define BM_DECLARE_string(name) BENCHMARK_EXPORT extern std::string FLAG(name)
 #define BM_DECLARE_kvpairs(name) \
-  extern std::map<std::string, std::string> FLAG(name)
+  BENCHMARK_EXPORT extern std::map<std::string, std::string> FLAG(name)
 
 // Macros for defining flags.
 #define BM_DEFINE_bool(name, default_val) \
-  bool FLAG(name) = benchmark::BoolFromEnv(#name, default_val)
+  BENCHMARK_EXPORT bool FLAG(name) = benchmark::BoolFromEnv(#name, default_val)
 #define BM_DEFINE_int32(name, default_val) \
-  int32_t FLAG(name) = benchmark::Int32FromEnv(#name, default_val)
+  BENCHMARK_EXPORT int32_t FLAG(name) =    \
+      benchmark::Int32FromEnv(#name, default_val)
 #define BM_DEFINE_double(name, default_val) \
-  double FLAG(name) = benchmark::DoubleFromEnv(#name, default_val)
+  BENCHMARK_EXPORT double FLAG(name) =      \
+      benchmark::DoubleFromEnv(#name, default_val)
 #define BM_DEFINE_string(name, default_val) \
-  std::string FLAG(name) = benchmark::StringFromEnv(#name, default_val)
-#define BM_DEFINE_kvpairs(name, default_val)      \
-  std::map<std::string, std::string> FLAG(name) = \
+  BENCHMARK_EXPORT std::string FLAG(name) = \
+      benchmark::StringFromEnv(#name, default_val)
+#define BM_DEFINE_kvpairs(name, default_val)                       \
+  BENCHMARK_EXPORT std::map<std::string, std::string> FLAG(name) = \
       benchmark::KvPairsFromEnv(#name, default_val)
 
 namespace benchmark {
@@ -35,6 +40,7 @@ namespace benchmark {
 //
 // If the variable exists, returns IsTruthyFlagValue() value;  if not,
 // returns the given default value.
+BENCHMARK_EXPORT
 bool BoolFromEnv(const char* flag, bool default_val);
 
 // Parses an Int32 from the environment variable corresponding to the given
@@ -42,6 +48,7 @@ bool BoolFromEnv(const char* flag, bool default_val);
 //
 // If the variable exists, returns ParseInt32() value;  if not, returns
 // the given default value.
+BENCHMARK_EXPORT
 int32_t Int32FromEnv(const char* flag, int32_t default_val);
 
 // Parses an Double from the environment variable corresponding to the given
@@ -49,6 +56,7 @@ int32_t Int32FromEnv(const char* flag, int32_t default_val);
 //
 // If the variable exists, returns ParseDouble();  if not, returns
 // the given default value.
+BENCHMARK_EXPORT
 double DoubleFromEnv(const char* flag, double default_val);
 
 // Parses a string from the environment variable corresponding to the given
@@ -56,6 +64,7 @@ double DoubleFromEnv(const char* flag, double default_val);
 //
 // If variable exists, returns its value;  if not, returns
 // the given default value.
+BENCHMARK_EXPORT
 const char* StringFromEnv(const char* flag, const char* default_val);
 
 // Parses a set of kvpairs from the environment variable corresponding to the
@@ -63,6 +72,7 @@ const char* StringFromEnv(const char* flag, const char* default_val);
 //
 // If variable exists, returns its value;  if not, returns
 // the given default value.
+BENCHMARK_EXPORT
 std::map<std::string, std::string> KvPairsFromEnv(
     const char* flag, std::map<std::string, std::string> default_val);
 
@@ -75,40 +85,47 @@ std::map<std::string, std::string> KvPairsFromEnv(
 //
 // On success, stores the value of the flag in *value, and returns
 // true.  On failure, returns false without changing *value.
+BENCHMARK_EXPORT
 bool ParseBoolFlag(const char* str, const char* flag, bool* value);
 
 // Parses a string for an Int32 flag, in the form of "--flag=value".
 //
 // On success, stores the value of the flag in *value, and returns
 // true.  On failure, returns false without changing *value.
+BENCHMARK_EXPORT
 bool ParseInt32Flag(const char* str, const char* flag, int32_t* value);
 
 // Parses a string for a Double flag, in the form of "--flag=value".
 //
 // On success, stores the value of the flag in *value, and returns
 // true.  On failure, returns false without changing *value.
+BENCHMARK_EXPORT
 bool ParseDoubleFlag(const char* str, const char* flag, double* value);
 
 // Parses a string for a string flag, in the form of "--flag=value".
 //
 // On success, stores the value of the flag in *value, and returns
 // true.  On failure, returns false without changing *value.
+BENCHMARK_EXPORT
 bool ParseStringFlag(const char* str, const char* flag, std::string* value);
 
 // Parses a string for a kvpairs flag in the form "--flag=key=value,key=value"
 //
 // On success, stores the value of the flag in *value and returns true. On
 // failure returns false, though *value may have been mutated.
+BENCHMARK_EXPORT
 bool ParseKeyValueFlag(const char* str, const char* flag,
                        std::map<std::string, std::string>* value);
 
 // Returns true if the string matches the flag.
+BENCHMARK_EXPORT
 bool IsFlag(const char* str, const char* flag);
 
 // Returns true unless value starts with one of: '0', 'f', 'F', 'n' or 'N', or
 // some non-alphanumeric character. Also returns false if the value matches
 // one of 'no', 'false', 'off' (case-insensitive). As a special case, also
 // returns true if value is the empty string.
+BENCHMARK_EXPORT
 bool IsTruthyFlagValue(const std::string& value);
 
 }  // end namespace benchmark

--- a/src/perf_counters.h
+++ b/src/perf_counters.h
@@ -29,6 +29,12 @@
 #include <unistd.h>
 #endif
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+// C4251: <symbol> needs to have dll-interface to be used by clients of class
+#pragma warning(disable : 4251)
+#endif
+
 namespace benchmark {
 namespace internal {
 
@@ -68,7 +74,7 @@ class PerfCounterValues {
 // Collect PMU counters. The object, once constructed, is ready to be used by
 // calling read(). PMU counter collection is enabled from the time create() is
 // called, to obtain the object, until the object's destructor is called.
-class PerfCounters final {
+class BENCHMARK_EXPORT PerfCounters final {
  public:
   // True iff this platform supports performance counters.
   static const bool kSupported;
@@ -125,7 +131,7 @@ class PerfCounters final {
 };
 
 // Typical usage of the above primitives.
-class PerfCountersMeasurement final {
+class BENCHMARK_EXPORT PerfCountersMeasurement final {
  public:
   PerfCountersMeasurement(const std::vector<std::string>& counter_names);
   ~PerfCountersMeasurement();
@@ -183,5 +189,9 @@ BENCHMARK_UNUSED static bool perf_init_anchor = PerfCounters::Initialize();
 
 }  // namespace internal
 }  // namespace benchmark
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #endif  // BENCHMARK_PERF_COUNTERS_H

--- a/src/statistics.h
+++ b/src/statistics.h
@@ -25,12 +25,17 @@ namespace benchmark {
 // Return a vector containing the mean, median and standard devation information
 // (and any user-specified info) for the specified list of reports. If 'reports'
 // contains less than two non-errored runs an empty vector is returned
+BENCHMARK_EXPORT
 std::vector<BenchmarkReporter::Run> ComputeStats(
     const std::vector<BenchmarkReporter::Run>& reports);
 
+BENCHMARK_EXPORT
 double StatisticsMean(const std::vector<double>& v);
+BENCHMARK_EXPORT
 double StatisticsMedian(const std::vector<double>& v);
+BENCHMARK_EXPORT
 double StatisticsStdDev(const std::vector<double>& v);
+BENCHMARK_EXPORT
 double StatisticsCV(const std::vector<double>& v);
 
 }  // end namespace benchmark

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 
+#include "benchmark/export.h"
 #include "internal_macros.h"
 
 namespace benchmark {
@@ -13,6 +14,7 @@ void AppendHumanReadable(int n, std::string* str);
 
 std::string HumanReadableNumber(double n, double one_k = 1024.0);
 
+BENCHMARK_EXPORT
 #if defined(__MINGW32__)
 __attribute__((format(__MINGW_PRINTF_FORMAT, 1, 2)))
 #elif defined(__GNUC__)
@@ -38,6 +40,7 @@ inline std::string StrCat(Args&&... args) {
   return ss.str();
 }
 
+BENCHMARK_EXPORT
 std::vector<std::string> StrSplit(const std::string& str, char delim);
 
 // Disable lint checking for this block since it re-implements C functions.

--- a/test/AssemblyTests.cmake
+++ b/test/AssemblyTests.cmake
@@ -23,6 +23,7 @@ string(TOUPPER "${CMAKE_CXX_COMPILER_ID}" ASM_TEST_COMPILER)
 macro(add_filecheck_test name)
   cmake_parse_arguments(ARG "" "" "CHECK_PREFIXES" ${ARGV})
   add_library(${name} OBJECT ${name}.cc)
+  target_link_libraries(${name} PRIVATE benchmark::benchmark)
   set_target_properties(${name} PROPERTIES COMPILE_FLAGS "-S ${ASM_TEST_FLAGS}")
   set(ASM_OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/${name}.s")
   add_custom_target(copy_${name} ALL

--- a/test/BUILD
+++ b/test/BUILD
@@ -50,9 +50,8 @@ cc_library(
             "//:benchmark",
             "//:benchmark_internal_headers",
             "@com_google_googletest//:gtest",
-        ] + (
-            ["@com_google_googletest//:gtest_main"] if (test_src[-len("gtest.cc"):] == "gtest.cc") else []
-        ),
+            "@com_google_googletest//:gtest_main",
+        ]
         # FIXME: Add support for assembly tests to bazel.
         # See Issue #556
         # https://github.com/google/benchmark/issues/556

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Enable the tests
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
 find_package(Threads REQUIRED)
 include(CheckCXXCompilerFlag)
 
@@ -35,10 +37,11 @@ if (DEFINED BENCHMARK_CXX_LINKER_FLAGS)
 endif()
 
 add_library(output_test_helper STATIC output_test_helper.cc output_test.h)
+target_link_libraries(output_test_helper PRIVATE benchmark::benchmark)
 
 macro(compile_benchmark_test name)
   add_executable(${name} "${name}.cc")
-  target_link_libraries(${name} benchmark::benchmark ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(${name} benchmark::benchmark_main ${CMAKE_THREAD_LIBS_INIT})
 endmacro(compile_benchmark_test)
 
 macro(compile_benchmark_test_with_main name)
@@ -48,7 +51,7 @@ endmacro(compile_benchmark_test_with_main)
 
 macro(compile_output_test name)
   add_executable(${name} "${name}.cc" output_test.h)
-  target_link_libraries(${name} output_test_helper benchmark::benchmark
+  target_link_libraries(${name} output_test_helper benchmark::benchmark_main
           ${BENCHMARK_CXX_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 endmacro(compile_output_test)
 
@@ -158,8 +161,8 @@ add_test(NAME user_counters_thousands_test COMMAND user_counters_thousands_test 
 compile_output_test(memory_manager_test)
 add_test(NAME memory_manager_test COMMAND memory_manager_test --benchmark_min_time=0.01)
 
-check_cxx_compiler_flag(-std=c++03 BENCHMARK_HAS_CXX03_FLAG)
-if (BENCHMARK_HAS_CXX03_FLAG)
+# MSVC does not allow to set the language standard to C++98/03.
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   compile_benchmark_test(cxx03_test)
   set_target_properties(cxx03_test
       PROPERTIES
@@ -170,11 +173,17 @@ if (BENCHMARK_HAS_CXX03_FLAG)
   # causing the test to fail to compile. To prevent this we explicitly disable
   # the warning.
   check_cxx_compiler_flag(-Wno-odr BENCHMARK_HAS_WNO_ODR)
-  if (BENCHMARK_ENABLE_LTO AND BENCHMARK_HAS_WNO_ODR)
-    set_target_properties(cxx03_test
-        PROPERTIES
-        LINK_FLAGS "-Wno-odr")
+  check_cxx_compiler_flag(-Wno-lto-type-mismatch BENCHMARK_HAS_WNO_LTO_TYPE_MISMATCH)
+  # Cannot set_target_properties multiple times here because the warnings will
+  # be overwritten on each call
+  set (DISABLE_LTO_WARNINGS "")
+  if (BENCHMARK_HAS_WNO_ODR)
+    set(DISABLE_LTO_WARNINGS "${DISABLE_LTO_WARNINGS} -Wno-odr")
   endif()
+  if (BENCHMARK_HAS_WNO_LTO_TYPE_MISMATCH)
+    set(DISABLE_LTO_WARNINGS "${DISABLE_LTO_WARNINGS} -Wno-lto-type-mismatch")
+  endif()
+  set_target_properties(cxx03_test PROPERTIES LINK_FLAGS "${DISABLE_LTO_WARNINGS}")
   add_test(NAME cxx03 COMMAND cxx03_test --benchmark_min_time=0.01)
 endif()
 

--- a/test/benchmark_gtest.cc
+++ b/test/benchmark_gtest.cc
@@ -8,7 +8,7 @@
 
 namespace benchmark {
 namespace internal {
-extern std::map<std::string, std::string>* global_context;
+BENCHMARK_EXPORT extern std::map<std::string, std::string>* global_context;
 
 namespace {
 

--- a/tools/workspace/generate_export_header.bzl
+++ b/tools/workspace/generate_export_header.bzl
@@ -1,0 +1,148 @@
+#
+# Originl file is located at:
+# https://github.com/RobotLocomotion/drake/blob/bad032aeb09b13c7f8c87ed64b624c8d1e9adb30/tools/workspace/generate_export_header.bzl
+#
+# All components of Drake are licensed under the BSD 3-Clause License
+# shown below. Where noted in the source code, some portions may
+# be subject to other permissive, non-viral licenses.
+#
+# Copyright 2012-2016 Robot Locomotion Group @ CSAIL
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.  Redistributions
+# in binary form must reproduce the above copyright notice, this list of
+# conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.  Neither the name of
+# the Massachusetts Institute of Technology nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# -*- python -*-
+
+def _make_identifier(s):
+    result = ""
+    for i in range(len(s)):
+        result += s[i] if s[i].isalnum() else "_"
+
+    return result
+
+# Defines the implementation actions to generate_export_header.
+def _generate_export_header_impl(ctx):
+    output = ctx.outputs.out
+
+    guard = _make_identifier(output.basename.upper())
+
+    content = [
+        "#ifndef %s" % guard,
+        "#define %s" % guard,
+        "",
+        "#ifdef %s" % ctx.attr.static_define,
+        "#  define %s" % ctx.attr.export_macro_name,
+        "#  define %s" % ctx.attr.no_export_macro_name,
+        "#else",
+        "#  define %s __attribute__((visibility(\"default\")))" % ctx.attr.export_macro_name,  # noqa
+        "#  define %s __attribute__((visibility(\"hidden\")))" % ctx.attr.no_export_macro_name,  # noqa
+        "#endif",
+        "",
+        "#ifndef %s" % ctx.attr.deprecated_macro_name,
+        "#  define %s __attribute__ ((__deprecated__))" % ctx.attr.deprecated_macro_name,  # noqa
+        "#endif",
+        "",
+        "#ifndef %s" % ctx.attr.export_deprecated_macro_name,
+        "#  define %s %s %s" % (ctx.attr.export_deprecated_macro_name, ctx.attr.export_macro_name, ctx.attr.deprecated_macro_name),  # noqa
+        "#endif",
+        "",
+        "#ifndef %s" % ctx.attr.no_export_deprecated_macro_name,
+        "#  define %s %s %s" % (ctx.attr.no_export_deprecated_macro_name, ctx.attr.no_export_macro_name, ctx.attr.deprecated_macro_name),  # noqa
+        "#endif",
+        "",
+        "#endif",
+    ]
+
+    ctx.actions.write(output = output, content = "\n".join(content) + "\n")
+
+# Defines the rule to generate_export_header.
+_generate_export_header_gen = rule(
+    attrs = {
+        "out": attr.output(mandatory = True),
+        "export_macro_name": attr.string(),
+        "deprecated_macro_name": attr.string(),
+        "export_deprecated_macro_name": attr.string(),
+        "no_export_macro_name": attr.string(),
+        "no_export_deprecated_macro_name": attr.string(),
+        "static_define": attr.string(),
+    },
+    output_to_genfiles = True,
+    implementation = _generate_export_header_impl,
+)
+
+def generate_export_header(
+        lib = None,
+        name = None,
+        out = None,
+        export_macro_name = None,
+        deprecated_macro_name = None,
+        export_deprecated_macro_name = None,
+        no_export_macro_name = None,
+        no_export_deprecated_macro_name = None,
+        static_define = None,
+        **kwargs):
+    """Creates a rule to generate an export header for a named library.  This
+    is an incomplete implementation of CMake's generate_export_header. (In
+    particular, it assumes a platform that uses
+    __attribute__((visibility("default"))) to decorate exports.)
+
+    By default, the rule will have a mangled name related to the library name,
+    and will produce "<lib>_export.h".
+
+    The CMake documentation of the generate_export_header macro is:
+    https://cmake.org/cmake/help/latest/module/GenerateExportHeader.html
+
+    """
+
+    if name == None:
+        name = "__%s_export_h" % lib
+    if out == None:
+        out = "%s_export.h" % lib
+    if export_macro_name == None:
+        export_macro_name = "%s_EXPORT" % lib.upper()
+    if deprecated_macro_name == None:
+        deprecated_macro_name = "%s_DEPRECATED" % lib.upper()
+    if export_deprecated_macro_name == None:
+        export_deprecated_macro_name = "%s_DEPRECATED_EXPORT" % lib.upper()
+    if no_export_macro_name == None:
+        no_export_macro_name = "%s_NO_EXPORT" % lib.upper()
+    if no_export_deprecated_macro_name == None:
+        no_export_deprecated_macro_name = \
+            "%s_DEPRECATED_NO_EXPORT" % lib.upper()
+    if static_define == None:
+        static_define = "%s_STATIC_DEFINE" % lib.upper()
+
+    _generate_export_header_gen(
+        name = name,
+        out = out,
+        export_macro_name = export_macro_name,
+        deprecated_macro_name = deprecated_macro_name,
+        export_deprecated_macro_name = export_deprecated_macro_name,
+        no_export_macro_name = no_export_macro_name,
+        no_export_deprecated_macro_name = no_export_deprecated_macro_name,
+        static_define = static_define,
+        **kwargs
+    )


### PR DESCRIPTION
Compiling benchmark as a shared library with `-flto` and `-fvisibility=hidden` causes a huge number of linker errors:

<details>

```console
/usr/bin/ld: /tmp/ccyV4Uyl.ltrans0.ltrans.o: in function `MyFixture_Bar_Benchmark::BenchmarkCase(benchmark::State&)':
<artificial>:(.text+0x415): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x524): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccyV4Uyl.ltrans0.ltrans.o: in function `MyFixture_Foo_Benchmark::BenchmarkCase(benchmark::State&)':
<artificial>:(.text+0x7c5): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x8ba): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccyV4Uyl.ltrans0.ltrans.o: in function `MyFixture_Bar_Benchmark::~MyFixture_Bar_Benchmark()':
<artificial>:(.text+0xa3f): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccyV4Uyl.ltrans0.ltrans.o: in function `MyFixture_Foo_Benchmark::~MyFixture_Foo_Benchmark()':
<artificial>:(.text+0xa7f): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccyV4Uyl.ltrans0.ltrans.o: in function `MyFixture_Bar_Benchmark::~MyFixture_Bar_Benchmark()':
<artificial>:(.text+0x9db): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccyV4Uyl.ltrans0.ltrans.o: in function `MyFixture_Foo_Benchmark::~MyFixture_Foo_Benchmark()':
<artificial>:(.text+0xa0b): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccyV4Uyl.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x83): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x8e): undefined reference to `benchmark::ReportUnrecognizedArguments(int, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0xa0): undefined reference to `benchmark::RunSpecifiedBenchmarks()'
/usr/bin/ld: <artificial>:(.text.startup+0xa5): undefined reference to `benchmark::Shutdown()'
/usr/bin/ld: /tmp/ccyV4Uyl.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__ZN23MyFixture_Foo_Benchmark13BenchmarkCaseERN9benchmark5StateE':
<artificial>:(.text.startup+0x13b): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x153): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1ac): undefined reference to `benchmark::internal::Benchmark::SetName(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1b4): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1cc): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x218): undefined reference to `benchmark::internal::Benchmark::SetName(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x220): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: /tmp/ccyV4Uyl.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__ZN23MyFixture_Foo_Benchmark13BenchmarkCaseERN9benchmark5StateE.cold':
<artificial>:(.text.unlikely+0x1f): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x57): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccyV4Uyl.ltrans0.ltrans.o:(.data.rel.ro+0x110): undefined reference to `typeinfo for benchmark::internal::Benchmark'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/templated_fixture_test.dir/build.make:100: test/templated_fixture_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:654: test/CMakeFiles/templated_fixture_test.dir/all] Error 2
/usr/bin/ld: /tmp/cc9UDLec.ltrans0.ltrans.o: in function `BM_diagnostic_test(benchmark::State&)':
<artificial>:(.text+0x199): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x2fe): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc9UDLec.ltrans0.ltrans.o: in function `BM_diagnostic_test_keep_running(benchmark::State&)':
<artificial>:(.text+0x504): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x4f0): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x54c): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc9UDLec.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x77): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x7c): undefined reference to `benchmark::RunSpecifiedBenchmarks()'
/usr/bin/ld: /tmp/cc9UDLec.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__Z11TestHandlerv':
<artificial>:(.text.startup+0x118): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x152): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x16d): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x1a6): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1c2): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x207): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/diagnostics_test.dir/build.make:99: test/diagnostics_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:391: test/CMakeFiles/diagnostics_test.dir/all] Error 2
[ 78%] Linking CXX executable register_benchmark_test
/usr/bin/ld: /tmp/ccHHDfED.ltrans0.ltrans.o: in function `BM_empty(benchmark::State&)':
<artificial>:(.text+0x199): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x2fe): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccHHDfED.ltrans0.ltrans.o: in function `BM_spin_empty(benchmark::State&)':
<artificial>:(.text+0x5e1): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x76a): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccHHDfED.ltrans0.ltrans.o: in function `BM_spin_pause_before(benchmark::State&)':
<artificial>:(.text+0xb00): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xc8a): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccHHDfED.ltrans0.ltrans.o: in function `BM_spin_pause_after(benchmark::State&)':
<artificial>:(.text+0xfa7): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x112f): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccHHDfED.ltrans0.ltrans.o: in function `BM_spin_pause_before_and_after(benchmark::State&)':
<artificial>:(.text+0x1587): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1719): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccHHDfED.ltrans0.ltrans.o: in function `BM_empty_stop_start(benchmark::State&)':
<artificial>:(.text+0x1b08): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1bcb): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccHHDfED.ltrans0.ltrans.o: in function `BM_KeepRunning(benchmark::State&)':
<artificial>:(.text+0x1d75): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1e04): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccHHDfED.ltrans0.ltrans.o: in function `BM_KeepRunningBatch(benchmark::State&)':
<artificial>:(.text+0x1f98): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x204c): undefined reference to `benchmark::State::StartKeepRunning()'
[ 79%] Linking CXX executable skip_with_error_test
/usr/bin/ld: /tmp/ccHHDfED.ltrans0.ltrans.o: in function `BM_RangedFor(benchmark::State&)':
<artificial>:(.text+0x231d): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x23fa): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccHHDfED.ltrans0.ltrans.o: in function `BM_spin_pause_during(benchmark::State&)':
<artificial>:(.text+0x26e5): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x27b4): undefined reference to `benchmark::State::PauseTiming()'
/usr/bin/ld: <artificial>:(.text+0x2843): undefined reference to `benchmark::State::ResumeTiming()'
/usr/bin/ld: <artificial>:(.text+0x2919): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccHHDfED.ltrans0.ltrans.o: in function `BM_pause_during(benchmark::State&)':
<artificial>:(.text+0x2c56): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x2d04): undefined reference to `benchmark::State::PauseTiming()'
/usr/bin/ld: <artificial>:(.text+0x2d0c): undefined reference to `benchmark::State::ResumeTiming()'
/usr/bin/ld: <artificial>:(.text+0x2d4e): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccHHDfED.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x83): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x8e): undefined reference to `benchmark::ReportUnrecognizedArguments(int, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0xa0): undefined reference to `benchmark::RunSpecifiedBenchmarks()'
/usr/bin/ld: <artificial>:(.text.startup+0xa5): undefined reference to `benchmark::Shutdown()'
/usr/bin/ld: /tmp/ccHHDfED.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__Z8BM_emptyRN9benchmark5StateE':
<artificial>:(.text.startup+0x13e): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x156): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x171): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x1aa): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1c2): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x20f): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x217): undefined reference to `benchmark::internal::Benchmark::ThreadPerCpu()'
/usr/bin/ld: <artificial>:(.text.startup+0x22f): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x27c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x289): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x296): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x2a3): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x2bb): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x308): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x315): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x322): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x32f): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x337): undefined reference to `benchmark::internal::Benchmark::ThreadPerCpu()'
/usr/bin/ld: <artificial>:(.text.startup+0x34f): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x39c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x3a9): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x3b6): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x3c3): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x3db): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x428): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x435): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x442): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x44f): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x457): undefined reference to `benchmark::internal::Benchmark::ThreadPerCpu()'
/usr/bin/ld: <artificial>:(.text.startup+0x46f): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x4bc): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x4c9): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x4d6): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x4e3): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x4fb): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x548): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x555): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x562): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x56f): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x577): undefined reference to `benchmark::internal::Benchmark::ThreadPerCpu()'
/usr/bin/ld: <artificial>:(.text.startup+0x58f): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x5dc): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x5f4): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x63a): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x642): undefined reference to `benchmark::internal::Benchmark::ThreadPerCpu()'
/usr/bin/ld: <artificial>:(.text.startup+0x65a): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x6a0): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x6a8): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x6c0): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x70d): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x715): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x71d): undefined reference to `benchmark::internal::Benchmark::ThreadPerCpu()'
/usr/bin/ld: <artificial>:(.text.startup+0x735): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x782): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x78f): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x79c): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x7a9): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x7c1): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x80e): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x81b): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x828): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x835): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x83d): undefined reference to `benchmark::internal::Benchmark::ThreadPerCpu()'
/usr/bin/ld: <artificial>:(.text.startup+0x855): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x8a2): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x8af): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x8bc): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x8c9): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x8e1): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x92e): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x93b): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x948): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x955): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x95d): undefined reference to `benchmark::internal::Benchmark::ThreadPerCpu()'
/usr/bin/ld: <artificial>:(.text.startup+0x975): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x9c2): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x9da): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa20): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa28): undefined reference to `benchmark::internal::Benchmark::ThreadPerCpu()'
/usr/bin/ld: <artificial>:(.text.startup+0xa44): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa91): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xaad): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xafa): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xb07): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xb23): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xb68): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/basic_test.dir/build.make:99: test/basic_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:338: test/CMakeFiles/basic_test.dir/all] Error 2
/usr/bin/ld: /tmp/ccuT0Rhi.ltrans0.ltrans.o: in function `BM_basic(benchmark::State&)':
<artificial>:(.text+0x198): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x25b): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccuT0Rhi.ltrans0.ltrans.o: in function `BM_explicit_iteration_count(benchmark::State&)':
<artificial>:(.text+0x50e): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x5e5): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccuT0Rhi.ltrans0.ltrans.o: in function `BM_basic_slow(benchmark::State&)':
<artificial>:(.text+0xb35): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1063): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccuT0Rhi.ltrans0.ltrans.o: in function `CustomArgs(benchmark::internal::Benchmark*)':
<artificial>:(.text+0x12fb): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: /tmp/ccuT0Rhi.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x83): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x8e): undefined reference to `benchmark::ReportUnrecognizedArguments(int, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0xa0): undefined reference to `benchmark::RunSpecifiedBenchmarks()'
/usr/bin/ld: <artificial>:(.text.startup+0xa5): undefined reference to `benchmark::Shutdown()'
/usr/bin/ld: /tmp/ccuT0Rhi.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__Z8BM_basicRN9benchmark5StateE':
<artificial>:(.text.startup+0x22e): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x246): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x261): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x29c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2b4): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x30a): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x317): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x32f): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x37e): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x38b): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x395): undefined reference to `benchmark::internal::Benchmark::Unit(benchmark::TimeUnit)'
/usr/bin/ld: <artificial>:(.text.startup+0x3ad): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x3f5): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x402): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x40f): undefined reference to `benchmark::internal::Benchmark::Unit(benchmark::TimeUnit)'
/usr/bin/ld: <artificial>:(.text.startup+0x427): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x46f): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x47c): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x489): undefined reference to `benchmark::internal::Benchmark::Unit(benchmark::TimeUnit)'
/usr/bin/ld: <artificial>:(.text.startup+0x4a1): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x4e9): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x4f6): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x503): undefined reference to `benchmark::internal::Benchmark::Unit(benchmark::TimeUnit)'
/usr/bin/ld: <artificial>:(.text.startup+0x51b): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x56a): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x57c): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0x594): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x5e3): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x5f0): undefined reference to `benchmark::internal::Benchmark::RangeMultiplier(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x602): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0x61a): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x669): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x680): undefined reference to `benchmark::internal::Benchmark::DenseRange(long, long, int)'
/usr/bin/ld: <artificial>:(.text.startup+0x698): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x6ee): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x8b4): undefined reference to `benchmark::internal::Benchmark::Args(std::vector<long, std::allocator<long> > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0x92f): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x98c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa68): undefined reference to `benchmark::internal::Benchmark::Ranges(std::vector<std::pair<long, long>, std::allocator<std::pair<long, long> > > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0xadb): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xb2a): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xb3a): undefined reference to `benchmark::internal::Benchmark::MinTime(double)'
/usr/bin/ld: <artificial>:(.text.startup+0xb52): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xba1): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xba9): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xbc1): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xc10): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xc22): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0xc3a): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xc89): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xc91): undefined reference to `benchmark::internal::Benchmark::ThreadPerCpu()'
/usr/bin/ld: <artificial>:(.text.startup+0xca9): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xcf8): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xd05): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xd1d): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xd6c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xd79): undefined reference to `benchmark::internal::Benchmark::RangeMultiplier(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xd95): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0xdad): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xdfc): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xe12): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0xe2a): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xe79): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xe86): undefined reference to `benchmark::internal::Benchmark::RangeMultiplier(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xe9a): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0xeb2): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xf01): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xf1a): undefined reference to `benchmark::internal::Benchmark::DenseRange(long, long, int)'
/usr/bin/ld: <artificial>:(.text.startup+0xf32): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xf8c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1053): undefined reference to `benchmark::internal::Benchmark::Ranges(std::vector<std::pair<long, long>, std::allocator<std::pair<long, long> > > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0x10c6): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1115): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1124): undefined reference to `benchmark::internal::Benchmark::Apply(void (*)(benchmark::internal::Benchmark*))'
/usr/bin/ld: <artificial>:(.text.startup+0x1140): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x118d): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x119a): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/options_test.dir/build.make:99: test/options_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:312: test/CMakeFiles/options_test.dir/all] Error 2
[ 81%] Linking CXX executable cxx03_test
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::~TestReporter()':
<artificial>:(.text+0x744): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::~TestReporter()':
<artificial>:(.text+0x854): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x911): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o: in function `NoPrefix(benchmark::State&)':
<artificial>:(.text+0xad8): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xb9b): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o: in function `BM_Foo(benchmark::State&)':
<artificial>:(.text+0xe31): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xef4): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o: in function `BM_Bar(benchmark::State&)':
<artificial>:(.text+0x1181): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1244): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o: in function `BM_FooBar(benchmark::State&)':
<artificial>:(.text+0x14d1): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1594): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o: in function `BM_FooBa(benchmark::State&)':
<artificial>:(.text+0x1821): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x18e4): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::ReportContext(benchmark::BenchmarkReporter::Context const&)':
<artificial>:(.text+0x11): undefined reference to `benchmark::ConsoleReporter::ReportContext(benchmark::BenchmarkReporter::Context const&)'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::ReportRuns(std::vector<benchmark::BenchmarkReporter::Run, std::allocator<benchmark::BenchmarkReporter::Run> > const&)':
<artificial>:(.text+0x96): undefined reference to `benchmark::ConsoleReporter::ReportRuns(std::vector<benchmark::BenchmarkReporter::Run, std::allocator<benchmark::BenchmarkReporter::Run> > const&)'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::~TestReporter()':
<artificial>:(.text+0x80b): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o: in function `_GLOBAL__sub_I_main':
<artificial>:(.text.startup+0x36): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x52): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x6d): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xa6): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xc2): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x10f): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x12b): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x178): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x194): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1e1): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1fd): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x242): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x6f4): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x72a): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.startup+0x8d8): undefined reference to `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*)'
/usr/bin/ld: <artificial>:(.text.startup+0x908): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text.startup+0x944): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.startup+0x11a1): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text.startup+0x11d9): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o:(.data.rel.ro+0x10): undefined reference to `typeinfo for benchmark::ConsoleReporter'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o:(.data.rel.ro+0x78): undefined reference to `benchmark::ConsoleReporter::PrintRunData(benchmark::BenchmarkReporter::Run const&)'
/usr/bin/ld: /tmp/cc4QyMcv.ltrans0.ltrans.o:(.data.rel.ro+0x80): undefined reference to `benchmark::ConsoleReporter::PrintHeader(benchmark::BenchmarkReporter::Run const&)'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/filter_test.dir/build.make:99: test/filter_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:286: test/CMakeFiles/filter_test.dir/all] Error 2
[ 82%] Linking CXX executable benchmark_test
/usr/bin/ld: /tmp/ccGl6Qg2.ltrans0.ltrans.o: in function `MyFixture_Bar_Benchmark::~MyFixture_Bar_Benchmark()':
<artificial>:(.text+0x4f2): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccGl6Qg2.ltrans0.ltrans.o: in function `MyFixture_Foo_Benchmark::~MyFixture_Foo_Benchmark()':
<artificial>:(.text+0x612): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccGl6Qg2.ltrans0.ltrans.o: in function `MyFixture_Foo_Benchmark::BenchmarkCase(benchmark::State&)':
<artificial>:(.text+0x842): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x905): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccGl6Qg2.ltrans0.ltrans.o: in function `MyFixture_Bar_Benchmark::BenchmarkCase(benchmark::State&)':
<artificial>:(.text+0x1472): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x15d2): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccGl6Qg2.ltrans0.ltrans.o: in function `MyFixture::~MyFixture()':
<artificial>:(.text+0x3ce): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccGl6Qg2.ltrans0.ltrans.o: in function `MyFixture_Bar_Benchmark::~MyFixture_Bar_Benchmark()':
<artificial>:(.text+0x45e): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccGl6Qg2.ltrans0.ltrans.o: in function `MyFixture_Foo_Benchmark::~MyFixture_Foo_Benchmark()':
<artificial>:(.text+0x57e): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccGl6Qg2.ltrans0.ltrans.o: in function `MyFixture_Bar_Benchmark::MyFixture_Bar_Benchmark()':
<artificial>:(.text.startup+0x5e): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa3): undefined reference to `benchmark::internal::Benchmark::SetName(char const*)'
/usr/bin/ld: /tmp/ccGl6Qg2.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x153): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x15e): undefined reference to `benchmark::ReportUnrecognizedArguments(int, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x170): undefined reference to `benchmark::RunSpecifiedBenchmarks()'
/usr/bin/ld: <artificial>:(.text.startup+0x175): undefined reference to `benchmark::Shutdown()'
/usr/bin/ld: /tmp/ccGl6Qg2.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__ZN23MyFixture_Foo_Benchmark13BenchmarkCaseERN9benchmark5StateE':
<artificial>:(.text.startup+0x204): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x274): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2c8): undefined reference to `benchmark::internal::Benchmark::SetName(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2d0): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2ed): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2fa): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x317): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x324): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x32c): undefined reference to `benchmark::internal::Benchmark::ThreadPerCpu()'
/usr/bin/ld: /tmp/ccGl6Qg2.ltrans0.ltrans.o:(.data.rel.ro+0x90): undefined reference to `typeinfo for benchmark::internal::Benchmark'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/fixture_test.dir/build.make:99: test/fixture_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:469: test/CMakeFiles/fixture_test.dir/all] Error 2
/usr/bin/ld: /tmp/ccRUpKlp.ltrans0.ltrans.o: in function `ArgsProductFixture::~ArgsProductFixture()':
<artificial>:(.text+0x1806): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccRUpKlp.ltrans0.ltrans.o: in function `ArgsProductFixture_Empty_Benchmark::BenchmarkCase(benchmark::State&)':
<artificial>:(.text+0x1fb9): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x219c): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccRUpKlp.ltrans0.ltrans.o: in function `__static_initialization_and_destruction_0(int, int) [clone .constprop.0]':
<artificial>:(.text.startup+0x9b0): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x9ea): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1c03): undefined reference to `benchmark::internal::Benchmark::SetName(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1c0b): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1d03): undefined reference to `benchmark::internal::Benchmark::Args(std::vector<long, std::allocator<long> > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0x22fb): undefined reference to `benchmark::internal::Benchmark::ArgsProduct(std::vector<std::vector<long, std::allocator<long> >, std::allocator<std::vector<long, std::allocator<long> > > > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0x23e3): undefined reference to `benchmark::internal::Benchmark::Args(std::vector<long, std::allocator<long> > const&)'
/usr/bin/ld: /tmp/ccRUpKlp.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x2b43): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x2b4e): undefined reference to `benchmark::ReportUnrecognizedArguments(int, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x2b60): undefined reference to `benchmark::RunSpecifiedBenchmarks()'
/usr/bin/ld: <artificial>:(.text.startup+0x2b65): undefined reference to `benchmark::Shutdown()'
/usr/bin/ld: /tmp/ccRUpKlp.ltrans0.ltrans.o: in function `__static_initialization_and_destruction_0(int, int) [clone .constprop.0] [clone .cold]':
<artificial>:(.text.unlikely+0x43c): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccRUpKlp.ltrans0.ltrans.o:(.data.rel.ro+0x50): undefined reference to `typeinfo for benchmark::internal::Benchmark'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/args_product_test.dir/build.make:99: test/args_product_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:573: test/CMakeFiles/args_product_test.dir/all] Error 2
/usr/bin/ld: /tmp/ccmwBu6D.ltrans0.ltrans.o: in function `MultipleRangesFixture::~MultipleRangesFixture()':
<artificial>:(.text+0x1806): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccmwBu6D.ltrans0.ltrans.o: in function `MultipleRangesFixture_Empty_Benchmark::BenchmarkCase(benchmark::State&)':
<artificial>:(.text+0x1fb9): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x217c): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccmwBu6D.ltrans0.ltrans.o: in function `BM_CheckDefaultArgument(benchmark::State&)':
<artificial>:(.text+0x2512): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x25d5): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccmwBu6D.ltrans0.ltrans.o: in function `BM_MultipleRanges(benchmark::State&)':
<artificial>:(.text+0x28c8): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x298b): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccmwBu6D.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__ZN37MultipleRangesFixture_Empty_Benchmark13BenchmarkCaseERN9benchmark5StateE.cold':
<artificial>:(.text.unlikely+0x582): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccmwBu6D.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x643): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x64e): undefined reference to `benchmark::ReportUnrecognizedArguments(int, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x660): undefined reference to `benchmark::RunSpecifiedBenchmarks()'
/usr/bin/ld: <artificial>:(.text.startup+0x665): undefined reference to `benchmark::Shutdown()'
/usr/bin/ld: /tmp/ccmwBu6D.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__ZN37MultipleRangesFixture_Empty_Benchmark13BenchmarkCaseERN9benchmark5StateE':
<artificial>:(.text.startup+0xaac): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0xae6): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1f41): undefined reference to `benchmark::internal::Benchmark::SetName(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1f57): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1f64): undefined reference to `benchmark::internal::Benchmark::RangeMultiplier(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x2093): undefined reference to `benchmark::internal::Benchmark::Ranges(std::vector<std::pair<long, long>, std::allocator<std::pair<long, long> > > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0x2160): undefined reference to `benchmark::internal::Benchmark::Args(std::vector<long, std::allocator<long> > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0x2251): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x226c): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x22b3): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x238b): undefined reference to `benchmark::internal::Benchmark::Ranges(std::vector<std::pair<long, long>, std::allocator<std::pair<long, long> > > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0x23fe): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2419): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x2460): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2538): undefined reference to `benchmark::internal::Benchmark::Ranges(std::vector<std::pair<long, long>, std::allocator<std::pair<long, long> > > const&)'
/usr/bin/ld: /tmp/ccmwBu6D.ltrans0.ltrans.o:(.data.rel.ro+0x50): undefined reference to `typeinfo for benchmark::internal::Benchmark'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/multiple_ranges_test.dir/build.make:99: test/multiple_ranges_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:547: test/CMakeFiles/multiple_ranges_test.dir/all] Error 2
/usr/bin/ld: /tmp/ccsfMU46.ltrans0.ltrans.o: in function `MapFixture_Lookup_Benchmark::~MapFixture_Lookup_Benchmark()':
<artificial>:(.text+0x1f87): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccsfMU46.ltrans0.ltrans.o: in function `BM_MapLookup(benchmark::State&)':
<artificial>:(.text+0x37de): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x38ce): undefined reference to `benchmark::State::PauseTiming()'
/usr/bin/ld: <artificial>:(.text+0x3b7f): undefined reference to `benchmark::State::ResumeTiming()'
/usr/bin/ld: <artificial>:(.text+0x3e28): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccsfMU46.ltrans0.ltrans.o: in function `MapFixture_Lookup_Benchmark::BenchmarkCase(benchmark::State&)':
<artificial>:(.text+0x4d38): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x50db): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccsfMU46.ltrans0.ltrans.o: in function `MapFixture_Lookup_Benchmark::~MapFixture_Lookup_Benchmark()':
<artificial>:(.text+0x1ea9): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccsfMU46.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__ZN27MapFixture_Lookup_Benchmark13BenchmarkCaseERN9benchmark5StateE.cold':
<artificial>:(.text.unlikely+0x22e): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccsfMU46.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x83): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x8e): undefined reference to `benchmark::ReportUnrecognizedArguments(int, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0xa0): undefined reference to `benchmark::RunSpecifiedBenchmarks()'
/usr/bin/ld: <artificial>:(.text.startup+0xa5): undefined reference to `benchmark::Shutdown()'
/usr/bin/ld: /tmp/ccsfMU46.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__ZN27MapFixture_Lookup_Benchmark13BenchmarkCaseERN9benchmark5StateE':
<artificial>:(.text.startup+0x135): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x151): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x16c): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x1a5): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1b7): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0x227): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x30c): undefined reference to `benchmark::internal::Benchmark::SetName(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x314): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x326): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: /tmp/ccsfMU46.ltrans0.ltrans.o:(.data.rel.ro+0x10): undefined reference to `typeinfo for benchmark::internal::Benchmark'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/map_test.dir/build.make:99: test/map_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:521: test/CMakeFiles/map_test.dir/all] Error 2
[ 83%] Linking CXX executable display_aggregates_only_test
[ 84%] Linking CXX executable internal_threading_test
[ 86%] Linking CXX executable report_aggregates_only_test
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `BM_empty(benchmark::State&)':
<artificial>:(.text+0x387): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x3cf): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `BM_Fixture_BM_template1_Benchmark::BenchmarkCase(benchmark::State&)':
<artificial>:(.text+0x5d7): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x61f): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `void BM_template2<int, long>(benchmark::State&)':
<artificial>:(.text+0x827): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x86f): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `void BM_template1<long>(benchmark::State&)':
<artificial>:(.text+0xa77): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xabf): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `void BM_template1<int>(benchmark::State&)':
<artificial>:(.text+0xcc7): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xd0f): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `BM_old_arg_range_interface(benchmark::State&)':
<artificial>:(.text+0xf1c): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `BM_counters(benchmark::State&)':
<artificial>:(.text+0x1971): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x245d): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `BM_Fixture_BM_template2_Benchmark::~BM_Fixture_BM_template2_Benchmark()':
<artificial>:(.text+0x3785): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `BM_Fixture_BM_template1_Benchmark::~BM_Fixture_BM_template1_Benchmark()':
<artificial>:(.text+0x3805): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `BM_old_arg_range_interface(benchmark::State&)':
<artificial>:(.text+0xf0d): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xf6c): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `BM_Fixture_BM_template2_Benchmark::~BM_Fixture_BM_template2_Benchmark()':
<artificial>:(.text+0x374b): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `BM_Fixture_BM_template1_Benchmark::~BM_Fixture_BM_template1_Benchmark()':
<artificial>:(.text+0x37cb): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__Z8BM_emptyRN9benchmark5StateE.cold':
<artificial>:(.text.unlikely+0x18a): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x216): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0xa43): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0xa4e): undefined reference to `benchmark::ReportUnrecognizedArguments(int, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0xa60): undefined reference to `benchmark::RunSpecifiedBenchmarks()'
/usr/bin/ld: <artificial>:(.text.startup+0xa65): undefined reference to `benchmark::Shutdown()'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__Z8BM_emptyRN9benchmark5StateE':
<artificial>:(.text.startup+0xbc6): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0xbe2): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xbfd): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xc38): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xc54): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xcaa): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xd72): undefined reference to `benchmark::internal::Benchmark::Args(std::vector<long, std::allocator<long> > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0xfc1): undefined reference to `benchmark::internal::Benchmark::Ranges(std::vector<std::pair<long, long>, std::allocator<std::pair<long, long> > > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0x101d): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x106c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1088): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x10d7): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x10f3): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1149): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1161): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x118f): undefined reference to `benchmark::internal::Benchmark::SetName(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1197): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x11af): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x11dd): undefined reference to `benchmark::internal::Benchmark::SetName(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x11e5): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1201): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1250): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: /tmp/ccJIljQw.ltrans0.ltrans.o:(.data.rel.ro+0x110): undefined reference to `typeinfo for benchmark::internal::Benchmark'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/cxx03_test.dir/build.make:99: test/cxx03_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:896: test/CMakeFiles/cxx03_test.dir/all] Error 2
[ 87%] Linking CXX executable perf_counters_test
[ 88%] Linking CXX executable memory_manager_test
[ 89%] Linking CXX executable repetitions_test
[ 91%] Linking CXX executable user_counters_thousands_test
[ 92%] Linking CXX executable user_counters_tabular_test
[ 93%] Linking CXX executable user_counters_test
/usr/bin/ld: /tmp/ccgVRlP3.ltrans0.ltrans.o: in function `BM_SummaryRepeat(benchmark::State&)':
<artificial>:(.text+0x638): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x6fb): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccgVRlP3.ltrans0.ltrans.o: in function `GetFileReporterOutput[abi:cxx11](int, char**)':
<artificial>:(.text+0x1eea): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text+0x1eef): undefined reference to `benchmark::RunSpecifiedBenchmarks()'
/usr/bin/ld: /tmp/ccgVRlP3.ltrans0.ltrans.o: in function `_sub_I_65535_0.0':
<artificial>:(.text.startup+0x9d4): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x9ea): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0xa1c): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa33): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xa68): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa75): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xa82): undefined reference to `benchmark::internal::Benchmark::DisplayAggregatesOnly(bool)'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/display_aggregates_only_test.dir/build.make:100: test/display_aggregates_only_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:789: test/CMakeFiles/display_aggregates_only_test.dir/all] Error 2
/usr/bin/ld: /tmp/cc3EzFwf.ltrans0.ltrans.o: in function `BM_SummaryRepeat(benchmark::State&)':
<artificial>:(.text+0x638): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x6fb): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc3EzFwf.ltrans0.ltrans.o: in function `GetFileReporterOutput[abi:cxx11](int, char**)':
<artificial>:(.text+0x1eea): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text+0x1eef): undefined reference to `benchmark::RunSpecifiedBenchmarks()'
/usr/bin/ld: /tmp/cc3EzFwf.ltrans0.ltrans.o: in function `_sub_I_65535_0.0':
<artificial>:(.text.startup+0x8b4): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x8ca): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x8fc): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x913): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x948): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x955): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x962): undefined reference to `benchmark::internal::Benchmark::ReportAggregatesOnly(bool)'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/report_aggregates_only_test.dir/build.make:100: test/report_aggregates_only_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:762: test/CMakeFiles/report_aggregates_only_test.dir/all] Error 2
[ 94%] Linking CXX executable reporter_output_test
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `BM_CalculatePi(benchmark::State&)':
<artificial>:(.text+0x5a9): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x6f9): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `BM_LongTest(benchmark::State&)':
<artificial>:(.text+0x9c1): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xb69): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `benchmark_uniq_18BM_with_args::{lambda(benchmark::State&)#1}::_FUN(benchmark::State)':
<artificial>:(.text+0xe56): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xf20): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `benchmark_uniq_20BM_non_template_args::{lambda(benchmark::State&)#1}::_FUN(benchmark::State)':
<artificial>:(.text+0x1096): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `BM_DenseThreadRanges(benchmark::State&)':
<artificial>:(.text+0x1254): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `benchmark_uniq_19BM_with_args::{lambda(benchmark::State&)#1}::_FUN(benchmark::State)':
<artificial>:(.text+0x16e4): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x17c5): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `BM_SetInsert(benchmark::State&)':
<artificial>:(.text+0x3e55): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x3f49): undefined reference to `benchmark::State::PauseTiming()'
/usr/bin/ld: <artificial>:(.text+0x4717): undefined reference to `benchmark::State::ResumeTiming()'
/usr/bin/ld: <artificial>:(.text+0x4cab): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `BM_StringCompare(benchmark::State&)':
<artificial>:(.text+0x65d0): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x67d8): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `BM_ParallelMemset(benchmark::State&)':
<artificial>:(.text+0x6cd4): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x6e8a): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `BM_ManualTiming(benchmark::State&)':
<artificial>:(.text+0x76e6): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x7e24): undefined reference to `benchmark::State::SetIterationTime(double)'
/usr/bin/ld: <artificial>:(.text+0x7eac): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `void BM_Sequential<std::__cxx11::list<int, std::allocator<int> >, int>(benchmark::State&)':
<artificial>:(.text+0x8bc6): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x8eeb): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `BM_SetupTeardown(benchmark::State&)':
<artificial>:(.text+0xa7a8): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xaad3): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `void BM_Sequential<std::vector<int, std::allocator<int> >, int>(benchmark::State&)':
<artificial>:(.text+0xb0f6): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xb450): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `BM_Factorial(benchmark::State&)':
<artificial>:(.text+0xc8bc): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xc9b6): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xd38b): undefined reference to `benchmark::State::SetLabel(char const*)'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `BM_CalculatePiRange(benchmark::State&)':
<artificial>:(.text+0xdc9d): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xde4f): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xe824): undefined reference to `benchmark::State::SetLabel(char const*)'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `benchmark_uniq_20BM_non_template_args::{lambda(benchmark::State&)#1}::_FUN(benchmark::State)':
<artificial>:(.text+0x1087): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x10e2): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `BM_DenseThreadRanges(benchmark::State&)':
<artificial>:(.text+0x1245): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x12a4): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x83): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x8e): undefined reference to `benchmark::ReportUnrecognizedArguments(int, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0xa0): undefined reference to `benchmark::RunSpecifiedBenchmarks()'
/usr/bin/ld: <artificial>:(.text.startup+0xa5): undefined reference to `benchmark::Shutdown()'
/usr/bin/ld: /tmp/ccK6lB0G.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__Z20BM_non_template_argsRN9benchmark5StateEid':
<artificial>:(.text.startup+0x1f9): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x22f): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x24a): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x283): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x29b): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2e8): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2f0): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x30c): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x360): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x372): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0x38a): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x3d7): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x3e4): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x3fc): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x449): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x45b): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0x473): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x4c0): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x4c8): undefined reference to `benchmark::internal::Benchmark::ThreadPerCpu()'
/usr/bin/ld: <artificial>:(.text.startup+0x4e4): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x535): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x72d): undefined reference to `benchmark::internal::Benchmark::Ranges(std::vector<std::pair<long, long>, std::allocator<std::pair<long, long> > > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0x7a8): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x7f5): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x807): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0x823): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x870): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x882): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0x89e): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x8e4): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x8f1): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x90d): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x95a): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x96c): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0x988): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x9d5): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x9dd): undefined reference to `benchmark::internal::Benchmark::ThreadPerCpu()'
/usr/bin/ld: <artificial>:(.text.startup+0x9f9): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa46): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa58): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0xa74): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xac8): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xad5): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0xae7): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0xaff): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xb4c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xb5e): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0xb66): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xb7e): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xbd2): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xbe4): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0xbec): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xc16): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xc67): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xca0): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xcf8): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xd2a): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xd82): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xda1): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xdee): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xdfb): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0xe12): undefined reference to `benchmark::internal::Benchmark::DenseThreadRange(int, int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0xe2a): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xe70): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xe7d): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0xe94): undefined reference to `benchmark::internal::Benchmark::DenseThreadRange(int, int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0xeac): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xef2): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xeff): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0xf16): undefined reference to `benchmark::internal::Benchmark::DenseThreadRange(int, int, int)'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/benchmark_test.dir/build.make:99: test/benchmark_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:260: test/CMakeFiles/benchmark_test.dir/all] Error 2
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `BM_function(benchmark::State&)':
<artificial>:(.text+0xbf8): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xcbb): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `benchmark::internal::LambdaBenchmark<CustomFixture>::Run(benchmark::State&)':
<artificial>:(.text+0xf51): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1014): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `BM_extra_args(benchmark::State&, char const*)':
<artificial>:(.text+0x12a1): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1378): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x13a0): undefined reference to `benchmark::State::SetLabel(char const*)'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `benchmark::internal::LambdaBenchmark<TestRegistrationAtRuntime()::{lambda(benchmark::State&)#1}>::Run(benchmark::State&)':
<artificial>:(.text+0x163a): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1711): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x175b): undefined reference to `benchmark::State::SetLabel(char const*)'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::ReportRuns(std::vector<benchmark::BenchmarkReporter::Run, std::allocator<benchmark::BenchmarkReporter::Run> > const&)':
<artificial>:(.text+0x888e): undefined reference to `benchmark::ConsoleReporter::ReportRuns(std::vector<benchmark::BenchmarkReporter::Run, std::allocator<benchmark::BenchmarkReporter::Run> > const&)'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `TestRegistrationAtRuntime()':
<artificial>:(.text+0x14e6d): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text+0x14e9b): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text+0x14fdc): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text+0x15045): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `benchmark::internal::LambdaBenchmark<benchmark::RegisterBenchmark<void (*)(benchmark::State&, char const*), char const* const&>(char const*, void (*&&)(benchmark::State&, char const*), char const* const&)::{lambda(benchmark::State&)#1}>::~LambdaBenchmark()':
<artificial>:(.text+0x152cf): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `benchmark::internal::LambdaBenchmark<TestRegistrationAtRuntime()::{lambda(benchmark::State&)#1}>::~LambdaBenchmark()':
<artificial>:(.text+0x1533f): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `benchmark::internal::LambdaBenchmark<CustomFixture>::~LambdaBenchmark()':
<artificial>:(.text+0x153af): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::~TestReporter()':
<artificial>:(.text+0x15723): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::~TestReporter()':
<artificial>:(.text+0x15be3): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x15cb9): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `(anonymous namespace)::TestCase::CheckRun(benchmark::BenchmarkReporter::Run const&) const':
<artificial>:(.text+0x15fc7): undefined reference to `benchmark::BenchmarkReporter::Run::benchmark_name[abi:cxx11]() const'
/usr/bin/ld: <artificial>:(.text+0x1628c): undefined reference to `benchmark::BenchmarkReporter::Run::benchmark_name[abi:cxx11]() const'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `benchmark::internal::LambdaBenchmark<benchmark::RegisterBenchmark<void (*)(benchmark::State&, char const*), char const* const&>(char const*, void (*&&)(benchmark::State&, char const*), char const* const&)::{lambda(benchmark::State&)#1}>::~LambdaBenchmark()':
<artificial>:(.text+0x1529b): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `benchmark::internal::LambdaBenchmark<TestRegistrationAtRuntime()::{lambda(benchmark::State&)#1}>::~LambdaBenchmark()':
<artificial>:(.text+0x1530b): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `benchmark::internal::LambdaBenchmark<CustomFixture>::~LambdaBenchmark()':
<artificial>:(.text+0x1537b): undefined reference to `benchmark::internal::Benchmark::~Benchmark()'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::~TestReporter()':
<artificial>:(.text+0x15807): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x1b2): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x1c3): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.startup+0x372): undefined reference to `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*)'
/usr/bin/ld: <artificial>:(.text.startup+0x75c): undefined reference to `benchmark::ClearRegisteredBenchmarks()'
/usr/bin/ld: <artificial>:(.text.startup+0x7a2): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.startup+0x974): undefined reference to `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa7c): undefined reference to `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*)'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o: in function `_GLOBAL__sub_I__Z11BM_functionRN9benchmark5StateE':
<artificial>:(.text.startup+0x1375): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x142f): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x144a): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x148a): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x14a2): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x14bd): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x14f6): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x181f): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1880): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o:(.data.rel.ro+0x10): undefined reference to `typeinfo for benchmark::internal::Benchmark'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o:(.data.rel.ro+0x50): undefined reference to `typeinfo for benchmark::ConsoleReporter'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o:(.data.rel.ro+0x90): undefined reference to `typeinfo for benchmark::internal::Benchmark'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o:(.data.rel.ro+0xd0): undefined reference to `typeinfo for benchmark::internal::Benchmark'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o:(.data.rel.ro+0x110): undefined reference to `benchmark::ConsoleReporter::ReportContext(benchmark::BenchmarkReporter::Context const&)'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o:(.data.rel.ro+0x138): undefined reference to `benchmark::ConsoleReporter::PrintRunData(benchmark::BenchmarkReporter::Run const&)'
/usr/bin/ld: /tmp/ccxzL85p.ltrans0.ltrans.o:(.data.rel.ro+0x140): undefined reference to `benchmark::ConsoleReporter::PrintHeader(benchmark::BenchmarkReporter::Run const&)'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/register_benchmark_test.dir/build.make:99: test/register_benchmark_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:495: test/CMakeFiles/register_benchmark_test.dir/all] Error 2
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::~TestReporter()':
<artificial>:(.text+0xad3): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::~TestReporter()':
<artificial>:(.text+0xf93): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x1069): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `BM_error_before_running(benchmark::State&)':
<artificial>:(.text+0x112c): undefined reference to `benchmark::State::SkipWithError(char const*)'
/usr/bin/ld: <artificial>:(.text+0x11b4): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `BM_error_before_running_batch(benchmark::State&)':
<artificial>:(.text+0x122c): undefined reference to `benchmark::State::SkipWithError(char const*)'
/usr/bin/ld: <artificial>:(.text+0x12bc): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `BM_error_before_running_range_for(benchmark::State&)':
<artificial>:(.text+0x1421): undefined reference to `benchmark::State::SkipWithError(char const*)'
/usr/bin/ld: <artificial>:(.text+0x1519): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x160a): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `BM_error_during_running_ranged_for(benchmark::State&)':
<artificial>:(.text+0x1890): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x19ba): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1a2b): undefined reference to `benchmark::State::SkipWithError(char const*)'
/usr/bin/ld: <artificial>:(.text+0x1a77): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `BM_error_after_running(benchmark::State&)':
<artificial>:(.text+0x1d64): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1edf): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1fbb): undefined reference to `benchmark::State::SkipWithError(char const*)'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `BM_error_during_running(benchmark::State&)':
<artificial>:(.text+0x21bb): undefined reference to `benchmark::State::SkipWithError(char const*)'
/usr/bin/ld: <artificial>:(.text+0x21e4): undefined reference to `benchmark::State::PauseTiming()'
/usr/bin/ld: <artificial>:(.text+0x21ec): undefined reference to `benchmark::State::ResumeTiming()'
/usr/bin/ld: <artificial>:(.text+0x2234): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `BM_error_while_paused(benchmark::State&)':
<artificial>:(.text+0x2418): undefined reference to `benchmark::State::PauseTiming()'
/usr/bin/ld: <artificial>:(.text+0x2423): undefined reference to `benchmark::State::SkipWithError(char const*)'
/usr/bin/ld: <artificial>:(.text+0x244c): undefined reference to `benchmark::State::PauseTiming()'
/usr/bin/ld: <artificial>:(.text+0x2454): undefined reference to `benchmark::State::ResumeTiming()'
/usr/bin/ld: <artificial>:(.text+0x249c): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::ReportRuns(std::vector<benchmark::BenchmarkReporter::Run, std::allocator<benchmark::BenchmarkReporter::Run> > const&)':
<artificial>:(.text+0x92ee): undefined reference to `benchmark::ConsoleReporter::ReportRuns(std::vector<benchmark::BenchmarkReporter::Run, std::allocator<benchmark::BenchmarkReporter::Run> > const&)'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::ReportContext(benchmark::BenchmarkReporter::Context const&)':
<artificial>:(.text+0x11): undefined reference to `benchmark::ConsoleReporter::ReportContext(benchmark::BenchmarkReporter::Context const&)'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `(anonymous namespace)::TestReporter::~TestReporter()':
<artificial>:(.text+0xbb7): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `BM_error_no_running(benchmark::State&)':
<artificial>:(.text+0x1118): undefined reference to `benchmark::State::SkipWithError(char const*)'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `BM_error_before_running(benchmark::State&)':
<artificial>:(.text+0x11a3): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `BM_error_before_running_batch(benchmark::State&)':
<artificial>:(.text+0x12a8): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `BM_error_during_running(benchmark::State&)':
<artificial>:(.text+0x2226): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x228f): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `BM_error_while_paused(benchmark::State&)':
<artificial>:(.text+0x248e): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o:<artificial>:(.text+0x24f7): more undefined references to `benchmark::State::FinishKeepRunning()' follow
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `__static_initialization_and_destruction_0(int, int) [clone .constprop.0]':
<artificial>:(.text.startup+0x26a8): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x2762): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x277d): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x27bf): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x28e1): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x28fc): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x2943): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2ab3): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2ace): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x2b15): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2c85): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2ca0): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x2ce7): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2e57): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2e72): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x2eb9): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2ec6): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x2ed3): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x2ee5): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0x3492): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x34ad): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x34ed): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x34fa): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x3507): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x3514): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x3767): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x3782): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x37c9): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x37db): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0x3b08): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x3b23): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x3b63): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x3b70): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x3b7d): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x3b8f): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x449a): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text.startup+0x44a6): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.startup+0x467f): undefined reference to `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*)'
/usr/bin/ld: <artificial>:(.text.startup+0x48fa): undefined reference to `benchmark::BenchmarkReporter::Run::benchmark_name[abi:cxx11]() const'
/usr/bin/ld: <artificial>:(.text.startup+0x4bca): undefined reference to `benchmark::BenchmarkReporter::Run::benchmark_name[abi:cxx11]() const'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o:(.data.rel.ro+0x10): undefined reference to `typeinfo for benchmark::ConsoleReporter'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o:(.data.rel.ro+0x78): undefined reference to `benchmark::ConsoleReporter::PrintRunData(benchmark::BenchmarkReporter::Run const&)'
/usr/bin/ld: /tmp/ccUD2mcQ.ltrans0.ltrans.o:(.data.rel.ro+0x80): undefined reference to `benchmark::ConsoleReporter::PrintHeader(benchmark::BenchmarkReporter::Run const&)'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/skip_with_error_test.dir/build.make:99: test/skip_with_error_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:417: test/CMakeFiles/skip_with_error_test.dir/all] Error 2
/usr/bin/ld: /tmp/ccyKhsIo.ltrans0.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter()':
<artificial>:(.text+0xcd75): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccyKhsIo.ltrans0.ltrans.o: in function `BM_MainThreadAndWorkerThread(benchmark::State&)':
<artificial>:(.text+0xe419): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xe601): undefined reference to `benchmark::State::SetIterationTime(double)'
/usr/bin/ld: <artificial>:(.text+0xe6a0): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccyKhsIo.ltrans0.ltrans.o: in function `BM_MainThread(benchmark::State&)':
<artificial>:(.text+0xf160): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xf235): undefined reference to `benchmark::State::SetIterationTime(double)'
/usr/bin/ld: <artificial>:(.text+0xf28a): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccyKhsIo.ltrans0.ltrans.o: in function `BM_WorkerThread(benchmark::State&)':
<artificial>:(.text+0xfd19): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0xfefc): undefined reference to `benchmark::State::SetIterationTime(double)'
/usr/bin/ld: <artificial>:(.text+0xff9b): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccyKhsIo.ltrans0.ltrans.o: in function `RunOutputTests(int, char**)':
<artificial>:(.text+0x20672): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text+0x2067c): undefined reference to `benchmark::internal::GetOutputOptions(bool)'
/usr/bin/ld: <artificial>:(.text+0x20686): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x206a1): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x20804): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x2081f): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0x2086b): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x20886): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0x20be2): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x20e9e): undefined reference to `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*)'
/usr/bin/ld: <artificial>:(.text+0x242a2): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0x242df): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x242ff): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0x24317): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x24337): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x24374): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccyKhsIo.ltrans0.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter()':
<artificial>:(.text+0xcd16): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccyKhsIo.ltrans0.ltrans.o: in function `RunOutputTests(int, char**) [clone .cold]':
<artificial>:(.text.unlikely+0x135d): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x139a): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x13ba): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x13d5): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x13f7): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x142f): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x14d5): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccyKhsIo.ltrans0.ltrans.o: in function `_sub_I_65535_0.0':
<artificial>:(.text.startup+0x59): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x6f): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0xa4): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xbf): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xf8): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x105): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x112): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x12a): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x170): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x17d): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x18a): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x192): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x1aa): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1f0): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1fd): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x20a): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x212): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x22a): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x270): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x27d): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x28a): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x292): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x2aa): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2f0): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2fd): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x30a): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x312): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x31a): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x332): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x378): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x385): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x392): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x39a): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x3a2): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x3ba): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x400): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x40d): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x41a): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x432): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x478): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x485): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x492): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x49a): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x4b2): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x4f8): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x505): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x512): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x51a): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x532): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x578): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x585): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x592): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x59a): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x5b2): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x5f8): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x605): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x612): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x61a): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x622): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x63a): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x687): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x694): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x6a1): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x6a9): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x6b1): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x6c9): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x716): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x723): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x730): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x748): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x78e): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x79b): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x7a8): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x7b0): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x7c8): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x80e): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x81b): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x828): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x830): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x848): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x88e): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x89b): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x8a8): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x8b0): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x8c8): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x90e): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x91b): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x928): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x930): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x938): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x950): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x996): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x9a3): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x9b0): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x9b8): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x9c0): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x9d8): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa1e): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa2b): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0xa38): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xa50): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa96): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xaa3): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0xab0): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xab8): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xad0): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xb16): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xb23): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0xb30): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xb38): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xb50): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xb96): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xba3): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0xbb0): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xbb8): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xbd0): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xc16): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xc23): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0xc30): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xc38): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xc40): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xc58): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xca5): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xcb2): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0xcbf): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xcc7): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xccf): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xce7): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xd34): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xd41): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0xd4e): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xd66): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xdac): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xdb9): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0xdc6): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xdce): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xde6): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xe2c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xe39): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0xe46): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xe4e): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xe66): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xeac): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xeb9): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0xec6): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xece): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xee6): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xf2c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xf39): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0xf46): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xf4e): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xf56): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xf6e): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xfb4): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xfc1): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0xfce): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xfd6): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xfde): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0xff6): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x103c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1049): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x1056): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x106e): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x10b4): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x10c1): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x10ce): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x10d6): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x10ee): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1134): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1141): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x114e): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x1156): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x116e): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x11b4): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x11c1): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x11ce): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x11d6): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x11ee): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1234): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1241): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x124e): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x1256): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x125e): undefined reference to `benchmark::internal::Benchmark::UseRealTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x1276): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x12b4): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x12c1): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x12ce): undefined reference to `benchmark::internal::Benchmark::Threads(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x12d6): undefined reference to `benchmark::internal::Benchmark::MeasureProcessCPUTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x12de): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: /tmp/ccyKhsIo.ltrans0.ltrans.o:(.data.rel.ro+0x10): undefined reference to `typeinfo for benchmark::BenchmarkReporter'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/internal_threading_test.dir/build.make:100: test/internal_threading_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:735: test/CMakeFiles/internal_threading_test.dir/all] Error 2
/usr/bin/ld: /tmp/cckTWz3B.ltrans0.ltrans.o: in function `BM_Counters_Thousands(benchmark::State&)':
<artificial>:(.text+0x392a): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x3a14): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cckTWz3B.ltrans0.ltrans.o: in function `RunOutputTests(int, char**)':
<artificial>:(.text+0x1277c): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text+0x12786): undefined reference to `benchmark::internal::GetOutputOptions(bool)'
/usr/bin/ld: <artificial>:(.text+0x12790): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x127ab): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x1290e): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x12929): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0x12975): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x12990): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0x12cec): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x12fa2): undefined reference to `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*)'
/usr/bin/ld: <artificial>:(.text+0x18071): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0x180ae): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x180ce): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0x180e6): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x18106): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x18143): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cckTWz3B.ltrans0.ltrans.o: in function `RunOutputTests(int, char**) [clone .cold]':
<artificial>:(.text.unlikely+0x26d0): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x270d): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x272d): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2748): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x276a): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x27a2): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2e73): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cckTWz3B.ltrans0.ltrans.o:(.data.rel.ro+0x10): undefined reference to `typeinfo for benchmark::BenchmarkReporter'
/usr/bin/ld: /tmp/cckTWz3B.ltrans2.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0x4165): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cckTWz3B.ltrans2.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0x112e6): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cckTWz3B.ltrans2.ltrans.o: in function `__static_initialization_and_destruction_0(int, int) [clone .constprop.1]':
<artificial>:(.text.startup+0x1303): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x133d): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1358): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x139f): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x13ac): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: /tmp/cckTWz3B.ltrans2.ltrans.o: in function `_sub_I_65535_0.0':
<artificial>:(.text.startup+0x8003): undefined reference to `benchmark::internal::InitializeStreams()'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/user_counters_thousands_test.dir/build.make:100: test/user_counters_thousands_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:843: test/CMakeFiles/user_counters_thousands_test.dir/all] Error 2
/usr/bin/ld: /tmp/ccMYkB0J.ltrans0.ltrans.o: in function `BM_Simple(benchmark::State&) [clone .lto_priv.0]':
<artificial>:(.text+0x2ea9): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x300e): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccMYkB0J.ltrans0.ltrans.o: in function `RunOutputTests(int, char**)':
<artificial>:(.text+0xed72): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text+0xed7c): undefined reference to `benchmark::internal::GetOutputOptions(bool)'
/usr/bin/ld: <artificial>:(.text+0xed86): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0xeda1): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0xef04): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0xef1f): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0xef6b): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0xef86): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0xf2e2): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0xf598): undefined reference to `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*)'
/usr/bin/ld: <artificial>:(.text+0x13f31): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0x13f6e): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x13f8e): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0x13fa6): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x13fc6): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x14003): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccMYkB0J.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x5bf7): undefined reference to `benchmark::internal::PerfCounters::kSupported'
/usr/bin/ld: /tmp/ccMYkB0J.ltrans0.ltrans.o: in function `RunOutputTests(int, char**) [clone .cold]':
<artificial>:(.text.unlikely+0x25c0): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x25fd): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x261d): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2638): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x265a): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2692): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2d08): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccMYkB0J.ltrans0.ltrans.o:(.data.rel.ro+0x10): undefined reference to `typeinfo for benchmark::BenchmarkReporter'
/usr/bin/ld: /tmp/ccMYkB0J.ltrans2.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0x2925): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccMYkB0J.ltrans2.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0xdfd6): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccMYkB0J.ltrans2.ltrans.o: in function `_sub_I_65535_0.0':
<artificial>:(.text.startup+0x496): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x4ac): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x4c7): undefined reference to `benchmark::internal::PerfCounters::Initialize()'
/usr/bin/ld: <artificial>:(.text.startup+0x4e3): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x4fe): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x53e): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/perf_counters_test.dir/build.make:100: test/perf_counters_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:708: test/CMakeFiles/perf_counters_test.dir/all] Error 2
/usr/bin/ld: /tmp/cc32gjUB.ltrans0.ltrans.o: in function `BM_ImplicitRepetitions(benchmark::State&) [clone .lto_priv.0]':
<artificial>:(.text+0x2c38): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x2cfb): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc32gjUB.ltrans0.ltrans.o: in function `BM_ExplicitRepetitions(benchmark::State&) [clone .lto_priv.0]':
<artificial>:(.text+0x2f91): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x3054): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc32gjUB.ltrans0.ltrans.o: in function `RunOutputTests(int, char**)':
<artificial>:(.text+0xff5c): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text+0xff66): undefined reference to `benchmark::internal::GetOutputOptions(bool)'
/usr/bin/ld: <artificial>:(.text+0xff70): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0xff8b): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x100ee): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x10109): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0x10155): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x10170): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0x104cc): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x10780): undefined reference to `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*)'
/usr/bin/ld: <artificial>:(.text+0x156ba): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0x156f7): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x15717): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0x1572f): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x1574f): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x1578c): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cc32gjUB.ltrans0.ltrans.o: in function `RunOutputTests(int, char**) [clone .cold]':
<artificial>:(.text.unlikely+0x2436): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2473): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2493): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x24ae): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x24d0): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2508): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2a22): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cc32gjUB.ltrans0.ltrans.o:(.data.rel.ro+0x10): undefined reference to `typeinfo for benchmark::BenchmarkReporter'
/usr/bin/ld: /tmp/cc32gjUB.ltrans2.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0x17e5): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cc32gjUB.ltrans2.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0xa246): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cc32gjUB.ltrans2.ltrans.o: in function `__static_initialization_and_destruction_0(int, int) [clone .constprop.1]':
<artificial>:(.text.startup+0x1105): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x113f): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x115a): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x11aa): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x11b7): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x4b7a): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x4b95): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x4bec): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: /tmp/cc32gjUB.ltrans3.ltrans.o: in function `_sub_I_65535_0.0':
<artificial>:(.text.startup+0x233): undefined reference to `benchmark::internal::InitializeStreams()'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/repetitions_test.dir/build.make:100: test/repetitions_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:365: test/CMakeFiles/repetitions_test.dir/all] Error 2
/usr/bin/ld: /tmp/cc3Z901k.ltrans0.ltrans.o: in function `BM_Counters_Tabular(benchmark::State&)':
<artificial>:(.text+0x1b8a): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1c75): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc3Z901k.ltrans0.ltrans.o: in function `BM_CounterRates_Tabular(benchmark::State&)':
<artificial>:(.text+0x2c08): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x2da0): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc3Z901k.ltrans0.ltrans.o: in function `BM_CounterSet0_Tabular(benchmark::State&)':
<artificial>:(.text+0x3d24): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x3e0f): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc3Z901k.ltrans0.ltrans.o: in function `BM_CounterSet1_Tabular(benchmark::State&)':
<artificial>:(.text+0x47a4): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x488f): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc3Z901k.ltrans0.ltrans.o: in function `BM_CounterSet2_Tabular(benchmark::State&)':
<artificial>:(.text+0x5224): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x530f): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/cc3Z901k.ltrans1.ltrans.o: in function `RunOutputTests(int, char**)':
<artificial>:(.text+0xf5c6): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text+0xf5d0): undefined reference to `benchmark::internal::GetOutputOptions(bool)'
/usr/bin/ld: <artificial>:(.text+0xf5da): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0xf5f5): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0xf758): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0xf773): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0xf7bf): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0xf7da): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0xfb36): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0xfdea): undefined reference to `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*)'
/usr/bin/ld: <artificial>:(.text+0x15552): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0x1558f): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x155af): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0x155c7): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x155e7): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x15624): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cc3Z901k.ltrans1.ltrans.o: in function `RunOutputTests(int, char**) [clone .cold]':
<artificial>:(.text.unlikely+0x232f): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x236c): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x238c): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x23a7): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x23c9): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2401): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2685): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cc3Z901k.ltrans1.ltrans.o:(.data.rel.ro+0x10): undefined reference to `typeinfo for benchmark::BenchmarkReporter'
/usr/bin/ld: /tmp/cc3Z901k.ltrans3.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0x1555): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cc3Z901k.ltrans3.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0xca36): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/cc3Z901k.ltrans4.ltrans.o: in function `__static_initialization_and_destruction_0(int, int) [clone .constprop.1]':
<artificial>:(.text.startup+0x269b): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x3dda): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x3df5): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x3e37): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x3e49): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0x3e56): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0xe58a): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xe5a5): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xe5e7): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xe5f9): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0xf551): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xf56c): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xf5ae): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xf5c0): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0x102eb): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x10306): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x10348): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1035a): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0x11083): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1109e): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x110e0): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x110f2): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: /tmp/cc3Z901k.ltrans5.ltrans.o: in function `_sub_I_65535_0.0':
<artificial>:(.text.startup+0x503): undefined reference to `benchmark::internal::InitializeStreams()'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/user_counters_tabular_test.dir/build.make:100: test/user_counters_tabular_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:816: test/CMakeFiles/user_counters_tabular_test.dir/all] Error 2
/usr/bin/ld: /tmp/ccidNFO1.ltrans0.ltrans.o: in function `BM_Counters_Simple(benchmark::State&)':
<artificial>:(.text+0x24e): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x334): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans0.ltrans.o: in function `BM_Counters_Rate(benchmark::State&)':
<artificial>:(.text+0xfcf): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x115f): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans0.ltrans.o: in function `BM_Invert(benchmark::State&)':
<artificial>:(.text+0x1d7e): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x1f0f): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans0.ltrans.o: in function `BM_Counters_InvertedRate(benchmark::State&)':
<artificial>:(.text+0x2aff): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x2c8f): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans0.ltrans.o: in function `BM_Counters_Threads(benchmark::State&)':
<artificial>:(.text+0x389f): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x3986): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans0.ltrans.o: in function `BM_Counters_AvgThreads(benchmark::State&)':
<artificial>:(.text+0x455e): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x4644): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans0.ltrans.o: in function `BM_Counters_AvgThreadsRate(benchmark::State&)':
<artificial>:(.text+0x51fe): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x538f): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans0.ltrans.o: in function `BM_Counters_IterationInvariant(benchmark::State&)':
<artificial>:(.text+0x5f7f): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x6066): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans0.ltrans.o: in function `BM_Counters_kIsIterationInvariantRate(benchmark::State&)':
<artificial>:(.text+0x6c3e): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x6dcf): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans0.ltrans.o: in function `BM_Counters_WithBytesAndItemsPSec(benchmark::State&)':
<artificial>:(.text+0x79b4): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x7b41): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans1.ltrans.o: in function `BM_Counters_AvgIterations(benchmark::State&)':
<artificial>:(.text+0x439e): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x4484): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans1.ltrans.o: in function `BM_Counters_kAvgIterationsRate(benchmark::State&)':
<artificial>:(.text+0x502f): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x51bf): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans1.ltrans.o: in function `RunOutputTests(int, char**)':
<artificial>:(.text+0x12882): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text+0x1288c): undefined reference to `benchmark::internal::GetOutputOptions(bool)'
/usr/bin/ld: <artificial>:(.text+0x12896): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x128b1): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x12a14): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x12a2f): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0x12a7b): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x12a96): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0x12df2): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x130a8): undefined reference to `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*)'
/usr/bin/ld: <artificial>:(.text+0x18331): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0x1836e): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x1838e): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0x183a6): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x183c6): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x18403): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans1.ltrans.o: in function `RunOutputTests(int, char**) [clone .cold]':
<artificial>:(.text.unlikely+0x2660): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x269d): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x26bd): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x26d8): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x26fa): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2732): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x296d): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans1.ltrans.o:(.data.rel.ro+0x10): undefined reference to `typeinfo for benchmark::BenchmarkReporter'
/usr/bin/ld: /tmp/ccidNFO1.ltrans3.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0x1ba5): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans3.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0xd8a6): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans4.ltrans.o: in function `_sub_I_65535_0.0':
<artificial>:(.text.startup+0x503): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: /tmp/ccidNFO1.ltrans4.ltrans.o: in function `__static_initialization_and_destruction_0(int, int) [clone .constprop.1]':
<artificial>:(.text.startup+0x16d1): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x19c2): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x19dd): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x1a2b): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x278b): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x27a6): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x27f4): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x36c4): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x36df): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x372d): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x4493): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x44ae): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x44fc): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x5263): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x527e): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x52cc): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x6033): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x604e): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x609c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x60ae): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0x6e13): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x6e2e): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x6e7c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x6e8e): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0x7bf3): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x7c0e): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x7c5c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x7c6e): undefined reference to `benchmark::internal::Benchmark::ThreadRange(int, int)'
/usr/bin/ld: <artificial>:(.text.startup+0x89d3): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x89ee): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x8a3c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x97a3): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x97be): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x980c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa573): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa58e): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xa5dc): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xb343): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xb35e): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xb3ac): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/user_counters_test.dir/build.make:100: test/user_counters_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:681: test/CMakeFiles/user_counters_test.dir/all] Error 2
/usr/bin/ld: /tmp/ccCXvWWy.ltrans0.ltrans.o: in function `BM_empty(benchmark::State&)':
<artificial>:(.text+0x2fb9): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x311e): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccCXvWWy.ltrans0.ltrans.o: in function `RunOutputTests(int, char**)':
<artificial>:(.text+0xf4d2): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text+0xf4dc): undefined reference to `benchmark::internal::GetOutputOptions(bool)'
/usr/bin/ld: <artificial>:(.text+0xf4e6): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0xf501): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0xf664): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0xf67f): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0xf6cb): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0xf6e6): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0xfa42): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0xfcf6): undefined reference to `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*)'
/usr/bin/ld: <artificial>:(.text+0x1470a): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0x14747): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x14767): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0x1477f): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x1479f): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x147dc): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccCXvWWy.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0x9d80): undefined reference to `benchmark::RegisterMemoryManager(benchmark::MemoryManager*)'
/usr/bin/ld: <artificial>:(.text.startup+0x9d92): undefined reference to `benchmark::RegisterMemoryManager(benchmark::MemoryManager*)'
/usr/bin/ld: /tmp/ccCXvWWy.ltrans0.ltrans.o: in function `RunOutputTests(int, char**) [clone .cold]':
<artificial>:(.text.unlikely+0x24bd): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x24fa): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x251a): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2535): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2557): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x258f): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x2b0c): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccCXvWWy.ltrans0.ltrans.o:(.data.rel.ro+0x10): undefined reference to `typeinfo for benchmark::BenchmarkReporter'
/usr/bin/ld: /tmp/ccCXvWWy.ltrans1.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0x40b5): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccCXvWWy.ltrans1.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0xfc46): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccCXvWWy.ltrans1.ltrans.o: in function `__static_initialization_and_destruction_0(int, int) [clone .constprop.1]':
<artificial>:(.text.startup+0x2f2): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x32c): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x347): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x390): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: /tmp/ccCXvWWy.ltrans2.ltrans.o: in function `_sub_I_65535_0.0':
<artificial>:(.text.startup+0x233): undefined reference to `benchmark::internal::InitializeStreams()'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/memory_manager_test.dir/build.make:100: test/memory_manager_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:870: test/CMakeFiles/memory_manager_test.dir/all] Error 2
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_basic(benchmark::State&)':
<artificial>:(.text+0x38c8): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x398b): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_time_label_nanosecond(benchmark::State&)':
<artificial>:(.text+0x3c21): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x3ce4): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_time_label_microsecond(benchmark::State&)':
<artificial>:(.text+0x3f71): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x4034): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_time_label_millisecond(benchmark::State&)':
<artificial>:(.text+0x42c1): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x4384): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_time_label_second(benchmark::State&)':
<artificial>:(.text+0x4611): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x46d4): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_no_arg_name(benchmark::State&)':
<artificial>:(.text+0x4961): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x4a24): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_arg_name(benchmark::State&)':
<artificial>:(.text+0x4cb1): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x4d74): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_arg_names(benchmark::State&)':
<artificial>:(.text+0x5001): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x50c4): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_name(benchmark::State&)':
<artificial>:(.text+0x5351): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x5414): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_BigArgs(benchmark::State&)':
<artificial>:(.text+0x56a1): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x5764): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_Complexity_O1(benchmark::State&)':
<artificial>:(.text+0x59e4): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x5b5f): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_Repeat(benchmark::State&)':
<artificial>:(.text+0x5f11): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x5fd4): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_RepeatOnce(benchmark::State&)':
<artificial>:(.text+0x6261): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x6324): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_SummaryRepeat(benchmark::State&)':
<artificial>:(.text+0x65b1): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x6674): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_SummaryDisplay(benchmark::State&)':
<artificial>:(.text+0x6901): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x69c4): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_RepeatTimeUnit(benchmark::State&)':
<artificial>:(.text+0x6c51): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x6d14): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_bytes_per_second(benchmark::State&)':
<artificial>:(.text+0x7049): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x71d7): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_items_per_second(benchmark::State&)':
<artificial>:(.text+0x7d19): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x7ea7): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_label(benchmark::State&)':
<artificial>:(.text+0x893d): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x8a13): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x8a3c): undefined reference to `benchmark::State::SetLabel(char const*)'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_error(benchmark::State&)':
<artificial>:(.text+0x8be2): undefined reference to `benchmark::State::SkipWithError(char const*)'
/usr/bin/ld: <artificial>:(.text+0x8cd7): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x8d9a): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_CSV_Format(benchmark::State&)':
<artificial>:(.text+0x8f42): undefined reference to `benchmark::State::SkipWithError(char const*)'
/usr/bin/ld: <artificial>:(.text+0x9037): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x90fa): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_UserStats(benchmark::State&)':
<artificial>:(.text+0x938c): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x9448): undefined reference to `benchmark::State::SetIterationTime(double)'
/usr/bin/ld: <artificial>:(.text+0x948a): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `BM_UserPercentStats(benchmark::State&)':
<artificial>:(.text+0x9755): undefined reference to `benchmark::State::StartKeepRunning()'
/usr/bin/ld: <artificial>:(.text+0x9810): undefined reference to `benchmark::State::SetIterationTime(double)'
/usr/bin/ld: <artificial>:(.text+0x985b): undefined reference to `benchmark::State::FinishKeepRunning()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `RunOutputTests(int, char**)':
<artificial>:(.text+0x14700): undefined reference to `benchmark::Initialize(int*, char**)'
/usr/bin/ld: <artificial>:(.text+0x1470a): undefined reference to `benchmark::internal::GetOutputOptions(bool)'
/usr/bin/ld: <artificial>:(.text+0x14714): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x1472f): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x14892): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x148ad): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0x148f9): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x14914): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0x14c70): undefined reference to `benchmark::BenchmarkReporter::BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x14f24): undefined reference to `benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*)'
/usr/bin/ld: <artificial>:(.text+0x199fa): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text+0x19a37): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x19a57): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text+0x19a6f): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text+0x19a8f): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text+0x19acc): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o: in function `RunOutputTests(int, char**) [clone .cold]':
<artificial>:(.text.unlikely+0x31f1): undefined reference to `vtable for benchmark::CSVReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x322e): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x324e): undefined reference to `vtable for benchmark::JSONReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x3269): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x328b): undefined reference to `vtable for benchmark::ConsoleReporter'
/usr/bin/ld: <artificial>:(.text.unlikely+0x32c3): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: <artificial>:(.text.unlikely+0x3705): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans0.ltrans.o:(.data.rel.ro+0x10): undefined reference to `typeinfo for benchmark::BenchmarkReporter'
/usr/bin/ld: /tmp/ccViH2hI.ltrans2.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0x1555): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans2.ltrans.o: in function `internal::(anonymous namespace)::TestReporter::~TestReporter() [clone .lto_priv.0]':
<artificial>:(.text+0xcac6): undefined reference to `benchmark::BenchmarkReporter::~BenchmarkReporter()'
/usr/bin/ld: /tmp/ccViH2hI.ltrans3.ltrans.o: in function `__static_initialization_and_destruction_0(int, int) [clone .constprop.1]':
<artificial>:(.text.startup+0x7c43): undefined reference to `benchmark::internal::InitializeStreams()'
/usr/bin/ld: <artificial>:(.text.startup+0x888d): undefined reference to `benchmark::CPUInfo::Get()'
/usr/bin/ld: <artificial>:(.text.startup+0xa1a1): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xa1bc): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xa1f5): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xae13): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xae2e): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xae67): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xbb50): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xbb6b): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xbba7): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xc890): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xc8ab): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xc8e4): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xd5d0): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xd5eb): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xd624): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xd62e): undefined reference to `benchmark::internal::Benchmark::Unit(benchmark::TimeUnit)'
/usr/bin/ld: <artificial>:(.text.startup+0xe24b): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xe266): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xe29f): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xe2ac): undefined reference to `benchmark::internal::Benchmark::Unit(benchmark::TimeUnit)'
/usr/bin/ld: <artificial>:(.text.startup+0xeec5): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xeee0): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xef1c): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xef29): undefined reference to `benchmark::internal::Benchmark::Unit(benchmark::TimeUnit)'
/usr/bin/ld: <artificial>:(.text.startup+0xfb45): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0xfb60): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0xfb99): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0xfba6): undefined reference to `benchmark::internal::Benchmark::Unit(benchmark::TimeUnit)'
/usr/bin/ld: <artificial>:(.text.startup+0x107c5): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x107e0): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x10819): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x111e2): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x111fd): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x11236): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x11243): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x11a89): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x11aa4): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x11add): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x11b31): undefined reference to `benchmark::internal::Benchmark::ArgName(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0x11b3e): undefined reference to `benchmark::internal::Benchmark::Arg(long)'
/usr/bin/ld: <artificial>:(.text.startup+0x123d9): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x123f4): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x1242d): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x12636): undefined reference to `benchmark::internal::Benchmark::Args(std::vector<long, std::allocator<long> > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0x12944): undefined reference to `benchmark::internal::Benchmark::ArgNames(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0x132bf): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x132da): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x13313): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x13367): undefined reference to `benchmark::internal::Benchmark::Name(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: <artificial>:(.text.startup+0x13fd7): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x13ff2): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x1402d): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1403a): undefined reference to `benchmark::internal::Benchmark::RangeMultiplier(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x1404c): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0x14268): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x14283): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x142bc): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x142ce): undefined reference to `benchmark::internal::Benchmark::Range(long, long)'
/usr/bin/ld: <artificial>:(.text.startup+0x142db): undefined reference to `benchmark::internal::Benchmark::Complexity(benchmark::BigO)'
/usr/bin/ld: <artificial>:(.text.startup+0x14e7e): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x14e99): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x14ed9): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x14ee6): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x17bde): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x17bf9): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x17c39): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x17c46): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x1b10e): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1b129): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x1b169): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1b176): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x1ede4): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1edff): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x1ee38): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1ee45): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x1ee52): undefined reference to `benchmark::internal::Benchmark::ReportAggregatesOnly(bool)'
/usr/bin/ld: <artificial>:(.text.startup+0x1f69f): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1f6ba): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x1f6f3): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x1f700): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x1f70d): undefined reference to `benchmark::internal::Benchmark::ReportAggregatesOnly(bool)'
/usr/bin/ld: <artificial>:(.text.startup+0x21699): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x216b4): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x216ed): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x216fa): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x21707): undefined reference to `benchmark::internal::Benchmark::DisplayAggregatesOnly(bool)'
/usr/bin/ld: <artificial>:(.text.startup+0x23691): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x236ac): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x236e5): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x236f2): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x236ff): undefined reference to `benchmark::internal::Benchmark::ReportAggregatesOnly(bool)'
/usr/bin/ld: <artificial>:(.text.startup+0x2370c): undefined reference to `benchmark::internal::Benchmark::Unit(benchmark::TimeUnit)'
/usr/bin/ld: <artificial>:(.text.startup+0x258fb): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x25916): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x2594f): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2595c): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x25969): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x25971): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x259ce): undefined reference to `benchmark::internal::Benchmark::ComputeStatistics(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double (*)(std::vector<double, std::allocator<double> > const&), benchmark::StatisticUnit)'
/usr/bin/ld: <artificial>:(.text.startup+0x2a06c): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2a087): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x2a0c0): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2a0cd): undefined reference to `benchmark::internal::Benchmark::Repetitions(int)'
/usr/bin/ld: <artificial>:(.text.startup+0x2a0da): undefined reference to `benchmark::internal::Benchmark::Iterations(unsigned long)'
/usr/bin/ld: <artificial>:(.text.startup+0x2a0e2): undefined reference to `benchmark::internal::Benchmark::UseManualTime()'
/usr/bin/ld: <artificial>:(.text.startup+0x2a0ec): undefined reference to `benchmark::internal::Benchmark::Unit(benchmark::TimeUnit)'
/usr/bin/ld: <artificial>:(.text.startup+0x2a14c): undefined reference to `benchmark::internal::Benchmark::ComputeStatistics(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double (*)(std::vector<double, std::allocator<double> > const&), benchmark::StatisticUnit)'
/usr/bin/ld: <artificial>:(.text.startup+0x2e7ec): undefined reference to `benchmark::internal::Benchmark::Benchmark(char const*)'
/usr/bin/ld: <artificial>:(.text.startup+0x2e807): undefined reference to `vtable for benchmark::internal::FunctionBenchmark'
/usr/bin/ld: <artificial>:(.text.startup+0x2e840): undefined reference to `benchmark::internal::RegisterBenchmarkInternal(benchmark::internal::Benchmark*)'
/usr/bin/ld: /tmp/ccViH2hI.ltrans4.ltrans.o: in function `_sub_I_65535_0.0':
<artificial>:(.text.startup+0x50d3): undefined reference to `benchmark::internal::InitializeStreams()'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/reporter_output_test.dir/build.make:100: test/reporter_output_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:627: test/CMakeFiles/reporter_output_test.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

</details>

The problem is caused by missing visibility attributes for symbols used outside of the library (as such part of the public interface even though some of these symbols are declared in the `internal` namespace).

This PR adds proper annotations to public symbols using the new `export.h` header. This fixes #1070 and enables fixing #1022.

Selective symbol export has the benefit of reducing the size of the generated `libbenchmark.so.*`. For instance, on Ubuntu 20.04 I observe a size reduction from 436K to 420K.

Open questions:
- [x] How should `export.h` be defined for Bazel builds?
- [x] Should CI build shared library variant by default?  Ideally, with `CMAKE_CXX_VISIBILITY_PRESET=hidden` and possibly `CMAKE_VISIBILITY_INLINES_HIDDEN=ON`, and `-flto` enabled to avoid regressions