### PR TITLE
Add missing parentheses in ParseBenchMinTime()

### DIFF
--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -206,10 +206,10 @@ BenchTimeType ParseBenchMinTime(const std::string& value) {
   errno = 0;
   double min_time = std::strtod(time_str, &p_end);
 
-  // After a successfull parse, p_end should point to the suffix 's'
-  // or the end of the string, if the suffix was omitted.
+  // After a successful parse, p_end should point to the suffix 's',
+  // or the end of the string if the suffix was omitted.
   BM_CHECK(errno == 0 && p_end != nullptr &&
-           (has_suffix && *p_end == 's' || *p_end == '\0'))
+           ((has_suffix && *p_end == 's') || *p_end == '\0'))
       << "Malformed seconds value passed to --benchmark_min_time: `" << value
       << "`. Expected --benchmark_min_time=<float>x.";
 


### PR DESCRIPTION
The previous code was triggering a warning in Debug builds where `NDEBUG` is not defined and `BM_CHECK()` is included:

```
  benchmark/src/benchmark_runner.cc: In function ‘benchmark::internal::BenchTimeType benchmark::internal::ParseBenchMinTime(const std::string&)’:
  benchmark/src/benchmark_runner.cc:212:24: error: suggest parentheses around ‘&&’ within ‘||’ [-Werror=parentheses]
    212 |            (has_suffix && *p_end == 's' || *p_end == '\0'))
        |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~
  benchmark/src/check.h:82:4: note: in definition of macro ‘BM_CHECK’
     82 |   (b ? ::benchmark::internal::GetNullLogInstance()                           \
        |    ^
```

Add parenthesis around the `&&` expression.

Also fix a spelling error and move the comma in the preceding comment to improve clarity.

Tested:
- `cmake -E make_directory build`
- `cmake -E chdir "build" cmake -DBENCHMARK_DOWNLOAD_DEPENDENCIES=on -DCMAKE_BUILD_TYPE=Debug ../`
- `cmake --build "build" --config Debug`
- `cmake -E chdir "build" ctest --build-config Debug`