### PR TITLE
Add BENCHMARK_STATIC_DEFINE to the Python bindings' `cc_binary` local…

### DIFF
--- a/bindings/python/build_defs.bzl
+++ b/bindings/python/build_defs.bzl
@@ -8,12 +8,13 @@ def py_extension(name, srcs, hdrs = [], copts = [], features = [], deps = []):
         shared_lib_name = name + shared_lib_suffix
         native.cc_binary(
             name = shared_lib_name,
-            linkshared = 1,
-            linkstatic = 1,
+            linkshared = True,
+            linkstatic = True,
             srcs = srcs + hdrs,
             copts = copts,
             features = features,
             deps = deps,
+            local_defines = ["BENCHMARK_STATIC_DEFINE"],
         )
 
     return native.py_library(


### PR DESCRIPTION
… defines.

Fixes #1367.

This commit fixes the previous breakage in Python wheel builds for Windows by adding a `local_defines` field to the `cc_binary` generated in the process of the Python bindings builds. This define is being
picked up by the auto-generated export header `benchmark_export.h`, unsetting the benchmark export macro.
Furthermore, the `linkshared` and `linkstatic` attributes are passed booleans now instead of ints, making the command more directly interpretable to the human reader.

The fix was suggested by @junyer in the corresponding GitHub issue thread https://github.com/google/benchmark/issues/1367 - thank you for the suggestion!

Wheel CI is green with this change @dominichamon - see https://github.com/nicholasjng/benchmark/actions/runs/1980232291.