### PR TITLE
upgrade python requirements to latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *~
 *.swp
 *.pyc
+*.whl
 __pycache__
 .DS_Store
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy == 1.22
-scipy == 1.5.4
+numpy == 1.24.3
+scipy == 1.10.1


### PR DESCRIPTION
i was having issues building //tools/... against the current requirements with python 3.10. upgrading them seems to have helped.