### PR TITLE
Bump pybind11 version to enable Python 3.11 wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build wheels on ${{ matrix.os }} using cibuildwheel
         uses: pypa/cibuildwheel@v2.9.0
         env:
-          CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'
+          CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-* cp311-*'
           CIBW_SKIP: "cp37-*-arm64 *-musllinux_*"
           # TODO: Build ppc64le using some other trick
           CIBW_ARCHS_LINUX: x86_64 aarch64

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,9 +19,9 @@ git_repository(
 http_archive(
     name = "pybind11",
     build_file = "@//bindings/python:pybind11.BUILD",
-    sha256 = "1eed57bc6863190e35637290f97a20c81cfe4d9090ac0a24f3bbf08f265eb71d",
-    strip_prefix = "pybind11-2.4.3",
-    urls = ["https://github.com/pybind/pybind11/archive/v2.4.3.tar.gz"],
+    sha256 = "eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec",
+    strip_prefix = "pybind11-2.10.0",
+    urls = ["https://github.com/pybind/pybind11/archive/v2.10.0.tar.gz"],
 )
 
 new_local_repository(


### PR DESCRIPTION
This commit bumps the pybind11 version to 2.10.0, which is the first pybind version coming with Python 3.11 support. This change is necessary to facilitate wheel builds for Python 3.11 and upward, as changes to Python internals in 3.11 broke compatibility with older pybind11 versions.

Fixes #1476.
