### PR TITLE
Implement unlimited number of performance counters

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ Federico Ficarelli <federico.ficarelli@gmail.com>
 Felix Homann <linuxaudio@showlabor.de>
 Gergő Szitár <szitar.gergo@gmail.com>
 Google Inc.
+Henrique Bucher <hbucher@gmail.com>
 International Business Machines Corporation
 Ismael Jimenez Martinez <ismael.jimenez.martinez@gmail.com>
 Jern-Kuan Leong <jernkuan@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -52,6 +52,7 @@ Felix Homann <linuxaudio@showlabor.de>
 Geoffrey Martin-Noble <gcmn@google.com> <gmngeoffrey@gmail.com>
 Gergő Szitár <szitar.gergo@gmail.com>
 Hannes Hauswedell <h2@fsfe.org>
+Henrique Bucher <hbucher@gmail.com>
 Ismael Jimenez Martinez <ismael.jimenez.martinez@gmail.com>
 Jern-Kuan Leong <jernkuan@gmail.com>
 JianXiong Zhou <zhoujianxiong2@gmail.com>


### PR DESCRIPTION
Linux performance counters will limit the number of hardware counters per reading group. For that reason the implementation of PerfCounters is limited to 3. However if only software counters are added, there is no reason to limit the counters. For hardware counters, we create multiple groups and store a vector or leaders in the PerfCounters object. When reading, there is an extra time waste by iterating through all the group leaders. However this should be the same performance as with today. Reading is done by groups and it had to be heavily adjusted with the logic being moved to PerfCounterValues. I created a test for x86-64 and took care of filtering out the events in case it runs in a platform that does not support those counters - the test will not fail. The current tests were already failing (ReOpenExistingCounters, CreateExistingMeasurements and MultiThreaded) on the main branch and they continue to fail after this implementation - I did not fix those not to conflate all here.