### PR TITLE
Fixes incorrect wide string conversion on win32

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -423,15 +423,12 @@ std::string GetSystemName() {
 #ifndef UNICODE
   str = std::string(hostname, DWCOUNT);
 #else
+  // `WideCharToMultiByte` returns `0` when conversion fails.
   int len = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, hostname,
                                 DWCOUNT, NULL, 0, NULL, NULL);
-  // TODO: Report error from GetLastError()?
-  if (len == 0) return std::string("");
   str.resize(len);
   WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, hostname, DWCOUNT, &str[0],
-                      len, NULL, NULL);
-  // TODO: Report error from GetLastError()?
-  if (len == 0) return std::string("");
+                      str.size(), NULL, NULL);
 #endif
   return str;
 #elif defined(BENCHMARK_OS_QURT)

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -423,19 +423,15 @@ std::string GetSystemName() {
 #ifndef UNICODE
   str = std::string(hostname, DWCOUNT);
 #else
-  std::vector<wchar_t> converted;
-  // Find the length first.
-  int len = ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, hostname,
-                                  DWCOUNT, converted.begin(), 0);
+  int len = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, hostname,
+                                DWCOUNT, NULL, 0, NULL, NULL);
   // TODO: Report error from GetLastError()?
   if (len == 0) return std::string("");
-  converted.reserve(len + 1);
-
-  len = ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, hostname, DWCOUNT,
-                              converted.begin(), converted.size());
+  str.resize(len);
+  WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, hostname, DWCOUNT, &str[0],
+                      len, NULL, NULL);
   // TODO: Report error from GetLastError()?
   if (len == 0) return std::string("");
-  str = std::string(converted.data());
 #endif
   return str;
 #elif defined(BENCHMARK_OS_QURT)


### PR DESCRIPTION
Fixes issue #1515 that I reported.

The PR this fixes incorrectly tried to convert an existing wide string (`GetComputerName` returns a wide string when building with `UNICODE`) into another wide string (`std::vector<wchar_t> converted` specifically), and then tried to simply initialize an `std::string` with a `wchar_t*`.

I preserved the error handling from the original code (ignoring the error and just returning nothing). Depending on your affinity to exceptions, that PR originally replaced `std::wstring_convert` which would throw an `std::range_error`. I'm happy to preserve that behaviour.

I locally ran this to verify the output, feel free to test this more rigorously.