### PR TITLE
run ClearRegisteredBenchmarks at exit

### DIFF
--- a/bindings/python/google_benchmark/__init__.py
+++ b/bindings/python/google_benchmark/__init__.py
@@ -26,6 +26,7 @@ Example usage:
   if __name__ == '__main__':
     benchmark.main()
 """
+import atexit
 
 from absl import app
 from google_benchmark import _benchmark
@@ -158,3 +159,4 @@ def main(argv=None):
 # Methods for use with custom main function.
 initialize = _benchmark.Initialize
 run_benchmarks = _benchmark.RunSpecifiedBenchmarks
+atexit.register(_benchmark.ClearRegisteredBenchmarks)

--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -179,5 +179,6 @@ PYBIND11_MODULE(_benchmark, m) {
         py::return_value_policy::reference);
   m.def("RunSpecifiedBenchmarks",
         []() { benchmark::RunSpecifiedBenchmarks(); });
+  m.def("ClearRegisteredBenchmarks", benchmark::ClearRegisteredBenchmarks);
 };
 }  // namespace


### PR DESCRIPTION
We have to clear the registered benchmarks from a Python thread because they hold references to Python objects via lambda callbacks. If we skip this step, we might accidentally attempt to decrease reference counts on Python objects in the C exit handler after the interpreter was shut down. 
