### PR TITLE
Fix wheel job name for PyPI uploads

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -69,7 +69,7 @@ jobs:
 
   pypi_upload:
     name: Publish google-benchmark wheels to PyPI
-    needs: [build_sdist, build_linux, build_macos, build_windows]
+    needs: [build_sdist, build_wheels]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v3


### PR DESCRIPTION
Previously, with the unrolled job matrix, all jobs had to be listed individually in the `needs` section of the PyPI upload job. But as the wheel build job was reimplemented as a job matrix now, with a single build job name `build_wheels`, we need to adjust the name in the PyPI upload job as well here to avoid errors.