### PR TITLE
Remove not needed msan implementation from workflows 

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -21,12 +21,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: configure msan env
-      if: matrix.sanitizer == 'msan'
-      run: |
-        echo "EXTRA_FLAGS=-g -O2 -fno-omit-frame-pointer -fsanitize=memory -fsanitize-memory-track-origins" >> $GITHUB_ENV
-        echo "LIBCXX_SANITIZER=MemoryWithOrigins" >> $GITHUB_ENV
-
     - name: configure ubsan env
       if: matrix.sanitizer == 'ubsan'
       run: |


### PR DESCRIPTION
Hi team, 

As msan is not currently used and probably is not expected to be used in the near future I'm suggesting to remove this build step what will make the pipeline log easier to read and will remove one unneded step. 