### PR TITLE
Guard NOMINMAX to prevent redefinition error (#1581)

### DIFF
--- a/src/internal_macros.h
+++ b/src/internal_macros.h
@@ -44,7 +44,9 @@
   #define BENCHMARK_OS_WINDOWS 1
   // WINAPI_FAMILY_PARTITION is defined in winapifamily.h.
   // We include windows.h which implicitly includes winapifamily.h for compatibility.
-  #define NOMINMAX
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
   #include <windows.h>
   #if defined(WINAPI_FAMILY_PARTITION)
     #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)


### PR DESCRIPTION
Fix for issue #1581.