### PR TITLE
Add a CI test for the new bzlmod integration

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -33,3 +33,32 @@ jobs:
     - name: test
       run: |
         bazel test --test_output=all //test/...
+
+  job:
+    name: bazel_with_bzlmod
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-2022]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: mount bazel cache
+      uses: actions/cache@v3
+      env:
+        cache-name: bazel-cache
+      with:
+        path: "~/.cache/bazel"
+        key: ${{ env.cache-name }}-${{ matrix.os }}-${{ github.ref }}
+        restore-keys: |
+          ${{ env.cache-name }}-${{ matrix.os }}-main
+
+    - name: build
+      run: |
+        bazel build --enable_bzlmod //:benchmark //:benchmark_main //test/...
+
+    - name: test
+      run: |
+        bazel test --enable_bzlmod --test_output=all //test/...

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2022]
+        flags: [-c opt, -c opt --enable_bzlmod]
 
     steps:
     - uses: actions/checkout@v3
@@ -28,37 +29,8 @@ jobs:
 
     - name: build
       run: |
-        bazel build //:benchmark //:benchmark_main //test/...
+        bazel build ${{ matrix.flags }} //:benchmark //:benchmark_main //test/...
 
     - name: test
       run: |
-        bazel test --test_output=all //test/...
-
-  build_and_test_bzlmod:
-    name: bazel_with_bzlmod
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-2022]
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: mount bazel cache
-      uses: actions/cache@v3
-      env:
-        cache-name: bazel-cache
-      with:
-        path: "~/.cache/bazel"
-        key: ${{ env.cache-name }}-${{ matrix.os }}-${{ github.ref }}
-        restore-keys: |
-          ${{ env.cache-name }}-${{ matrix.os }}-main
-
-    - name: build
-      run: |
-        bazel build --enable_bzlmod //:benchmark //:benchmark_main //test/...
-
-    - name: test
-      run: |
-        bazel test --enable_bzlmod --test_output=all //test/...
+        bazel test ${{ matrix.flags }}  --test_output=all //test/...

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -6,14 +6,13 @@ on:
 
 jobs:
   build_and_test_default:
-    name: bazel.${{ matrix.os }}.${{ matrix.pfm && 'pfm' || 'nopfm' }}.${{ matrix.bzlmod && 'bzlmod' || 'nobzlmod' }}
+    name: bazel.${{ matrix.os }}.${{ matrix.bzlmod && 'bzlmod' || 'no_bzlmod' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2022]
         bzlmod: [false, true]
-        pfm: [false, true]
     steps:
     - uses: actions/checkout@v3
 
@@ -29,8 +28,8 @@ jobs:
 
     - name: build
       run: |
-        bazel build ${{ matrix.bzlmod && '--enable_bzlmod' || '--noenable_bzlmod' }} ${{ matrix.pfm && '--define pfm=1' || '--define pfm=0' }} //:benchmark //:benchmark_main //test/...
+        bazel build ${{ matrix.bzlmod && '--enable_bzlmod' || '--noenable_bzlmod' }} //:benchmark //:benchmark_main //test/...
 
     - name: test
       run: |
-        bazel test ${{ matrix.bzlmod && '--enable_bzlmod' || '--noenable_bzlmod' }} ${{ matrix.pfm && '--define pfm=1' || '--define pfm=0' }}  --test_output=all //test/...
+        bazel test ${{ matrix.bzlmod && '--enable_bzlmod' || '--noenable_bzlmod' }} --test_output=all //test/...

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -6,14 +6,14 @@ on:
 
 jobs:
   build_and_test_default:
-    name: bazel.${{ matrix.os }}
+    name: bazel.${{ matrix.os }}.${{ matrix.pfm && 'pfm' || 'nopfm' }}.${{ matrix.bzlmod && 'bzlmod' || 'nobzlmod' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2022]
-        flags: [-c opt, -c opt --enable_bzlmod]
-
+        bzlmod: [false, true]
+        pfm: [false, true]
     steps:
     - uses: actions/checkout@v3
 
@@ -29,8 +29,8 @@ jobs:
 
     - name: build
       run: |
-        bazel build ${{ matrix.flags }} //:benchmark //:benchmark_main //test/...
+        bazel build ${{ matrix.bzlmod && '--enable_bzlmod' || '--noenable_bzlmod' }} ${{ matrix.pfm && '--define pfm=1' || '--define pfm=0' }} //:benchmark //:benchmark_main //test/...
 
     - name: test
       run: |
-        bazel test ${{ matrix.flags }}  --test_output=all //test/...
+        bazel test ${{ matrix.bzlmod && '--enable_bzlmod' || '--noenable_bzlmod' }} ${{ matrix.pfm && '--define pfm=1' || '--define pfm=0' }}  --test_output=all //test/...

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -5,7 +5,7 @@ on:
   pull_request: {}
 
 jobs:
-  job:
+  build_and_test_default:
     name: bazel.${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -34,7 +34,7 @@ jobs:
       run: |
         bazel test --test_output=all //test/...
 
-  job:
+  build_and_test_bzlmod:
     name: bazel_with_bzlmod
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Enhanced the already existing bazel test to also run with the `--enable_bzlmod` flag.

Technically it shouldn't be necessary to run these additional test on all operating systems, but this will make the eventual switch to exclusively use bzlmod (slightly) easier.

The one thing that is unclear is if there should be another test for the `--define pfm=1` flag, which uses more libraries. This is missing for the base case and is currently only exercises in the cmake CI workflows, so it might be worth a separate PR to introduce those tests (for both variants then).

Related issue: https://github.com/bazelbuild/bazel-central-registry/issues/384