### PR TITLE
Add more terminals with color support

### DIFF
--- a/src/colorprint.cc
+++ b/src/colorprint.cc
@@ -163,12 +163,24 @@ bool IsColorTerminal() {
 #else
   // On non-Windows platforms, we rely on the TERM variable. This list of
   // supported TERM values is copied from Google Test:
-  // <https://github.com/google/googletest/blob/main/googletest/src/gtest.cc#L2925>.
+  // <https://github.com/google/googletest/blob/v1.13.0/googletest/src/gtest.cc#L3225-L3259>.
   const char* const SUPPORTED_TERM_VALUES[] = {
-      "xterm",         "xterm-color",     "xterm-256color",
-      "screen",        "screen-256color", "tmux",
-      "tmux-256color", "rxvt-unicode",    "rxvt-unicode-256color",
-      "linux",         "cygwin",
+      "xterm",
+      "xterm-color",
+      "xterm-256color",
+      "screen",
+      "screen-256color",
+      "tmux",
+      "tmux-256color",
+      "rxvt-unicode",
+      "rxvt-unicode-256color",
+      "linux",
+      "cygwin",
+      "xterm-kitty",
+      "alacritty",
+      "foot",
+      "foot-extra",
+      "wezterm",
   };
 
   const char* const term = getenv("TERM");


### PR DESCRIPTION
Reference for alacritty supporting colors: https://github.com/google/benchmark/pull/1620#discussion_r1251262592

Reference for wezterm supporting colors: https://github.com/wez/wezterm/blob/9459f64cce393a56b9be6deddc6a622332aff7c8/docs/features.md?plain=1#L10

Reference for foot supporting colors: https://codeberg.org/dnkl/foot/src/commit/4a7382891112d898d4ba0f8d445439b8ad86477e/README.md#L62