### PR TITLE
Update Python version to PY3, as indicated by the actual source file.

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -12,7 +12,7 @@ py_library(
 py_binary(
     name = "compare",
     srcs = ["compare.py"],
-    python_version = "PY2",
+    python_version = "PY3",
     deps = [
         ":gbench",
     ],


### PR DESCRIPTION
The code compiled in this binary is actually Python 3 code (see https://github.com/google/benchmark/blob/main/tools/compare.py).