### PR TITLE
Add pandas and numpy to tools/requirements.txt

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,1 +1,3 @@
 scipy>=1.5.0
+pandas>=1.1.5
+numpy>=1.21


### PR DESCRIPTION
Add the appropriate requirements that `tools/gbench/report.py` uses to `tools/requirements.txt`. Right now `tools/compare.py` can fail if someone relies on `tools/requirements.txt`.