### PR TITLE
Expose default display reporter creation in public API

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -293,6 +293,11 @@ bool ReportUnrecognizedArguments(int argc, char** argv);
 // Returns the current value of --benchmark_filter.
 std::string GetBenchmarkFilter();
 
+// Creates a default display reporter. Used by the library when no display
+// reporter is provided, but also made available for external use in case a
+// custom reporter should respect the `--benchmark_format` flag as a fallback
+BenchmarkReporter* CreateDefaultDisplayReporter();
+
 // Generate a list of benchmarks matching the specified --benchmark_filter flag
 // and if --benchmark_list_tests is specified return after printing the name
 // of each matching benchmark. Otherwise run each matching benchmark and

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -388,9 +388,9 @@ std::unique_ptr<BenchmarkReporter> CreateReporter(
   if (name == "console") {
     return PtrType(new ConsoleReporter(output_opts));
   } else if (name == "json") {
-    return PtrType(new JSONReporter);
+    return PtrType(new JSONReporter());
   } else if (name == "csv") {
-    return PtrType(new CSVReporter);
+    return PtrType(new CSVReporter());
   } else {
     std::cerr << "Unexpected format: '" << name << "'\n";
     std::exit(1);
@@ -431,6 +431,13 @@ ConsoleReporter::OutputOptions GetOutputOptions(bool force_no_color) {
 
 }  // end namespace internal
 
+BenchmarkReporter* CreateDefaultDisplayReporter() {
+  static auto default_display_reporter =
+      internal::CreateReporter(FLAGS_benchmark_format,
+                               internal::GetOutputOptions()).release();
+  return default_display_reporter;
+}
+
 size_t RunSpecifiedBenchmarks() {
   return RunSpecifiedBenchmarks(nullptr, nullptr, FLAGS_benchmark_filter);
 }
@@ -466,8 +473,7 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
   std::unique_ptr<BenchmarkReporter> default_display_reporter;
   std::unique_ptr<BenchmarkReporter> default_file_reporter;
   if (!display_reporter) {
-    default_display_reporter = internal::CreateReporter(
-        FLAGS_benchmark_format, internal::GetOutputOptions());
+    default_display_reporter.reset(CreateDefaultDisplayReporter());
     display_reporter = default_display_reporter.get();
   }
   auto& Out = display_reporter->GetOutputStream();

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -434,7 +434,8 @@ ConsoleReporter::OutputOptions GetOutputOptions(bool force_no_color) {
 BenchmarkReporter* CreateDefaultDisplayReporter() {
   static auto default_display_reporter =
       internal::CreateReporter(FLAGS_benchmark_format,
-                               internal::GetOutputOptions()).release();
+                               internal::GetOutputOptions())
+          .release();
   return default_display_reporter;
 }
 

--- a/test/benchmark_random_interleaving_gtest.cc
+++ b/test/benchmark_random_interleaving_gtest.cc
@@ -51,10 +51,9 @@ class BenchmarkTest : public testing::Test {
   void Execute(const std::string& pattern) {
     queue->Clear();
 
-    BenchmarkReporter* reporter = new NullReporter;
+    std::unique_ptr<BenchmarkReporter> reporter(new NullReporter());
     FLAGS_benchmark_filter = pattern;
-    RunSpecifiedBenchmarks(reporter);
-    delete reporter;
+    RunSpecifiedBenchmarks(reporter.get());
 
     queue->Put("DONE");  // End marker
   }


### PR DESCRIPTION
This is useful if a custom reporter needs a fallback to what would be the benchmark's default display reporter.  Custom reporters don't have access to benchmark's configuration so can't (and shouldn't) guess what the default reporter would have been.