### PR TITLE
Bump `nanobind` to stable v1.4.0 tag

### DIFF
--- a/bazel/benchmark_deps.bzl
+++ b/bazel/benchmark_deps.bzl
@@ -48,8 +48,7 @@ def benchmark_deps():
         new_git_repository(
             name = "nanobind",
             remote = "https://github.com/wjakob/nanobind.git",
-            commit = "1ffbfe836c9dac599496a170274ee0075094a607", # v0.2.0
-            shallow_since = "1677873085 +0100",
+            tag = "v1.4.0",
             build_file = "@//bindings/python:nanobind.BUILD",
             recursive_init_submodules = True,
         )

--- a/bindings/python/nanobind.BUILD
+++ b/bindings/python/nanobind.BUILD
@@ -31,6 +31,7 @@ cc_library(
         "src/nb_internals.cpp",
         "src/nb_internals.h",
         "src/nb_ndarray.cpp",
+        "src/nb_static_property.cpp",
         "src/nb_type.cpp",
         "src/trampoline.cpp",
     ],


### PR DESCRIPTION
This seems to reduce binding sizes even further, with a wheel size of 175KB on my local machine (macOS 13.4.1).