### PR TITLE
Fix DoNotOptimize() GCC copy overhead (#1340)

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -446,6 +446,7 @@ inline BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
 // intended to add little to no overhead.
 // See: https://youtu.be/nXaxk27zwlk?t=2441
 #ifndef BENCHMARK_HAS_NO_INLINE_ASSEMBLY
+#if !defined(__GNUC__) || defined(__llvm__) || defined(__INTEL_COMPILER)
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   asm volatile("" : : "r,m"(value) : "memory");
@@ -459,6 +460,55 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
   asm volatile("" : "+m,r"(value) : : "memory");
 #endif
 }
+#elif defined(BENCHMARK_HAS_CXX11) && (__GNUC__ >= 5)
+// Workaround for a bug with full argument copy overhead with GCC.
+// See: #1340 and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105519
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE
+    typename std::enable_if<std::is_trivially_copyable<Tp>::value &&
+                            (sizeof(Tp) <= sizeof(Tp*))>::type
+    DoNotOptimize(Tp const& value) {
+  asm volatile("" : : "r"(value) : "memory");
+}
+
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE
+    typename std::enable_if<!std::is_trivially_copyable<Tp>::value ||
+                            (sizeof(Tp) > sizeof(Tp*))>::type
+    DoNotOptimize(Tp const& value) {
+  asm volatile("" : : "m"(value) : "memory");
+}
+
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE
+    typename std::enable_if<std::is_trivially_copyable<Tp>::value &&
+                            (sizeof(Tp) <= sizeof(Tp*))>::type
+    DoNotOptimize(Tp& value) {
+  asm volatile("" : "+r"(value) : : "memory");
+}
+
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE
+    typename std::enable_if<!std::is_trivially_copyable<Tp>::value ||
+                            (sizeof(Tp) > sizeof(Tp*))>::type
+    DoNotOptimize(Tp& value) {
+  asm volatile("" : "+m"(value) : : "memory");
+}
+
+#else
+// Fallback for GCC < 5. Can add some overhead because the compiler is forced
+// to use memory operations instead of operations with registers.
+// TODO: Remove if GCC < 5 will be unsupported.
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
+  asm volatile("" : : "m"(value) : "memory");
+}
+
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
+  asm volatile("" : "+m"(value) : : "memory");
+}
+#endif
 
 #ifndef BENCHMARK_HAS_CXX11
 inline BENCHMARK_ALWAYS_INLINE void ClobberMemory() {

--- a/test/AssemblyTests.cmake
+++ b/test/AssemblyTests.cmake
@@ -1,3 +1,23 @@
+set(CLANG_SUPPORTED_VERSION "5.0.0")
+set(GCC_SUPPORTED_VERSION "5.5.0")
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL ${CLANG_SUPPORTED_VERSION})
+    message (WARNING
+      "Unsupported Clang version " ${CMAKE_CXX_COMPILER_VERSION}
+      ". Expected is " ${CLANG_SUPPORTED_VERSION}
+      ". Assembly tests may be broken.")
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL ${GCC_SUPPORTED_VERSION})
+    message (WARNING
+      "Unsupported GCC version " ${CMAKE_CXX_COMPILER_VERSION}
+      ". Expected is " ${GCC_SUPPORTED_VERSION}
+      ". Assembly tests may be broken.")
+  endif()
+else()
+  message (WARNING "Unsupported compiler. Assembly tests may be broken.")
+endif()
 
 include(split_list)
 

--- a/test/donotoptimize_assembly_test.cc
+++ b/test/donotoptimize_assembly_test.cc
@@ -9,6 +9,9 @@ extern "C" {
 extern int ExternInt;
 extern int ExternInt2;
 extern int ExternInt3;
+extern int BigArray[2049];
+
+const int ConstBigArray[2049]{};
 
 inline int Add42(int x) { return x + 42; }
 
@@ -23,7 +26,15 @@ struct Large {
   int value;
   int data[2];
 };
+
+struct ExtraLarge {
+  int arr[2049];
+};
 }
