### PR TITLE
Expose google_benchmark.State for python bindings.

### DIFF
--- a/bindings/python/google_benchmark/__init__.py
+++ b/bindings/python/google_benchmark/__init__.py
@@ -44,6 +44,7 @@ from google_benchmark._benchmark import (
     oNLogN,
     oAuto,
     oLambda,
+    State,
 )
 
 
@@ -64,6 +65,7 @@ __all__ = [
     "oNLogN",
     "oAuto",
     "oLambda",
+    "State",
 ]
 
 __version__ = "1.6.1"


### PR DESCRIPTION
Allows for type annotations.