### PR TITLE
Use std::function in ComputeStatistics()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,6 +63,7 @@ Shuo Chen <chenshuo@chenshuo.com>
 Staffan Tjernstrom <staffantj@gmail.com>
 Steinar H. Gunderson <sgunderson@bigfoot.com>
 Stripe, Inc.
+Tim Oelkers <tim.oelkers@web.de>
 Tobias Schmidt <tobias.schmidt@in.tum.de>
 Yixuan Qiu <yixuanq@gmail.com>
 Yusuke Suzuki <utatane.tea@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -85,6 +85,7 @@ Roman Lebedev <lebedev.ri@gmail.com>
 Sayan Bhattacharjee <aero.sayan@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Steven Wan <wan.yu@ibm.com>
+Tim Oelkers <tim.oelkers@web.de>
 Tobias Schmidt <tobias.schmidt@in.tum.de>
 Tobias Ulvgård <tobias.ulvgard@dirac.se>
 Tom Madams <tom.ej.madams@gmail.com> <tmadams@google.com>

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -194,6 +194,7 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #include <initializer_list>
 #include <type_traits>
 #include <utility>
+#include <functional>
 #endif
 
 #if defined(_MSC_VER)
@@ -636,15 +637,19 @@ typedef double(BigOFunc)(IterationCount);
 
 // StatisticsFunc is passed to a benchmark in order to compute some descriptive
 // statistics over all the measurements of some type
-typedef double(StatisticsFunc)(const std::vector<double>&);
+#ifdef BENCHMARK_HAS_CXX11
+typedef std::function<double(const std::vector<double>&)> StatisticsFunc;
+#else
+typedef double(*StatisticsFunc)(const std::vector<double>&);
+#endif
 
 namespace internal {
 struct Statistics {
   std::string name_;
-  StatisticsFunc* compute_;
+  StatisticsFunc compute_;
   StatisticUnit unit_;
 
-  Statistics(const std::string& name, StatisticsFunc* compute,
+  Statistics(const std::string& name, StatisticsFunc compute,
              StatisticUnit unit = kTime)
       : name_(name), compute_(compute), unit_(unit) {}
 };
@@ -1207,7 +1212,7 @@ class BENCHMARK_EXPORT Benchmark {
 
   // Add this statistics to be computed over all the values of benchmark run
   Benchmark* ComputeStatistics(const std::string& name,
-                               StatisticsFunc* statistics,
+                               StatisticsFunc statistics,
                                StatisticUnit unit = kTime);
 
   // Support for running multiple copies of the same benchmark concurrently

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -430,7 +430,7 @@ Benchmark* Benchmark::Complexity(BigOFunc* complexity) {
 }
 
 Benchmark* Benchmark::ComputeStatistics(const std::string& name,
-                                        StatisticsFunc* statistics,
+                                        StatisticsFunc statistics,
                                         StatisticUnit unit) {
   statistics_.emplace_back(name, statistics, unit);
   return this;


### PR DESCRIPTION
Uses std::function instead of function pointers for the callback provided with ComputeStatistics(), if C++11 is used. This allows for greater flexibility as the user can use closures, member functions, bind expressions, etc. This should be a non API breaking change as std::function implicitly stores function pointers as well.

Closes #1604. Instead of a dedicated function, all the values can now be aggregated by the user. This should be the easier change.