### PR TITLE
Filter performance counter names, not invalidate all

### DIFF
--- a/src/perf_counters.h
+++ b/src/perf_counters.h
@@ -87,6 +87,9 @@ class BENCHMARK_EXPORT PerfCounterValues {
 // called, to obtain the object, until the object's destructor is called.
 class BENCHMARK_EXPORT PerfCounters final {
  public:
+  // A handy type helper
+  using ResultType = std::vector<std::pair<std::string, double>>;
+
   // True iff this platform supports performance counters.
   static const bool kSupported;
 

--- a/src/perf_counters.h
+++ b/src/perf_counters.h
@@ -87,9 +87,6 @@ class BENCHMARK_EXPORT PerfCounterValues {
 // called, to obtain the object, until the object's destructor is called.
 class BENCHMARK_EXPORT PerfCounters final {
  public:
-  // A handy type helper
-  using ResultType = std::vector<std::pair<std::string, double>>;
-
   // True iff this platform supports performance counters.
   static const bool kSupported;
 


### PR DESCRIPTION
Currently, the performance counters are validated while they are being created and one failure returns NoCounters(), ie it effecitvely invalidates all them together.

I would like to propose a new behavior: filter instead. If an invalid name is added to the counter list, or if that particular counter is not supported on this platform, that counter is dropped from the list and an error messages is created, while all the other counters remain active.

This will give testers a peace of mind that if one mistake is made or if something is changed or removed from libpfm, their entire test will not be invalidated. This feature gives more tolerance with respect to versioning.

Another positive is that testers can now input a superset of all desired counters for all platforms they support and just let Benchmark drop all those that are not supported, although it will create quite a lot of noise down the line, in which case perhaps we should drop silently or make a consolidated, single error line but this was not implemented in this change set.