### PR TITLE
restore `BENCHMARK_MAIN()`

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1464,7 +1464,15 @@ class Fixture : public internal::Benchmark {
 #endif
 
 // Helper macro to create a main routine in a test that runs the benchmarks
-#define BENCHMARK_MAIN() BENCHMARK_EXPORT int main(int argc, char** argv)
+#define BENCHMARK_MAIN()                                                \
+  int main(int argc, char** argv) {                                     \
+    ::benchmark::Initialize(&argc, argv);                               \
+    if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1; \
+    ::benchmark::RunSpecifiedBenchmarks();                              \
+    ::benchmark::Shutdown();                                            \
+    return 0;                                                           \
+  }                                                                     \
+  int main(int, char**)
 
 // ------------------------------------------------------
 // Benchmark Reporters

--- a/src/benchmark_main.cc
+++ b/src/benchmark_main.cc
@@ -14,14 +14,5 @@
 
 #include "benchmark/benchmark.h"
 
+BENCHMARK_EXPORT int main(int, char**);
 BENCHMARK_MAIN();
-
-// MSVC does not allow the definition of dllimport. Thus, define it here instead
-// inline in a macro.
-int main(int argc, char** argv) {
-  ::benchmark::Initialize(&argc, argv);
-  if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1;
-  ::benchmark::RunSpecifiedBenchmarks();
-  ::benchmark::Shutdown();
-  return 0;
-}


### PR DESCRIPTION
In #1321 I unintentionally changed the semantics of `BENCHMARK_MAIN` requiring to always link against the `benchmark_main` library. This PR restores the original documented behavior.