### PR TITLE
Correct libpfm dep for integrators.

### DIFF
--- a/bazel/benchmark_deps.bzl
+++ b/bazel/benchmark_deps.bzl
@@ -58,7 +58,7 @@ def benchmark_deps():
         # Downloaded from v4.9.0 tag at https://sourceforge.net/p/perfmon2/libpfm4/ref/master/tags/
         http_archive(
             name = "libpfm",
-            build_file = str(Label("@//tools:libpfm.BUILD.bazel")),
+            build_file = str(Label("//tools:libpfm.BUILD.bazel")),
             sha256 = "5da5f8872bde14b3634c9688d980f68bda28b510268723cc12973eedbab9fecc",
             type = "tar.gz",
             strip_prefix = "libpfm-4.11.0",


### PR DESCRIPTION
This change corrects the label when the macro is called by another repository.