### PR TITLE
add compiler to build-and-test and create min-cmake CI bot

### DIFF
--- a/.github/workflows/build-and-test-min-cmake.yml
+++ b/.github/workflows/build-and-test-min-cmake.yml
@@ -55,17 +55,13 @@ jobs:
       fail-fast: false
       matrix:
         msvc:
-          - VS-16-2019
-          - VS-17-2022
+          - VS-15-2017
         arch:
           - x64
         include:
-          - msvc: VS-16-2019
-            os: windows-2019
-            generator: 'Visual Studio 16 2019'
-          - msvc: VS-17-2022
-            os: windows-2022
-            generator: 'Visual Studio 17 2022'
+          - msvc: VS-15-2017
+            os: windows-2017
+            generator: 'Visual Studio 15 2017'
 
     steps:
       - uses: actions/checkout@v2
@@ -83,5 +79,4 @@ jobs:
 
       - name: build
         run: cmake --build _build/
-
 

--- a/.github/workflows/build-and-test-min-cmake.yml
+++ b/.github/workflows/build-and-test-min-cmake.yml
@@ -1,0 +1,87 @@
+name: build-and-test-min-cmake
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  job:
+    name: ${{ matrix.os }}.min-cmake
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: 3.10.0
+
+      - name: create build environment
+        run: cmake -E make_directory ${{ runner.workspace }}/_build
+
+      - name: setup cmake initial cache
+        run: touch compiler-cache.cmake
+
+      - name: configure cmake
+        env:
+          CXX: ${{ matrix.compiler }}
+        shell: bash
+        working-directory: ${{ runner.workspace }}/_build
+        run: >
+          cmake -C ${{ github.workspace }}/compiler-cache.cmake
+          $GITHUB_WORKSPACE
+          -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+          -DCMAKE_CXX_VISIBILITY_PRESET=hidden
+          -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON
+
+      - name: build
+        shell: bash
+        working-directory: ${{ runner.workspace }}/_build
+        run: cmake --build .
+
+  msvc:
+    name: ${{ matrix.os }}.${{ matrix.msvc }}.min-cmake
+    runs-on: ${{ matrix.os }}
+    defaults:
+        run:
+            shell: powershell
+    strategy:
+      fail-fast: false
+      matrix:
+        msvc:
+          - VS-16-2019
+          - VS-17-2022
+        arch:
+          - x64
+        include:
+          - msvc: VS-16-2019
+            os: windows-2019
+            generator: 'Visual Studio 16 2019'
+          - msvc: VS-17-2022
+            os: windows-2022
+            generator: 'Visual Studio 17 2022'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: 3.10.0
+
+      - name: configure cmake
+        run: >
+          cmake -S . -B _build/
+          -A ${{ matrix.arch }}
+          -G "${{ matrix.generator }}"
+          -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+
+      - name: build
+        run: cmake --build _build/
+
+

--- a/.github/workflows/build-and-test-min-cmake.yml
+++ b/.github/workflows/build-and-test-min-cmake.yml
@@ -44,39 +44,3 @@ jobs:
         shell: bash
         working-directory: ${{ runner.workspace }}/_build
         run: cmake --build .
-
-  msvc:
-    name: ${{ matrix.os }}.${{ matrix.msvc }}.min-cmake
-    runs-on: ${{ matrix.os }}
-    defaults:
-        run:
-            shell: powershell
-    strategy:
-      fail-fast: false
-      matrix:
-        msvc:
-          - VS-15-2017
-        arch:
-          - x64
-        include:
-          - msvc: VS-15-2017
-            os: windows-2017
-            generator: 'Visual Studio 15 2017'
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: lukka/get-cmake@latest
-        with:
-          cmakeVersion: 3.10.0
-
-      - name: configure cmake
-        run: >
-          cmake -S . -B _build/
-          -A ${{ matrix.arch }}
-          -G "${{ matrix.generator }}"
-          -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
-
-      - name: build
-        run: cmake --build _build/
-

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,33 +19,13 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-latest]
         build_type: ['Release', 'Debug']
-        compiler: ['gcc', 'clang']
+        compiler: ['g++', 'clang++']
         lib: ['shared', 'static']
 
     steps:
       - uses: actions/checkout@v3
 
       - uses: lukka/get-cmake@latest
-
-      - name: setup clang
-        if: matrix.compiler == 'clang'
-        uses: egor-tensin/setup-clang@v1
-        with:
-          version: latest
-          platform: x64
-
-      - name: configure clang
-        if: matrix.compiler == 'clang'
-        run: |
-          echo "CC=cc" >> $GITHUB_ENV
-          echo "CXX=c++" >> $GITHUB_ENV
-
-      - name: configure gcc
-        if: matrix.compiler == 'gcc'
-        run: |
-          sudo apt update && sudo apt -y install gcc-10 g++-10
-          echo "CC=gcc-10" >> $GITHUB_ENV
-          echo "CXX=g++-10" >> $GITHUB_ENV
 
       - name: create build environment
         run: cmake -E make_directory ${{ runner.workspace }}/_build
@@ -64,7 +44,6 @@ jobs:
           -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
           -DBUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-          -DCMAKE_C_COMPILER=${{ env.CC }}
           -DCMAKE_CXX_COMPILER=${{ env.CXX }}
           -DCMAKE_CXX_VISIBILITY_PRESET=hidden
           -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,11 +19,33 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-latest]
         build_type: ['Release', 'Debug']
-        compiler: [g++, clang++]
+        compiler: ['gcc', 'clang']
         lib: ['shared', 'static']
 
     steps:
       - uses: actions/checkout@v3
+
+      - uses: lukka/get-cmake@latest
+
+      - name: setup clang
+        if: matrix.compiler == 'clang'
+        uses: egor-tensin/setup-clang@v1
+        with:
+          version: latest
+          platform: x64
+
+      - name: configure clang
+        if: matrix.compiler == 'clang'
+        run: |
+          echo "CC=cc" >> $GITHUB_ENV
+          echo "CXX=c++" >> $GITHUB_ENV
+
+      - name: configure gcc
+        if: matrix.compiler == 'gcc'
+        run: |
+          sudo apt update && sudo apt -y install gcc-10 g++-10
+          echo "CC=gcc-10" >> $GITHUB_ENV
+          echo "CXX=g++-10" >> $GITHUB_ENV
 
       - name: create build environment
         run: cmake -E make_directory ${{ runner.workspace }}/_build
@@ -42,6 +64,8 @@ jobs:
           -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
           -DBUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DCMAKE_C_COMPILER=${{ env.CC }}
+          -DCMAKE_CXX_COMPILER=${{ env.CXX }}
           -DCMAKE_CXX_VISIBILITY_PRESET=hidden
           -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON
 
@@ -85,6 +109,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - uses: lukka/get-cmake@latest
 
       - name: configure cmake
         run: >


### PR DESCRIPTION
Related to #1544 
Inspired by #1548 

I noticed when adding the new min-cmake CI bot that we didn't actually set the compiler correctly for g++ and clang++ any more.  let's see how much this breaks.