### PR TITLE
Fix cross compilation for macOS ARM builds in `cibuildwheel`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,12 @@ class BuildBazelExtension(build_ext.build_ext):
         elif sys.platform == "darwin" and platform.machine() == "x86_64":
             bazel_argv.append("--macos_minimum_os=10.9")
 
+            # ARCHFLAGS is always set by cibuildwheel before macOS wheel builds.
+            archflags = os.getenv("ARCHFLAGS", "")
+            if "arm64" in archflags:
+                bazel_argv.append("--cpu=darwin_arm64")
+                bazel_argv.append("--macos_cpus=arm64")
+
         self.spawn(bazel_argv)
 
         shared_lib_suffix = '.dll' if IS_WINDOWS else '.so'


### PR DESCRIPTION
This commit contains a fix for macOS ARM64 wheel buils in Google Benchmark's wheel building CI.

Previously, while `cibuildwheel` itself properly identified the need for cross-compilations and produced valid ARM platform wheels, the included shared library containing the Python bindings built by `bazel` was built for x86, resulting in immediate errors upon import.

To fix this, logic was added to the setup.py file that adds the "--cpu=darwin_arm64" and "--macos_cpus=arm64" switches to the `bazel build` command if
1) The current system platform is macOS Darwin running on the x86_64 architecture, and
2) The ARCHFLAGS environment variable, set by wheel build systems like `conda` and `cibuildwheel`, contains the tag "arm64".

This way, bazel correctly sets the target CPU to ARM64, and produces functional wheels for the macOS ARM line of CPUs.

On current `main`:

```python
~ via gbm-test
➜ pip install Downloads/dist-1/google_benchmark-1.6.1-cp39-cp39-macosx_11_0_arm64.whl
Processing ./Downloads/dist-1/google_benchmark-1.6.1-cp39-cp39-macosx_11_0_arm64.whl
Collecting absl-py>=0.7.1
  Using cached absl_py-1.0.0-py3-none-any.whl (126 kB)
Collecting six
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: six, absl-py, google-benchmark
Successfully installed absl-py-1.0.0 google-benchmark-1.6.1 six-1.16.0

~ via gbm-test
➜ python
Python 3.9.10 (main, Jan 15 2022, 11:40:53)
[Clang 13.0.0 (clang-1300.0.29.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import google_benchmark
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/nicholasjunge/.venv/gbm-test/lib/python3.9/site-packages/google_benchmark/__init__.py", line 31, in <module>
    from google_benchmark import _benchmark
ImportError: dlopen(/Users/nicholasjunge/.venv/gbm-test/lib/python3.9/site-packages/google_benchmark/_benchmark.cpython-39-darwin.so, 0x0002): tried: '/Users/nicholasjunge/.venv/gbm-test/lib/python3.9/site-packages/google_benchmark/_benchmark.cpython-39-darwin.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/local/lib/_benchmark.cpython-39-darwin.so' (no such file), '/usr/lib/_benchmark.cpython-39-darwin.so' (no such file)
```

With this branch:

```python
~ via gbm-test
➜ pip install Downloads/dist-2/google_benchmark-1.6.1-cp39-cp39-macosx_11_0_arm64.whl
Processing ./Downloads/dist-2/google_benchmark-1.6.1-cp39-cp39-macosx_11_0_arm64.whl
Requirement already satisfied: absl-py>=0.7.1 in ./.venv/gbm-test/lib/python3.9/site-packages (from google-benchmark==1.6.1) (1.0.0)
Requirement already satisfied: six in ./.venv/gbm-test/lib/python3.9/site-packages (from absl-py>=0.7.1->google-benchmark==1.6.1) (1.16.0)
Installing collected packages: google-benchmark
Successfully installed google-benchmark-1.6.1

~ via gbm-test
➜ python
Python 3.9.10 (main, Jan 15 2022, 11:40:53)
[Clang 13.0.0 (clang-1300.0.29.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import google_benchmark
>>>
```