### PR TITLE
Change artifact download name to dist to match upload name

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -139,7 +139,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v2
       with:
-        name: artifact
+        name: dist
         path: dist
 
     - uses: pypa/gh-action-pypi-publish@v1.5.0


### PR DESCRIPTION
The uploaded artifact name is `dist` in every wheel build job, as well as on the completed jobs page.