### PR TITLE
Fix failing perf gtests

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -218,6 +218,26 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #define BENCHMARK_UNUSED
 #endif
 
+#if defined(__ICC) || defined(_WIN32)
+// Because of MSVC we had to use this two-macro setup instead of
+// a single function attribute but MSVC does not support them
+#define BENCHMARK_DONT_OPTIMIZE_BEGIN __pragma(optimize("", off));
+#define BENCHMARK_DONT_OPTIMIZE_END __pragma(optimize("", on));
+#elif defined(__clang__)
+// I am afraid that this _Pragma() form although standard might
+// break newer compilers
+#define BENCHMARK_DONT_OPTIMIZE_BEGIN _Pragma("clang optimize off");
+#define BENCHMARK_DONT_OPTIMIZE_END _Pragma("clang optimize on");
+#elif defined(__GNUC__) || defined(__GNUG__)
+#define BENCHMARK_DONT_OPTIMIZE_BEGIN \
+  _Pragma("GCC push_options");        \
+  _Pragma("GCC optimize(\"0\")");
+#define BENCHMARK_DONT_OPTIMIZE_END _Pragma("GCC pop_options");
+#else
+#define BENCHMARK_DONT_OPTIMIZE_BEGIN
+#define BENCHMARK_DONT_OPTIMIZE_END
+#endif
+
 #if defined(__GNUC__) || defined(__clang__)
 #define BENCHMARK_ALWAYS_INLINE __attribute__((always_inline))
 #elif defined(_MSC_VER) && !defined(__clang__)
@@ -586,7 +606,7 @@ class Counter {
   Counter(double v = 0., Flags f = kDefaults, OneK k = kIs1000)
       : value(v), flags(f), oneK(k) {}
 
-  BENCHMARK_ALWAYS_INLINE operator double const &() const { return value; }
+  BENCHMARK_ALWAYS_INLINE operator double const&() const { return value; }
   BENCHMARK_ALWAYS_INLINE operator double&() { return value; }
 };
 

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -218,24 +218,15 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #define BENCHMARK_UNUSED
 #endif
 
-#if defined(__ICC) || defined(_WIN32)
-// Because of MSVC we had to use this two-macro setup instead of
-// a single function attribute but MSVC does not support them
-#define BENCHMARK_DONT_OPTIMIZE_BEGIN __pragma(optimize("", off));
-#define BENCHMARK_DONT_OPTIMIZE_END __pragma(optimize("", on));
-#elif defined(__clang__)
-// I am afraid that this _Pragma() form although standard might
-// break newer compilers
-#define BENCHMARK_DONT_OPTIMIZE_BEGIN _Pragma("clang optimize off");
-#define BENCHMARK_DONT_OPTIMIZE_END _Pragma("clang optimize on");
+// Used to annotate functions, methods and classes so they
+// are not optimized by the compiler. Useful for tests
+// where you expect loops to stay in place churning cycles
+#if defined(__clang__)
+#define BENCHMARK_DONT_OPTIMIZE __attribute__((optnone))
 #elif defined(__GNUC__) || defined(__GNUG__)
-#define BENCHMARK_DONT_OPTIMIZE_BEGIN \
-  _Pragma("GCC push_options");        \
-  _Pragma("GCC optimize(\"0\")");
-#define BENCHMARK_DONT_OPTIMIZE_END _Pragma("GCC pop_options");
+#define BENCHMARK_DONT_OPTIMIZE __attribute__((optimize(0)))
 #else
