### PR TITLE
Do not depend on unversioned python binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,7 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 add_subdirectory(src)
 
 if (BENCHMARK_ENABLE_TESTING)
+  find_package(Python3 3.6 REQUIRED COMPONENTS Interpreter)
   enable_testing()
   if (BENCHMARK_ENABLE_GTEST_TESTS AND
       NOT (TARGET gtest AND TARGET gtest_main AND

--- a/test/AssemblyTests.cmake
+++ b/test/AssemblyTests.cmake
@@ -47,7 +47,7 @@ macro(add_filecheck_test name)
   set_target_properties(${name} PROPERTIES COMPILE_FLAGS "-S ${ASM_TEST_FLAGS}")
   set(ASM_OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/${name}.s")
   add_custom_target(copy_${name} ALL
-      COMMAND ${PROJECT_SOURCE_DIR}/tools/strip_asm.py
+      COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/strip_asm.py
         $<TARGET_OBJECTS:${name}>
         ${ASM_OUTPUT_FILE}
       BYPRODUCTS ${ASM_OUTPUT_FILE})

--- a/tools/compare.py
+++ b/tools/compare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import unittest
 """

--- a/tools/strip_asm.py
+++ b/tools/strip_asm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 strip_asm.py - Cleanup ASM output for the specified file


### PR DESCRIPTION
Some linux distributions no longer provide `python` binary and require usage of `python3` instead. This changes the scripts here and uses cmake `find_package(Python3` when running python.