### PR TITLE
Add project name to CMake status message.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ else()
   set(VERSION "${GIT_VERSION}")
 endif()
 # Tell the user what versions we are using
-message(STATUS "Version: ${VERSION}")
+message(STATUS "Google benchmark version: ${VERSION}")
 
 # The version of the libraries
 set(GENERIC_LIB_VERSION ${VERSION})


### PR DESCRIPTION
When building `benchmark` as part of a larger CMake project, the meaning of the following status message is not clear:
```
-- Version: 1.8.0
```
This patch identifies Google benchmark as the project to which the version refers:
```
-- Google benchmark version: 1.8.0
```