### PR TITLE
Removing warnings appearing with C++20 / CLang 15

### DIFF
--- a/test/benchmark_min_time_flag_iters_test.cc
+++ b/test/benchmark_min_time_flag_iters_test.cc
@@ -13,13 +13,15 @@ namespace {
 
 class TestReporter : public benchmark::ConsoleReporter {
  public:
+  using benchmark::Counter::IterationCount IterationCount;
+
   virtual bool ReportContext(const Context& context) BENCHMARK_OVERRIDE {
     return ConsoleReporter::ReportContext(context);
   };
 
   virtual void ReportRuns(const std::vector<Run>& report) BENCHMARK_OVERRIDE {
     assert(report.size() == 1);
-    iter_nums_.push_back(static_cast<int>(report[0].iterations));
+    iter_nums_.push_back(report[0].iterations);
     ConsoleReporter::ReportRuns(report);
   };
 
@@ -27,10 +29,10 @@ class TestReporter : public benchmark::ConsoleReporter {
 
   virtual ~TestReporter() {}
 
-  const std::vector<int>& GetIters() const { return iter_nums_; }
+  const std::vector<IterationCount>& GetIters() const { return iter_nums_; }
 
  private:
-  std::vector<int> iter_nums_;
+  std::vector<IterationCount> iter_nums_;
 };
 
 }  // end namespace

--- a/test/benchmark_min_time_flag_iters_test.cc
+++ b/test/benchmark_min_time_flag_iters_test.cc
@@ -27,7 +27,9 @@ class TestReporter : public benchmark::ConsoleReporter {
 
   virtual ~TestReporter() {}
 
-  const std::vector<benchmark::IterationCount>& GetIters() const { return iter_nums_; }
+  const std::vector<benchmark::IterationCount>& GetIters() const {
+    return iter_nums_;
+  }
 
  private:
   std::vector<benchmark::IterationCount> iter_nums_;

--- a/test/benchmark_min_time_flag_iters_test.cc
+++ b/test/benchmark_min_time_flag_iters_test.cc
@@ -19,7 +19,7 @@ class TestReporter : public benchmark::ConsoleReporter {
 
   virtual void ReportRuns(const std::vector<Run>& report) BENCHMARK_OVERRIDE {
     assert(report.size() == 1);
-    iter_nums_.push_back(report[0].iterations);
+    iter_nums_.push_back(static_cast<int>(report[0].iterations));
     ConsoleReporter::ReportRuns(report);
   };
 

--- a/test/benchmark_min_time_flag_iters_test.cc
+++ b/test/benchmark_min_time_flag_iters_test.cc
@@ -13,8 +13,6 @@ namespace {
 
 class TestReporter : public benchmark::ConsoleReporter {
  public:
-  using benchmark::Counter::IterationCount IterationCount;
-
   virtual bool ReportContext(const Context& context) BENCHMARK_OVERRIDE {
     return ConsoleReporter::ReportContext(context);
   };
@@ -29,10 +27,10 @@ class TestReporter : public benchmark::ConsoleReporter {
 
   virtual ~TestReporter() {}
 
-  const std::vector<IterationCount>& GetIters() const { return iter_nums_; }
+  const std::vector<benchmark::IterationCount>& GetIters() const { return iter_nums_; }
 
  private:
-  std::vector<IterationCount> iter_nums_;
+  std::vector<benchmark::IterationCount> iter_nums_;
 };
 
 }  // end namespace

--- a/test/benchmark_min_time_flag_iters_test.cc
+++ b/test/benchmark_min_time_flag_iters_test.cc
@@ -58,7 +58,7 @@ int main(int argc, char** argv) {
   assert(returned_count == 1);
 
   // Check the executed iters.
-  const std::vector<int> iters = test_reporter.GetIters();
+  const std::vector<benchmark::IterationCount> iters = test_reporter.GetIters();
   assert(!iters.empty() && iters[0] == 4);
 
   delete[] fake_argv;

--- a/test/benchmark_min_time_flag_time_test.cc
+++ b/test/benchmark_min_time_flag_time_test.cc
@@ -28,8 +28,8 @@ class TestReporter : public benchmark::ConsoleReporter {
     ConsoleReporter::ReportRuns(report);
   };
 
-  virtual void ReportRunsConfig(double min_time, bool has_explicit_iters,
-                                IterationCount iters) BENCHMARK_OVERRIDE {
+  virtual void ReportRunsConfig(double min_time, bool /* has_explicit_iters */,
+                                IterationCount /* iters */) BENCHMARK_OVERRIDE {
     min_times_.push_back(min_time);
   }
 


### PR DESCRIPTION
```
[ 70%] Building CXX object _deps/benchmark-build/test/CMakeFiles/benchmark_min_time_flag_time_test.dir/benchmark_min_time_flag_time_test.cc.o
/home/xxx/cpp/_deps/benchmark-src/test/benchmark_min_time_flag_time_test.cc:31:55: warning: unused parameter 'has_explicit_iters' [-Wunused-parameter]
  virtual void ReportRunsConfig(double min_time, bool has_explicit_iters,
                                                      ^
/home/xxx/cpp/_deps/benchmark-src/test/benchmark_min_time_flag_time_test.cc:32:48: warning: unused parameter 'iters' [-Wunused-parameter]
                                IterationCount iters) BENCHMARK_OVERRIDE {
                                               ^
2 warnings generated.
```

```
[ 70%] Building CXX object _deps/benchmark-build/test/CMakeFiles/benchmark_min_time_flag_iters_test.dir/benchmark_min_time_flag_iters_test.cc.o
/home/xxx/cpp/_deps/benchmark-src/test/benchmark_min_time_flag_iters_test.cc:22:36: warning: implicit conversion loses integer precision: 'const benchmark::IterationCount' (aka 'const long') to 'std::vector<int>::value_type' (aka 'int') [-Wshorten-64-to-32]
    iter_nums_.push_back(report[0].iterations);
               ~~~~~~~~~ ~~~~~~~~~~^~~~~~~~~~
1 warning generated.
```