### PR TITLE
Remove stray comment and added missing header

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -29,7 +29,7 @@ cc_library(
     ),
     hdrs = [
         "include/benchmark/benchmark.h",
-        "include/benchmark/export.h", # From generate_export_header
+        "include/benchmark/export.h",
     ],
     linkopts = select({
         ":windows": ["-DEFAULTLIB:shlwapi.lib"],
@@ -47,7 +47,7 @@ cc_library(
 cc_library(
     name = "benchmark_main",
     srcs = ["src/benchmark_main.cc"],
-    hdrs = ["include/benchmark/benchmark.h"],
+    hdrs = ["include/benchmark/benchmark.h", "include/benchmark/export.h"],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [":benchmark"],


### PR DESCRIPTION
- The export.h is no longer generated, so removed the comment.
- Added export.h to benchmark_main