### PR TITLE
Partially revert "Do not depend on unversioned python binary (#1496)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,6 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 add_subdirectory(src)
 
 if (BENCHMARK_ENABLE_TESTING)
-  find_package(Python3 3.6 REQUIRED COMPONENTS Interpreter)
   enable_testing()
   if (BENCHMARK_ENABLE_GTEST_TESTS AND
       NOT (TARGET gtest AND TARGET gtest_main AND

--- a/test/AssemblyTests.cmake
+++ b/test/AssemblyTests.cmake
@@ -47,7 +47,7 @@ macro(add_filecheck_test name)
   set_target_properties(${name} PROPERTIES COMPILE_FLAGS "-S ${ASM_TEST_FLAGS}")
   set(ASM_OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/${name}.s")
   add_custom_target(copy_${name} ALL
-      COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/strip_asm.py
+      COMMAND ${PROJECT_SOURCE_DIR}/tools/strip_asm.py
         $<TARGET_OBJECTS:${name}>
         ${ASM_OUTPUT_FILE}
       BYPRODUCTS ${ASM_OUTPUT_FILE})


### PR DESCRIPTION
As predicted, the cmake part of the change is contentious. https://github.com/google/benchmark/pull/1496#issuecomment-1276508266

This partially reverts commit 229bc5a93729d72b97a77759b2ba991008c4e330.