-#define BENCHMARK_DONT_OPTIMIZE_BEGIN
-#define BENCHMARK_DONT_OPTIMIZE_END
+#define BENCHMARK_DONT_OPTIMIZE
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -348,16 +348,21 @@ void RunBenchmarks(const std::vector<BenchmarkInstance>& benchmarks,
 
     size_t num_repetitions_total = 0;
 
-    auto perfcounters = std::make_shared<PerfCountersMeasurement>(
+    // This perfcounters object needs to be created before the runners vector
+    // below so it outlasts their lifetime.
+    PerfCountersMeasurement perfcounters(
         StrSplit(FLAGS_benchmark_perf_counters, ','));
+
+    // Vector of benchmarks to run
     std::vector<internal::BenchmarkRunner> runners;
     runners.reserve(benchmarks.size());
+
     for (const BenchmarkInstance& benchmark : benchmarks) {
       BenchmarkReporter::PerFamilyRunReports* reports_for_family = nullptr;
       if (benchmark.complexity() != oNone)
         reports_for_family = &per_family_reports[benchmark.family_index()];
 
-      runners.emplace_back(benchmark, perfcounters, reports_for_family);
+      runners.emplace_back(benchmark, &perfcounters, reports_for_family);
       int num_repeats_of_this_instance = runners.back().GetNumRepeats();
       num_repetitions_total += num_repeats_of_this_instance;
       if (reports_for_family)

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -362,10 +362,7 @@ void RunBenchmarks(const std::vector<BenchmarkInstance>& benchmarks,
       BenchmarkReporter::PerFamilyRunReports* reports_for_family = nullptr;
       if (benchmark.complexity() != oNone)
         reports_for_family = &per_family_reports[benchmark.family_index()];
-      if (benchmark.threads() > 0) {
-        benchmarks_with_threads++;
-      }
-
+      benchmarks_with_threads += (benchmark.threads() > 0);
       runners.emplace_back(benchmark, &perfcounters, reports_for_family);
       int num_repeats_of_this_instance = runners.back().GetNumRepeats();
       num_repetitions_total += num_repeats_of_this_instance;

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -348,6 +348,8 @@ void RunBenchmarks(const std::vector<BenchmarkInstance>& benchmarks,
 
     size_t num_repetitions_total = 0;
 
+    auto perfcounters = std::make_shared<PerfCountersMeasurement>(
+        StrSplit(FLAGS_benchmark_perf_counters, ','));
     std::vector<internal::BenchmarkRunner> runners;
     runners.reserve(benchmarks.size());
     for (const BenchmarkInstance& benchmark : benchmarks) {
@@ -355,7 +357,7 @@ void RunBenchmarks(const std::vector<BenchmarkInstance>& benchmarks,
       if (benchmark.complexity() != oNone)
         reports_for_family = &per_family_reports[benchmark.family_index()];
 
-      runners.emplace_back(benchmark, reports_for_family);
+      runners.emplace_back(benchmark, perfcounters, reports_for_family);
       int num_repeats_of_this_instance = runners.back().GetNumRepeats();
       num_repetitions_total += num_repeats_of_this_instance;
       if (reports_for_family)

--- a/src/benchmark_runner.h
+++ b/src/benchmark_runner.h
@@ -58,7 +58,7 @@ BenchTimeType ParseBenchMinTime(const std::string& value);
 class BenchmarkRunner {
  public:
   BenchmarkRunner(const benchmark::internal::BenchmarkInstance& b_,
-                  const std::shared_ptr<PerfCountersMeasurement>& pmc_,
+                  PerfCountersMeasurement* pmc_,
                   BenchmarkReporter::PerFamilyRunReports* reports_for_family);
 
   int GetNumRepeats() const { return repeats; }
@@ -104,7 +104,7 @@ class BenchmarkRunner {
   // So only the first repetition has to find/calculate it,
   // the other repetitions will just use that precomputed iteration count.
 
-  std::shared_ptr<PerfCountersMeasurement> perf_counters_measurement_ptr;
+  PerfCountersMeasurement* perf_counters_measurement_ptr;
 
   struct IterationResults {
     internal::ThreadManager::Result results;

--- a/src/benchmark_runner.h
+++ b/src/benchmark_runner.h
@@ -104,7 +104,7 @@ class BenchmarkRunner {
   // So only the first repetition has to find/calculate it,
   // the other repetitions will just use that precomputed iteration count.
 
-  PerfCountersMeasurement* perf_counters_measurement_ptr;
+  PerfCountersMeasurement* const perf_counters_measurement_ptr = nullptr;
 
   struct IterationResults {
     internal::ThreadManager::Result results;

--- a/src/benchmark_runner.h
+++ b/src/benchmark_runner.h
@@ -58,6 +58,7 @@ BenchTimeType ParseBenchMinTime(const std::string& value);
 class BenchmarkRunner {
  public:
   BenchmarkRunner(const benchmark::internal::BenchmarkInstance& b_,
+                  const std::shared_ptr<PerfCountersMeasurement>& pmc_,
                   BenchmarkReporter::PerFamilyRunReports* reports_for_family);
 
   int GetNumRepeats() const { return repeats; }
@@ -103,8 +104,7 @@ class BenchmarkRunner {
   // So only the first repetition has to find/calculate it,
   // the other repetitions will just use that precomputed iteration count.
 
-  PerfCountersMeasurement perf_counters_measurement;
-  PerfCountersMeasurement* const perf_counters_measurement_ptr;
+  std::shared_ptr<PerfCountersMeasurement> perf_counters_measurement_ptr;
 
   struct IterationResults {
     internal::ThreadManager::Result results;

--- a/src/perf_counters.cc
+++ b/src/perf_counters.cc
@@ -71,7 +71,7 @@ bool PerfCounters::IsCounterSupported(const std::string& name) {
   return (ret == PFM_SUCCESS);
 }
 
-std::shared_ptr<PerfCounters> PerfCounters::Create(
+PerfCounters PerfCounters::Create(
     const std::vector<std::string>& counter_names) {
   if (counter_names.empty()) {
     return NoCounters();
@@ -159,8 +159,8 @@ std::shared_ptr<PerfCounters> PerfCounters::Create(
     }
   }
 
-  return std::shared_ptr<PerfCounters>(new PerfCounters(
-      counter_names, std::move(counter_ids), std::move(leader_ids)));
+  return PerfCounters(counter_names, std::move(counter_ids),
+                      std::move(leader_ids));
 }
 
 void PerfCounters::CloseCounters() const {
@@ -183,7 +183,7 @@ bool PerfCounters::Initialize() { return false; }
 
 bool PerfCounters::IsCounterSupported(const std::string&) { return false; }
 
-std::shared_ptr<PerfCounters> PerfCounters::Create(
+PerfCounters PerfCounters::Create(
     const std::vector<std::string>& counter_names) {
   if (!counter_names.empty()) {
     GetErrorLogInstance() << "Performance counters not supported.";
@@ -194,16 +194,13 @@ std::shared_ptr<PerfCounters> PerfCounters::Create(
 void PerfCounters::CloseCounters() const {}
 #endif  // defined HAVE_LIBPFM
 
-// int PerfCountersMeasurement::ref_count_ = 0;
-// PerfCounters PerfCountersMeasurement::counters_ = PerfCounters::NoCounters();
-
 PerfCountersMeasurement::PerfCountersMeasurement(
     const std::vector<std::string>& counter_names)
     : start_values_(counter_names.size()), end_values_(counter_names.size()) {
   counters_ = PerfCounters::Create(counter_names);
 }
 
-PerfCountersMeasurement::~PerfCountersMeasurement() { counters_.reset(); }
+PerfCountersMeasurement::~PerfCountersMeasurement() {}
 
 PerfCounters& PerfCounters::operator=(PerfCounters&& other) noexcept {
   if (this != &other) {

--- a/src/perf_counters.cc
+++ b/src/perf_counters.cc
@@ -201,8 +201,6 @@ PerfCountersMeasurement::PerfCountersMeasurement(
   counters_ = PerfCounters::Create(counter_names);
 }
 
-PerfCountersMeasurement::~PerfCountersMeasurement() {}
-
 PerfCounters& PerfCounters::operator=(PerfCounters&& other) noexcept {
   if (this != &other) {
     CloseCounters();

--- a/src/perf_counters.cc
+++ b/src/perf_counters.cc
@@ -47,8 +47,9 @@ size_t PerfCounterValues::Read(const std::vector<int>& leaders) {
       size -= data_bytes;
     } else {
       int err = errno;
-      GetErrorLogInstance() << "Error reading lead " << lead << " errno:" << err
-                            << " " << ::strerror(err) << "\n";
+      GetErrorLogInstance()
+          << "PerfCounterValues: error reading fd:" << lead << " errno:" << err
+          << " " << ::strerror(err) << "\n";
       return 0;
     }
   }

--- a/src/perf_counters.h
+++ b/src/perf_counters.h
@@ -153,8 +153,6 @@ class BENCHMARK_EXPORT PerfCounters final {
 class BENCHMARK_EXPORT PerfCountersMeasurement final {
  public:
   PerfCountersMeasurement(const std::vector<std::string>& counter_names);
-  // PerfCountersMeasurement(PerfCountersMeasurement&&) = default;
-  ~PerfCountersMeasurement();
 
   size_t num_counters() const { return counters_.num_counters(); }
 

--- a/src/perf_counters.h
+++ b/src/perf_counters.h
@@ -90,7 +90,7 @@ class BENCHMARK_EXPORT PerfCounters final {
   // True iff this platform supports performance counters.
   static const bool kSupported;
 
-  bool IsValid() const { return !counter_names_.empty(); }
+  bool IsValid() const { return counter_ids_.size() == counter_names_.size(); }
 
   // Returns an empty object
   static PerfCounters NoCounters() { return PerfCounters(); }
@@ -124,7 +124,8 @@ class BENCHMARK_EXPORT PerfCounters final {
 #ifndef BENCHMARK_OS_WINDOWS
     assert(values != nullptr);
     assert(IsValid());
-    return values->Read(leader_ids_) == counter_ids_.size();
+    auto num_read = values->Read(leader_ids_);
+    return (num_read == counter_ids_.size());
 #else
     (void)values;
     return false;
@@ -152,7 +153,7 @@ class BENCHMARK_EXPORT PerfCounters final {
 class BENCHMARK_EXPORT PerfCountersMeasurement final {
  public:
   PerfCountersMeasurement(const std::vector<std::string>& counter_names);
-  PerfCountersMeasurement(PerfCountersMeasurement&&) = default;
+  // PerfCountersMeasurement(PerfCountersMeasurement&&) = default;
   ~PerfCountersMeasurement();
 
   size_t num_counters() const { return counters_.num_counters(); }

--- a/test/perf_counters_gtest.cc
+++ b/test/perf_counters_gtest.cc
@@ -125,12 +125,16 @@ TEST(PerfCountersTest, CreateExistingMeasurements) {
   const int kMinValidCounters = 3;
   const std::vector<std::string> kMetrics{"cycles"};
 
-  std::vector<std::shared_ptr<PerfCountersMeasurement>>
+  // Cannot create a vector of actual objects because the
+  // copy constructor of PerfCounters is deleted - and so is
+  // implicitly deleted on PerfCountersMeasurement too
+  std::vector<std::unique_ptr<PerfCountersMeasurement>>
       perf_counter_measurements;
+
   perf_counter_measurements.reserve(kMaxCounters);
   for (int j = 0; j < kMaxCounters; ++j) {
     perf_counter_measurements.emplace_back(
-        std::make_shared<PerfCountersMeasurement>(kMetrics));
+        new PerfCountersMeasurement(kMetrics));
   }
 
   std::vector<std::pair<std::string, double>> measurements;

--- a/test/perf_counters_gtest.cc
+++ b/test/perf_counters_gtest.cc
@@ -163,21 +163,14 @@ TEST(PerfCountersTest, CreateExistingMeasurements) {
   }
 }
 
-// This probably should go into include/benchmark.h together with
-// BENCHMARK_ALWAYS_INLINE and friends
-#if defined(__clang__)
-#define BENCHMARK_DONT_OPTIMIZE __attribute__((optnone))
-#elif defined(__GNUC__) || defined(__GNUG__)
-#define BENCHMARK_DONT_OPTIMIZE __attribute__((optimize(0)))
-#else
-#define BENCHMARK_DONT_OPTIMIZE
-#endif
-
 // We try to do some meaningful work here but the compiler
 // insists in optimizing away our loop so we had to add a
 // no-optimize macro. In case it fails, we added some entropy
 // to this pool as well.
-BENCHMARK_DONT_OPTIMIZE size_t do_work() {
+
+// Could not get the __pragma(optimize("",off)) to work...
+BENCHMARK_DONT_OPTIMIZE_BEGIN
+size_t do_work() {
   static std::mt19937 rd{std::random_device{}()};
   static std::uniform_int_distribution<size_t> mrand(0, 10);
   const size_t kNumLoops = 1000000;
@@ -188,6 +181,7 @@ BENCHMARK_DONT_OPTIMIZE size_t do_work() {
   benchmark::DoNotOptimize(sum);
   return sum;
 }
+BENCHMARK_DONT_OPTIMIZE_END
 
 void measure(size_t threadcount, PerfCounterValues* before,
              PerfCounterValues* after) {

--- a/test/perf_counters_gtest.cc
+++ b/test/perf_counters_gtest.cc
@@ -175,9 +175,7 @@ TEST(PerfCountersTest, CreateExistingMeasurements) {
 // no-optimize macro. In case it fails, we added some entropy
 // to this pool as well.
 
-// Could not get the __pragma(optimize("",off)) to work...
-BENCHMARK_DONT_OPTIMIZE_BEGIN
-size_t do_work() {
+BENCHMARK_DONT_OPTIMIZE size_t do_work() {
   static std::mt19937 rd{std::random_device{}()};
   static std::uniform_int_distribution<size_t> mrand(0, 10);
   const size_t kNumLoops = 1000000;
@@ -188,7 +186,6 @@ size_t do_work() {
   benchmark::DoNotOptimize(sum);
   return sum;
 }
-BENCHMARK_DONT_OPTIMIZE_END
 
 void measure(size_t threadcount, PerfCounterValues* before,
              PerfCounterValues* after) {


### PR DESCRIPTION
This is more of a *tentative* pull request to understand better the architecture, as I think the changes in this commit are more profound than they should be for just a "test fix".

I cannot understand why the PerfCounters counters_ object inside PerfCounterMeasurement was made static. There is really no reason for that from a perf_event point of view. I am here thinking that the reason for the static is some higher level process/thread issue that I do not familiar with. If so, kindly disregard this pull request.

Once you make that object non-static, the entire architecture simplifies a lot. I created a shared pointer on the off-chance that the static had to do with copy/move semantics and the way the top level class was created.

I could not create that shared pointer with std::make_shared because the relevant PerfCounters constructor is private and std::forward is obviously not a friend class. So we got an extra int malloc there. But I suspect this will have no impact since these objects are so infrequently created.

I did not want to replace the shared_ptr with a unique_ptr since the gain in performance would be really nil and the danger of introducing some move semantics glitch, much higher. Interesting 
enough, what you had there was effectively an intrusive pointer. 

The nice thing is that this shared pointer also acts as a std::optional - in the sense you can query it through its bool operator.

All tests were passing then - apart from the multithreaded in release mode. I had to make sure it stayed there computing for an arbitrary 0.25 seconds until the tests passed. Apparently it was going too fast - or even perhaps the compiler was optimizing away the entire squared sum. It is passing consistently now. I changed a bit the name of the variables there so I could understand better. Hope you do not mind.

If the basics of this pull request are sound, there is more to clean up like do away with the NoCounters() method which only returns an empty shared_ptr at the moment.

Please let me know. Thank you.