### PR TITLE
Fix some errors in Custom Statistics document demo code.

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1058,7 +1058,7 @@ void BM_spin_empty(benchmark::State& state) {
 BENCHMARK(BM_spin_empty)
   ->ComputeStatistics("ratio", [](const std::vector<double>& v) -> double {
     return std::begin(v) / std::end(v);
-  }, benchmark::StatisticUnit::Percentage)
+  }, benchmark::StatisticUnit::kPercentage)
   ->Arg(512);
 ```
 


### PR DESCRIPTION
I found there is an error in the demo code 

The wrong demo code in the documents use [benchmark::StatisticUnit::Percentage](https://github.com/google/benchmark/blob/acd75620347618dcf73e9d18474f110db63b97d4/docs/user_guide.md?plain=1#L1058-L1062)
```c++
BENCHMARK(BM_spin_empty)
  ->ComputeStatistics("ratio", [](const std::vector<double>& v) -> double {
    return std::begin(v) / std::end(v);
  }, benchmark::StatisticUnit::Percentage)
  ->Arg(512);
```

and the correct CPP code is `kPercentage` in https://github.com/google/benchmark/blob/acd75620347618dcf73e9d18474f110db63b97d4/include/benchmark/benchmark.h#L520-L522

