### PR TITLE
use CMAKE_INSTALL_FULL in pkg-config file (fixes nix package)

### DIFF
--- a/cmake/benchmark.pc.in
+++ b/cmake/benchmark.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: Google microbenchmark framework


### PR DESCRIPTION
CMAKE_INSTALL_LIBDIR/INCLUDEDIR can be and are absolute paths when being built by nix which causes the absolute path to the lib and include dirs being appended to the absolute prefix path which completely breaks the pkg-config file. 
```
babbaj@nixos:~ ❯ nix build nixpkgs#gbenchmark
babbaj@nixos:~ ❯ cat result/lib/pkgconfig/benchmark.pc
prefix=/nix/store/yf25swipsphj343waql8pf2qszg65wjs-gbenchmark-1.6.1
exec_prefix=${prefix}
libdir=${prefix}//nix/store/yf25swipsphj343waql8pf2qszg65wjs-gbenchmark-1.6.1/lib
includedir=${prefix}//nix/store/yf25swipsphj343waql8pf2qszg65wjs-gbenchmark-1.6.1/include

Name: benchmark
Description: Google microbenchmark framework
Version: 1.6.1

Libs: -L${libdir} -lbenchmark
Libs.private: -lpthread
Cflags: -I${includedir}
```
[CMAKE_INSTALL_FULL](https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html) dirs are documented at being the same as CMAKE_INSTALL dirs except prefixed with the CMAKE_INSTALL_PREFIX only if necessary to make them absolute paths.