### PR TITLE
Fixed linker issue

### DIFF
--- a/src/check.h
+++ b/src/check.h
@@ -9,12 +9,18 @@
 #include "internal_macros.h"
 #include "log.h"
 
+#if defined(_WIN32)
+#define WEAK_ATTR __declspec(selectany)
+#else
+#define WEAK_ATTR __attribute__((weak))
+#endif
+
 namespace benchmark {
 namespace internal {
 
 typedef void(AbortHandlerT)();
 
-BENCHMARK_EXPORT
+BENCHMARK_EXPORT WEAK_ATTR
 AbortHandlerT*& GetAbortHandler();
 
 BENCHMARK_NORETURN inline void CallAbortHandler() {


### PR DESCRIPTION
Since GetAbortHandler is no longer inline, we're now getting a missing definition from the linker in our internal build.
Added the weak-attr to resolve this.

Error:
```
ld: error: undefined reference due to --no-allow-shlib-undefined
```