### PR TITLE
Add SetBenchmarkFilter() to set --benchmark_filter flag value in user code

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -302,8 +302,10 @@ BENCHMARK_EXPORT bool ReportUnrecognizedArguments(int argc, char** argv);
 // Returns the current value of --benchmark_filter.
 BENCHMARK_EXPORT std::string GetBenchmarkFilter();
 
-// Sets the value of --benchmark_filter. (This will override this flag's
+// Sets a new value to --benchmark_filter. (This will override this flag's
 // current value).
+// Should be called after `benchmark::Initialize()`, as
+// `benchmark::Initialize()` will override the flag's value.
 BENCHMARK_EXPORT void SetBenchmarkFilter(std::string value);
 
 // Creates a default display reporter. Used by the library when no display

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -302,6 +302,10 @@ BENCHMARK_EXPORT bool ReportUnrecognizedArguments(int argc, char** argv);
 // Returns the current value of --benchmark_filter.
 BENCHMARK_EXPORT std::string GetBenchmarkFilter();
 
+// Sets the value of --benchmark_filter. (This will override this flag's
+// current value).
+BENCHMARK_EXPORT void SetBenchmarkFilter(std::string value);
+
 // Creates a default display reporter. Used by the library when no display
 // reporter is provided, but also made available for external use in case a
 // custom reporter should respect the `--benchmark_format` flag as a fallback

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -535,6 +535,10 @@ void SetDefaultTimeUnit(TimeUnit unit) { default_time_unit = unit; }
 
 std::string GetBenchmarkFilter() { return FLAGS_benchmark_filter; }
 
+void SetBenchmarkFilter(std::string value) {
+  FLAGS_benchmark_filter = std::move(value);
+}
+
 void RegisterMemoryManager(MemoryManager* manager) {
   internal::memory_manager = manager;
 }

--- a/test/spec_arg_test.cc
+++ b/test/spec_arg_test.cc
@@ -91,5 +91,15 @@ int main(int argc, char** argv) {
               << matched_functions.front() << "]\n";
     return 2;
   }
+
+  // Test that SetBenchmarkFilter works.
+  const std::string golden_value = "golden_value";
+  benchmark::SetBenchmarkFilter(golden_value);
+  std::string current_value = benchmark::GetBenchmarkFilter();
+  if (golden_value != current_value) {
+    std::cerr << "Expected [" << golden_value
+              << "] for --benchmark_filter but got [" << current_value << "]\n";
+    return 3;
+  }
   return 0;
 }


### PR DESCRIPTION

Use case:  Provide an API to set this flag independent of the flag's implementation (ie., absl flag vs benchmark's flag facility)