### PR TITLE
remove best effort support for ubuntu 18.04

### DIFF
--- a/.github/workflows/build-and-test-perfcounters.yml
+++ b/.github/workflows/build-and-test-perfcounters.yml
@@ -14,20 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # ubuntu-18.04 is deprecated but included for best-effort
-        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-22.04, ubuntu-20.04]
         build_type: ['Release', 'Debug']
     steps:
     - uses: actions/checkout@v2
 
     - name: install libpfm
       run: sudo apt -y install libpfm4-dev
-
-    - name: setup cmake
-      if: matrix.os == 'ubuntu-18.04'
-      uses: jwlawson/actions-setup-cmake@v1.9
-      with:
-        cmake-version: '3.16.3'
 
     - name: create build environment
       run: cmake -E make_directory ${{ runner.workspace }}/_build

--- a/.github/workflows/build-and-test-perfcounters.yml
+++ b/.github/workflows/build-and-test-perfcounters.yml
@@ -20,7 +20,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: install libpfm
-      run: sudo apt -y install libpfm4-dev
+      run: |
+        sudo apt update
+        sudo apt -y install libpfm4-dev
 
     - name: create build environment
       run: cmake -E make_directory ${{ runner.workspace }}/_build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,20 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # ubuntu-18.04 is deprecated but included for best-effort support
-        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-latest]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-latest]
         build_type: ['Release', 'Debug']
         compiler: [g++, clang++]
         lib: ['shared', 'static']
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: setup cmake
-        if: matrix.os == 'ubuntu-18.04'
-        uses: jwlawson/actions-setup-cmake@v1.9
-        with:
-          cmake-version: '3.16.3'
 
       - name: create build environment
         run: cmake -E make_directory ${{ runner.workspace }}/_build

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -9,12 +9,9 @@ still allow forward progress, we require any build tooling to be available for:
 Currently, this means using build tool versions that are available for Ubuntu
 Ubuntu 20.04 (Focal Fossa), Ubuntu 22.04 (Jammy Jellyfish) and Debian 11.4 (bullseye).
 
-_Note, CI also runs ubuntu-18.04 to attempt best effort support for older versions._
-
 ## cmake
 The current supported version is cmake 3.16.3 as of 2022-08-10.
 
-* _3.10.2 (ubuntu 18.04)_
 * 3.16.3 (ubuntu 20.04)
 * 3.18.4 (debian 11.4)
 * 3.22.1 (ubuntu 22.04)


### PR DESCRIPTION
as of 2022-01-12, github removed support for ubuntu-18.04.  as such, we are removing it from github actions and no longer will support it actively.

it was already "best effort" but time marches on.