### PR TITLE
cleanup: support CMake >= 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,5 @@
-cmake_minimum_required (VERSION 3.16.3)
-
-foreach(p
-    CMP0048 # OK to clear PROJECT_VERSION on project()
-    CMP0054 # CMake 3.1
-    CMP0056 # export EXE_LINKER_FLAGS to try_run
-    CMP0057 # Support no if() IN_LIST operator
-    CMP0063 # Honor visibility properties for all targets
-    CMP0067 # Honor language standard in try_compile() source file signature
-    CMP0077 # Allow option() overrides in importing projects
-    )
-  if(POLICY ${p})
-    cmake_policy(SET ${p} NEW)
-  endif()
-endforeach()
+# Require CMake 3.10. If available, use the policies up to CMake 3.22.
+cmake_minimum_required (VERSION 3.10...3.22)
 
 project (benchmark VERSION 1.7.1 LANGUAGES CXX)
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,7 +1,7 @@
 # Build tool dependency policy
 
-We follow the [Foundational C++ support policy] for our build tools. In
-particular the "Build Systems" [section].
+We follow the [Foundational C++ support policy](https://opensource.google/documentation/policies/cplusplus-support) for our build tools. In
+particular the ["Build Systems" section](https://opensource.google/documentation/policies/cplusplus-support#build-systems).
 
 ## CMake
 
@@ -11,6 +11,3 @@ distributions include newer versions, for example:
 * Ubuntu 20.04 provides CMake 3.16.3
 * Debian 11.4 provides CMake 3.18.4
 * Ubuntu 22.04 provides CMake 3.22.1
-
-[Foundational C++ support policy]: https://opensource.google/documentation/policies/cplusplus-support
-[Foundational C++ support policy]: https://opensource.google/documentation/policies/cplusplus-support#build-systems

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,18 +1,16 @@
 # Build tool dependency policy
 
-To ensure the broadest compatibility when building the benchmark library, but
-still allow forward progress, we require any build tooling to be available for:
+We follow the [Foundational C++ support policy] for our build tools. In
+particular the "Build Systems" [section].
 
-* Debian stable _and_
-* The last two Ubuntu LTS releases
+## CMake
 
-Currently, this means using build tool versions that are available for Ubuntu
-Ubuntu 20.04 (Focal Fossa), Ubuntu 22.04 (Jammy Jellyfish) and Debian 11.4 (bullseye).
+The current supported version is CMake 3.10 as of 2023-08-10. Most modern
+distributions include newer versions, for example:
 
-## cmake
-The current supported version is cmake 3.16.3 as of 2022-08-10.
+* Ubuntu 20.04 provides CMake 3.16.3
+* Debian 11.4 provides CMake 3.18.4
+* Ubuntu 22.04 provides CMake 3.22.1
 
-* 3.16.3 (ubuntu 20.04)
-* 3.18.4 (debian 11.4)
-* 3.22.1 (ubuntu 22.04)
-
+[Foundational C++ support policy]: https://opensource.google/documentation/policies/cplusplus-support
+[Foundational C++ support policy]: https://opensource.google/documentation/policies/cplusplus-support#build-systems


### PR DESCRIPTION
This aligns the project with the CMake support policies in:

https://opensource.google/documentation/policies/cplusplus-support

I also simplied the management of CMake policies. Most of the overriden policies (anything <= CMP0067) are enabled by default when you require CMake >= 3.10.  But it is easier to just declare that you will accept newer policies when they are available using the `...3.22` notation.

Part of the work for #1509 