### PR TITLE
Build `//:benchmark` as a static library only.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -55,10 +55,11 @@ cc_library(
         ":windows": [],
         "//conditions:default": posix_copts,
     }),
-    local_defines = select({
-        ":windows": ["benchmark_EXPORTS"],
-        "//conditions:default": [],
-    }),
+    # Only static linking is allowed; no .so will be produced.
+    # Using `defines` (i.e. not `local_defines`) means that no
+    # dependent rules need to bother about defining the macro.
+    linkstatic = True,
+    defines = ["BENCHMARK_STATIC_DEFINE"],
 )
 
 cc_library(

--- a/bindings/python/build_defs.bzl
+++ b/bindings/python/build_defs.bzl
@@ -14,7 +14,6 @@ def py_extension(name, srcs, hdrs = [], copts = [], features = [], deps = []):
             copts = copts,
             features = features,
             deps = deps,
-            local_defines = ["BENCHMARK_STATIC_DEFINE"],
         )
 
     return native.py_library(


### PR DESCRIPTION
If someone or something ever needs the dynamic library as a Bazel build
artifact, we can figure that out for them then, but right now, there is
no strong reason to be wrangling various `export.h`-controlling macros.

Fixes #1372.