### PR TITLE
Fix segfault on `--help` cli flag

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -678,9 +678,9 @@ void PrintDefaultHelp() {
 }
 
 void Initialize(int* argc, char** argv, void (*HelperPrintf)()) {
+  internal::HelperPrintf = HelperPrintf;
   internal::ParseCommandLineFlags(argc, argv);
   internal::LogLevel() = FLAGS_v;
-  internal::HelperPrintf = HelperPrintf;
 }
 
 void Shutdown() { delete internal::global_context; }


### PR DESCRIPTION
```sh
$ g++ bench.cpp -g -lbenchmark -std=c++17 -Og                                                                                          
$ ./a.out --help                                                                                                                       
zsh: segmentation fault (core dumped)  ./a.out --help
$ valgrind ./a.out --help                     
==6541== Memcheck, a memory error detector
==6541== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==6541== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==6541== Command: ./a.out --help
==6541== 
==6541== Jump to the invalid address stated on the next line
==6541==    at 0x0: ???
==6541==    by 0x48901DB: ??? (in /usr/lib/libbenchmark.so.1.6.2)
==6541==    by 0x4894C06: benchmark::Initialize(int*, char**, void (*)()) (in /usr/lib/libbenchmark.so.1.6.2)
==6541==    by 0x10A35A: main (bench.cpp:178)
==6541==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==6541== 
==6541== 
==6541== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==6541==  Bad permissions for mapped region at address 0x0
==6541==    at 0x0: ???
==6541==    by 0x48901DB: ??? (in /usr/lib/libbenchmark.so.1.6.2)
==6541==    by 0x4894C06: benchmark::Initialize(int*, char**, void (*)()) (in /usr/lib/libbenchmark.so.1.6.2)
==6541==    by 0x10A35A: main (bench.cpp:178)
...
```
HelperPrintf function pointer is called before assigning proper value causing null pointer dereference when `--help` flag is used.
This one-line patch fixes this. Bug was introduced by https://github.com/google/benchmark/commit/4136c4a3c57a3d1d5385da6d08fa4438fc352b75 commit and is present in 1.6.2 release