### PR TITLE
added INSTRUCTIONS and CYCLES hardware perf counters on MacOS.

### DIFF
--- a/docs/perf_counters.md
+++ b/docs/perf_counters.md
@@ -1,5 +1,3 @@
-<a name="perf-counters" />
-
 # User-Requested Performance Counters
 
 When running benchmarks, the user may choose to request collection of
@@ -9,14 +7,30 @@ performance improvement matches expectations.
 
 This feature is available if:
 
-* The benchmark is run on an architecture featuring a Performance Monitoring
-  Unit (PMU),
-* The benchmark is compiled with support for collecting counters. Currently,
-  this requires [libpfm](http://perfmon2.sourceforge.net/) be available at build
-  time
+* The benchmark is run on an architecture featuring a Performance Monitoring Unit (PMU),
+* The benchmark is compiled with support for collecting counters. 
+
 
 The feature does not require modifying benchmark code. Counter collection is
 handled at the boundaries where timer collection is also handled. 
+
+The counter values are reported back through the [User Counters](../README.md#custom-counters)
+mechanism, meaning, they are available in all the formats (e.g. JSON) supported
+by User Counters.
+
+## MacOS
+MacOS, on Apple Silicon and Intel, has built in support for per thread instruction 
+and cycle counters. These counters can be queried by the by semi-undocumented API 
+in libpthread `thread_selfcounts`. Benchmark support for these counters is always 
+enabled as it requires no additional dependencies.
+
+To use, pass a comma-separated list of counter names through the 
+`--benchmark_perf_counters` flag. The only available counter names 
+are `CYCLES` and `INSTRUCTIONS`.
+
+## Linux
+Currently, this requires [libpfm](http://perfmon2.sourceforge.net/) be available 
+at build time.
 
 To opt-in:
 
@@ -29,6 +43,3 @@ they are platform specific, but some (e.g. `CYCLES` or `INSTRUCTIONS`) are
 mapped by libpfm to platform-specifics - see libpfm
 [documentation](http://perfmon2.sourceforge.net/docs.html) for more details.
 
-The counter values are reported back through the [User Counters](../README.md#custom-counters)
-mechanism, meaning, they are available in all the formats (e.g. JSON) supported
-by User Counters.


### PR DESCRIPTION
MacOS has a semi undocumented API in libpthread that returns the INSTRUCTION and CYCLE counts of the calling thread. The API is thread_selfcounts and is available on Intel and Apple Silicon hardware.  Using the API, this PR cleanly integrates with the existing performance counter code and allows those two counters.

For example you can use `--benchmark_perf_counters=INSTRUCTIONS,CYCLES` just like you can on Linux but no external dependencies are required as everything needed is in libpthread.

The performance counter documentation has been updated to reflect this change.