### PR TITLE
Explicitly cast int literals to int8_t in tests to silence implicit-conversion warnings

### DIFF
--- a/test/benchmark_gtest.cc
+++ b/test/benchmark_gtest.cc
@@ -167,4 +167,3 @@ TEST(AddCustomContext, DuplicateKey) {
 }  // namespace
 }  // namespace internal
 }  // namespace benchmark
-

--- a/test/benchmark_gtest.cc
+++ b/test/benchmark_gtest.cc
@@ -5,7 +5,6 @@
 #include "../src/benchmark_register.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-
 namespace benchmark {
 namespace internal {
 
@@ -37,8 +36,9 @@ TEST(AddRangeTest, Advanced64) {
 
 TEST(AddRangeTest, FullRange8) {
   std::vector<int8_t> dst;
-  AddRange(&dst, int8_t{1}, std::numeric_limits<int8_t>::max(), 8);
-  EXPECT_THAT(dst, testing::ElementsAre(1, 8, 64, 127));
+  AddRange(&dst, int8_t{1}, std::numeric_limits<int8_t>::max(), int8_t{8});
+  EXPECT_THAT(
+      dst, testing::ElementsAre(int8_t{1}, int8_t{8}, int8_t{64}, int8_t{127}));
 }
 
 TEST(AddRangeTest, FullRange64) {
@@ -128,8 +128,9 @@ TEST(AddRangeTest, FullNegativeRange64) {
 
 TEST(AddRangeTest, Simple8) {
   std::vector<int8_t> dst;
-  AddRange<int8_t>(&dst, 1, 8, 2);
-  EXPECT_THAT(dst, testing::ElementsAre(1, 2, 4, 8));
+  AddRange<int8_t>(&dst, int8_t{1}, int8_t{8}, int8_t{2});
+  EXPECT_THAT(dst,
+              testing::ElementsAre(int8_t{1}, int8_t{2}, int8_t{4}, int8_t{8}));
 }
 
 TEST(AddCustomContext, Simple) {
@@ -166,3 +167,4 @@ TEST(AddCustomContext, DuplicateKey) {
 }  // namespace
 }  // namespace internal
 }  // namespace benchmark
+

--- a/test/benchmark_gtest.cc
+++ b/test/benchmark_gtest.cc
@@ -5,6 +5,7 @@
 #include "../src/benchmark_register.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
 namespace benchmark {
 namespace internal {
 


### PR DESCRIPTION


Error came from:
```
: error: implicit conversion loses integer precision: 'const int' to 'const signed char' [-Werror,-Wimplicit-int-conversion]
```