### PR TITLE
fix gcc7.5 compile error

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1243,8 +1243,15 @@ internal::Benchmark* RegisterBenchmark(const char* name, Lambda&& fn) {
 template <class Lambda, class... Args>
 internal::Benchmark* RegisterBenchmark(const char* name, Lambda&& fn,
                                        Args&&... args) {
+#if defined(BENCHMARK_HAS_CXX14)
+  return benchmark::RegisterBenchmark(
+      name, [=, gn = std::forward<Lambda>(fn)](benchmark::State& st) {
+        gn(st, args...);
+      });
+#else
   return benchmark::RegisterBenchmark(
       name, [=](benchmark::State& st) { fn(st, args...); });
+#endif
 }
 #else
 #define BENCHMARK_HAS_NO_VARIADIC_REGISTER_BENCHMARK

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -179,6 +179,7 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <functional>
 #include <iosfwd>
 #include <limits>
 #include <map>
@@ -1243,15 +1244,10 @@ internal::Benchmark* RegisterBenchmark(const char* name, Lambda&& fn) {
 template <class Lambda, class... Args>
 internal::Benchmark* RegisterBenchmark(const char* name, Lambda&& fn,
                                        Args&&... args) {
-#if defined(BENCHMARK_HAS_CXX14)
-  return benchmark::RegisterBenchmark(
-      name, [=, gn = std::forward<Lambda>(fn)](benchmark::State& st) {
-        gn(st, args...);
-      });
-#else
-  return benchmark::RegisterBenchmark(
-      name, [=](benchmark::State& st) { fn(st, args...); });
-#endif
+  auto func = std::bind(std::forward<Lambda>(fn), std::placeholders::_1,
+                        std::forward<Args>(args)...);
+  return benchmark::RegisterBenchmark(name,
+                                      [=](benchmark::State& st) { func(st); });
 }
 #else
 #define BENCHMARK_HAS_NO_VARIADIC_REGISTER_BENCHMARK

--- a/test/register_benchmark_test.cc
+++ b/test/register_benchmark_test.cc
@@ -106,12 +106,16 @@ struct CustomFixture {
   }
 };
 
+static void StaticFunction(::benchmark::State& state, int) {}
+
 void TestRegistrationAtRuntime() {
 #ifdef BENCHMARK_HAS_CXX11
   {
     CustomFixture fx;
     benchmark::RegisterBenchmark("custom_fixture", fx);
     AddCases({"custom_fixture"});
+
+    benchmark::RegisterBenchmark("static", StaticFunction, 1);
   }
 #endif
 #ifndef BENCHMARK_HAS_NO_VARIADIC_REGISTER_BENCHMARK


### PR DESCRIPTION
## Context
I tried to compile [google/uVkCompute](https://github.com/google/uVkCompute) with GCC7.5, got some error:
```shell
...
uVkCompute/third_party/benchmark/include/benchmark/benchmark.h:1204:41: error: field 
‘benchmark::RegisterBenchmark(const char*, Lambda&&, Args&& ...) [with Lambda = void (&)(benchmark::State&, 
uvkc::vulkan::Device*, uvkc::benchmark::LatencyMeasureMode, const double*, const unsigned int*, long unsigned int, 
long unsigned int, int, double*); Args = {uvkc::vulkan::Device*&, uvkc::benchmark::LatencyMeasureMode&, const 
double*&, const unsigned int* const&, long unsigned int, long unsigned int&, long unsigned int, double*&}]::
<lambda(benchmark::State&)>::<fn capture>’ invalidly declared function type

...
```

The key problem is **construct lambda in gcc7.5**, please build this snippet and have a try:
```c++
#include <iostream>

template <class Lambda>
void RegisterBenchmark(Lambda&& fn) {
  fprintf(stdout, "first version\n");
}

template <class Lambda, class... Args>
void RegisterBenchmark(Lambda&& fn, Args&&... args) {

  // no auto decay in g++7.5, crash !!!
  auto fff = [=](){ fn(args...); };

  fff = [=, gn=std::forward<Lambda>(fn)](){ gn(args...); };
  fff = [=, gn=std::decay_t<Lambda>(fn)](){ gn(args...); };
  RegisterBenchmark(std::move(fff)); 
}


int func(int a) {
  fprintf(stdout, "%d\n", a);
}

int main() {
RegisterBenchmark(func, 12);
return 0;
}
```

`auto fff = [=](){ fn(args...); };`  is fine in clang/gcc11, but does not work in gcc7.5.

please check
* https://stackoverflow.com/questions/34815698/c11-passing-function-as-lambda-parameter
* https://github.com/google/uVkCompute/issues/15

