### PR TITLE
Add support to get clock for new architecture CSKY

### DIFF
--- a/src/cycleclock.h
+++ b/src/cycleclock.h
@@ -173,7 +173,7 @@ inline BENCHMARK_ALWAYS_INLINE int64_t Now() {
   struct timeval tv;
   gettimeofday(&tv, nullptr);
   return static_cast<int64_t>(tv.tv_sec) * 1000000 + tv.tv_usec;
-#elif defined(__loongarch__)
+#elif defined(__loongarch__) || defined(__csky__)
   struct timeval tv;
   gettimeofday(&tv, nullptr);
   return static_cast<int64_t>(tv.tv_sec) * 1000000 + tv.tv_usec;


### PR DESCRIPTION
it's like what loongarch does to get cycle clock for CSKY by gettimeofday function.