### PR TITLE
simplify reference to internal path

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 licenses(["notice"])
 
 load(
-    "@com_github_google_benchmark//tools:workspace/generate_export_header.bzl",
+    "//tools:workspace/generate_export_header.bzl",
     "generate_export_header",
 )
 


### PR DESCRIPTION
The absolute name creates a superglobal new precondition on users of either a) under which name they import your workspace or b) to provide a suitable repo_mapping.

dropping the absolute name just works.