### PR TITLE
Fix link error when use as static library on windows.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
 endif()
 
 if (NOT BUILD_SHARED_LIBS)
-  target_compile_definitions(benchmark PRIVATE -DBENCHMARK_STATIC_DEFINE)
+  target_compile_definitions(benchmark PUBLIC -DBENCHMARK_STATIC_DEFINE)
 endif()
 
 # Benchmark main library


### PR DESCRIPTION
When we use static library on windows, we should define BENCHMARK_STATIC_DEFINE in places where user library.