### PR TITLE
Fix DoNotOptimize() GCC compile error with some types (#1340)

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -468,7 +468,7 @@ inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<std::is_trivially_copyable<Tp>::value &&
                             (sizeof(Tp) <= sizeof(Tp*))>::type
     DoNotOptimize(Tp const& value) {
-  asm volatile("" : : "r"(value) : "memory");
+  asm volatile("" : : "r,m"(value) : "memory");
 }
 
 template <class Tp>
@@ -484,7 +484,7 @@ inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<std::is_trivially_copyable<Tp>::value &&
                             (sizeof(Tp) <= sizeof(Tp*))>::type
     DoNotOptimize(Tp& value) {
-  asm volatile("" : "+r"(value) : : "memory");
+  asm volatile("" : "+m,r"(value) : : "memory");
 }
 
 template <class Tp>

--- a/test/donotoptimize_test.cc
+++ b/test/donotoptimize_test.cc
@@ -29,6 +29,15 @@ struct BitRef {
 int main(int, char*[]) {
   // this test verifies compilation of DoNotOptimize() for some types
 
+  char buffer1[1] = "";
+  benchmark::DoNotOptimize(buffer1);
+
+  char buffer2[2] = "";
+  benchmark::DoNotOptimize(buffer2);
+
+  char buffer3[3] = "";
+  benchmark::DoNotOptimize(buffer3);
+
   char buffer8[8] = "";
   benchmark::DoNotOptimize(buffer8);
 
@@ -38,6 +47,25 @@ int main(int, char*[]) {
   char buffer1024[1024] = "";
   benchmark::DoNotOptimize(buffer1024);
   benchmark::DoNotOptimize(&buffer1024[0]);
+
+  const char const_buffer1[1] = "";
+  benchmark::DoNotOptimize(const_buffer1);
+
+  const char const_buffer2[2] = "";
+  benchmark::DoNotOptimize(const_buffer2);
+
+  const char const_buffer3[3] = "";
+  benchmark::DoNotOptimize(const_buffer3);
+
+  const char const_buffer8[8] = "";
+  benchmark::DoNotOptimize(const_buffer8);
+
+  const char const_buffer20[20] = "";
+  benchmark::DoNotOptimize(const_buffer20);
+
+  const char const_buffer1024[1024] = "";
+  benchmark::DoNotOptimize(const_buffer1024);
+  benchmark::DoNotOptimize(&const_buffer1024[0]);
 
   int x = 123;
   benchmark::DoNotOptimize(x);


### PR DESCRIPTION
It's a fix for **https://github.com/google/benchmark/pull/1410#issuecomment-1168214494**

### Issue

Non-const DoNotOptimize() can't compile when used with some types.
Example of code which can't compile:

```c++
char buffer3[3] = "";
benchmark::DoNotOptimize(buffer3);
```

Error message:

```
error: impossible constraint in 'asm'
  asm volatile("" : "+r"(value) : : "memory");
```

Introduced in 8545dfb (Fix DoNotOptimize() GCC copy overhead (#1340) (#1410))

### Cause

The cause is compiler can't work with the +r constraint for types that can't be placed perfectly in registers. For example, char array[3] can't be perfectly fit in register on x86_64 so it requires placed in memory but constraint doesn't allow that.

### Solution

- Use +m,r constraint for the small objects so the compiler can decide to use register or/and memory
- For the big objects +m constraint is used which allows avoiding extra copy bug(see #1340)
- The same approach is used for the const version of DoNotOptimize() although the const version works fine with the "r" constraint only. Using mixed r,m constraint looks more general solution.

### See
- Comment describing the issue https://github.com/google/benchmark/pull/1410#issuecomment-1168214494
- Issue #1340
- Pull request #1410
- Commit 8545dfb (Fix DoNotOptimize() GCC copy overhead)
- [GCC: Bug 105519 - Unnecessary memcpy() copy for empty asm volatile](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105519)