### PR TITLE
Update CMake threads library detection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ Marcel Jacobse <mjacobse@uni-bremen.de>
 Matt Clarkson <mattyclarkson@gmail.com>
 Maxim Vafin <maxvafin@gmail.com>
 Mike Apodaca <gatorfax@gmail.com>
+Mitchell O'Sullivan <contact@mosullivan.au>
 MongoDB Inc.
 Nick Hutchinson <nshutchinson@gmail.com>
 Norman Heino <norman.heino@gmail.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,6 @@ endif()
 
 cxx_feature_check(STEADY_CLOCK)
 # Ensure we have pthreads
-set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 cxx_feature_check(PTHREAD_AFFINITY)
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -68,6 +68,7 @@ Marcel Jacobse <mjacobse@uni-bremen.de>
 Matt Clarkson <mattyclarkson@gmail.com>
 Maxim Vafin <maxvafin@gmail.com>
 Mike Apodaca <gatorfax@gmail.com>
+Mitchell O'Sullivan <contact@mosullivan.au>
 Nick Hutchinson <nshutchinson@gmail.com>
 Norman Heino <norman.heino@gmail.com>
 Oleksandr Sochka <sasha.sochka@gmail.com>

--- a/cmake/benchmark.pc.in
+++ b/cmake/benchmark.pc.in
@@ -7,6 +7,5 @@ Name: @PROJECT_NAME@
 Description: Google microbenchmark framework
 Version: @VERSION@
 
-Libs: -L${libdir} -lbenchmark
-Libs.private: -lpthread
+Libs: -L${libdir} -lbenchmark @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Enable the tests
 
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-
 find_package(Threads REQUIRED)
 include(CheckCXXCompilerFlag)
 


### PR DESCRIPTION
When glibc < 2.34, `-lpthread` or `-pthread` needs to be present in order for this project to be linked successfully. CMake provides the `@CMAKE_THREAD_LIBS_INIT@` variable that will expand to the necessary flag. This will typically expand to `-lpthreads`, but users can override this behaviour if they wish by setting the `THREADS_PREFER_PTHREAD_FLAG` variable to TRUE/ON/etc.

This patch ensures the thread library is always present in the linker options and restores the default behaviour.