+
+extern ExtraLarge ExtraLargeObj;
+const ExtraLarge ConstExtraLargeObj{};
+
 // CHECK-LABEL: test_with_rvalue:
 extern "C" void test_with_rvalue() {
   benchmark::DoNotOptimize(Add42(0));
@@ -68,6 +79,22 @@ extern "C" void test_with_large_lvalue() {
   // CHECK: ret
 }
 
+// CHECK-LABEL: test_with_extra_large_lvalue_with_op:
+extern "C" void test_with_extra_large_lvalue_with_op() {
+  ExtraLargeObj.arr[16] = 42;
+  benchmark::DoNotOptimize(ExtraLargeObj);
+  // CHECK: movl $42, ExtraLargeObj+64(%rip)
+  // CHECK: ret
+}
+
+// CHECK-LABEL: test_with_big_array_with_op
+extern "C" void test_with_big_array_with_op() {
+  BigArray[16] = 42;
+  benchmark::DoNotOptimize(BigArray);
+  // CHECK: movl $42, BigArray+64(%rip)
+  // CHECK: ret
+}
+
 // CHECK-LABEL: test_with_non_trivial_lvalue:
 extern "C" void test_with_non_trivial_lvalue() {
   NotTriviallyCopyable NTC(ExternInt);
@@ -93,6 +120,18 @@ extern "C" void test_with_large_const_lvalue() {
   // CHECK: movl %eax, -{{[0-9]+}}(%[[REG:[a-z]+]])
   // CHECK: movl %eax, -{{[0-9]+}}(%[[REG]])
   // CHECK: movl %eax, -{{[0-9]+}}(%[[REG]])
+  // CHECK: ret
+}
+
+// CHECK-LABEL: test_with_const_extra_large_obj:
+extern "C" void test_with_const_extra_large_obj() {
+  benchmark::DoNotOptimize(ConstExtraLargeObj);
+  // CHECK: ret
+}
+
+// CHECK-LABEL: test_with_const_big_array
+extern "C" void test_with_const_big_array() {
+  benchmark::DoNotOptimize(ConstBigArray);
   // CHECK: ret
 }
 


### PR DESCRIPTION
- Fixed issue with GCC copy overhead
- Assembly tests for issued cases were added
- Specific compiler versions required for reliable tests passed assembly tests
  was added

## Fix/Workaround for the bug

The solution is the split DoNotOptimize() in two cases - value fits in register and value doesn't fit in a register. And use case-specific asm constraint.

The solution works with GCC starting 5 version because the fix requires std::is_trivially_copyable feature which is available since GCC 5 and newer.

## Add specific compiler versions for assembly tests

- Assembly tests are inherently non-portable. So explicitly add GCC and Clang versions required for reliable tests passed
- Write a warning message if the current compiler version isn't supported

## How to check

Use this **[Dockerfile](https://gist.github.com/alexgpg/959f7ded943e7d42100a2013c8f0f697#file-dockerfile)**.
Copy it and run

```
docker build --tag googlebench:1340fix .
```

If docker build successfully that means the branch builds and tests passed.

## Notes

- Fallback for GCC version < 5 still exists but it uses the "m" constraint which means a little bit more overhead in some cases

- Why versions are 5.5.0 for GCC and 5.0.0 for Clang?
  I took Clang version from [CI configuration](https://www.travis-ci.org/github/google/benchmark/jobs/741836197#L51)
  I use GCC 5.5.0 cause it's a version available for Ubuntu 14.04 and supports std::is_trivially_copyable

- Is it right that run_state_assembly_test_CHECK tests failed?
  Yes, that's right. But it's not related with this PR/commits.
  Test run_state_assembly_test_CHECK doesn't work since [commit: Enable -Wconversion (#1390) ](https://github.com/google/benchmark/commit/8d86026c67e41b1f74e67c1b20cc8f73871bc76e)

## Topics to discuss

- Is a fallback for GCC < 5 is needed or it's ok to drop support for GCC < 5 right now in this PR?
- Is more assembly tests for is needed? **I'm very happy to hear ideas for test cases**

## Links

- [Issue: [BUG] DoNotOptimize() adds overhead with extra copy of argument(gcc)](https://github.com/google/benchmark/issues/1340)
- [Dockerfile](https://gist.github.com/alexgpg/959f7ded943e7d42100a2013c8f0f697#file-dockerfile) for check build and tests
- [GCC: Bug 105519 - Unnecessary memcpy() copy for empty asm volatile](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105519)