### PR TITLE
Enable aarch64 Linux wheel builds, use cibuildwheel action directly

### DIFF
--- a/.github/install_bazel.sh
+++ b/.github/install_bazel.sh
@@ -1,0 +1,13 @@
+if ! bazel version; then
+  arch=$(uname -m)
+  if [ "$arch" == "aarch64" ]; then
+    arch="arm64"
+  fi
+  echo "Installing wget and downloading $arch Bazel binary from GitHub releases."
+  yum install -y wget
+  wget "https://github.com/bazelbuild/bazel/releases/download/5.2.0/bazel-5.2.0-linux-$arch" -O /usr/local/bin/bazel
+  chmod +x /usr/local/bin/bazel
+else
+  # bazel is installed for the correct architecture
+  exit 0
+fi

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -39,27 +39,23 @@ jobs:
       - name: Check out Google Benchmark
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
         with:
-          python-version: 3.9
+          platforms: all
 
-      - name: Install and run cibuildwheel on ${{ matrix.os }}
+      - name: Build wheels on ${{ matrix.os }} using cibuildwheel
+        uses: pypa/cibuildwheel@v2.9.0
         env:
           CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'
           CIBW_SKIP: "cp37-*-arm64 *-musllinux_*"
-          # TODO: Build ppc64le, aarch64 using some other trick
-          CIBW_ARCHS_LINUX: x86_64
+          # TODO: Build ppc64le using some other trick
+          CIBW_ARCHS_LINUX: x86_64 aarch64
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_WINDOWS: AMD64
-          CIBW_BEFORE_ALL_LINUX: >
-            curl -O --retry-delay 5 --retry 5 https://copr.fedorainfracloud.org/coprs/vbatts/bazel/repo/epel-7/vbatts-bazel-epel-7.repo &&
-            cp vbatts-bazel-epel-7.repo /etc/yum.repos.d/bazel.repo &&
-            yum install -y bazel4
+          CIBW_BEFORE_ALL_LINUX: bash .github/install_bazel.sh
           CIBW_TEST_COMMAND: python {project}/bindings/python/google_benchmark/example.py
-        run: |
-          pip install cibuildwheel
-          python -m cibuildwheel --output-dir wheelhouse
 
       - name: Upload Google Benchmark ${{ matrix.os }} wheels
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This commit enables arm64 Linux wheel builds for Python. It also changes the build procedure on Linux using
cibuildwheel in GitHub Actions. Instead of the more granular, verbose approach that was used until now, we opt for the GitHub Action released by cibuildwheel directly.

We also change the Bazel install procedure in the manylinux Docker container image. Previously, Bazel was installed from an added RHEL repo, since that is the recommended official way of installing Bazel on CentOS platforms.
However, the last successful build available for manylinux2014 has been Bazel 4, which is showing its age with the release of Bazel 6 coming up as of this commit.

After this change, prebuilt Bazel binaries are downloaded using wget directly from the Bazel GitHub release page. Since Bazel is built for both x86 and arm64 on Linux, we immediately gain wheel build support for these architectures. However, since the architecture of the manylinux image is aarch64 instead of arm64, a shell script was added that normalizes aarch64 to arm64, and installs the correct arm64 Bazel binary if necessary.