### PR TITLE
Change nanobind linkage to response file approach on macOS

### DIFF
--- a/.github/install_bazel.sh
+++ b/.github/install_bazel.sh
@@ -5,7 +5,7 @@ if ! bazel version; then
   fi
   echo "Installing wget and downloading $arch Bazel binary from GitHub releases."
   yum install -y wget
-  wget "https://github.com/bazelbuild/bazel/releases/download/6.3.0/bazel-6.3.0-linux-$arch" -O /usr/local/bin/bazel
+  wget "https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-linux-$arch" -O /usr/local/bin/bazel
   chmod +x /usr/local/bin/bazel
 else
   # bazel is installed for the correct architecture

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(name = "google_benchmark", version="1.8.3")
 
-bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "platforms", version = "0.0.6")
 bazel_dep(name = "rules_foreign_cc", version = "0.9.0")
 bazel_dep(name = "rules_cc", version = "0.0.6")

--- a/bazel/benchmark_deps.bzl
+++ b/bazel/benchmark_deps.bzl
@@ -7,26 +7,27 @@ def benchmark_deps():
     if "bazel_skylib" not in native.existing_rules():
         http_archive(
             name = "bazel_skylib",
-            sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+            sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa ",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
-                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
             ],
         )
 
     if "rules_foreign_cc" not in native.existing_rules():
         http_archive(
             name = "rules_foreign_cc",
-            sha256 = "bcd0c5f46a49b85b384906daae41d277b3dc0ff27c7c752cc51e43048a58ec83",
-            strip_prefix = "rules_foreign_cc-0.7.1",
-            url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.7.1.tar.gz",
+            sha256 = "2a4d07cd64b0719b39a7c12218a3e507672b82a97b98c6a89d38565894cf7c51",
+            strip_prefix = "rules_foreign_cc-0.9.0",
+            url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.9.0.tar.gz",
         )
 
     if "rules_python" not in native.existing_rules():
         http_archive(
             name = "rules_python",
-            url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
-            sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
+            sha256 = "0a8003b044294d7840ac7d9d73eef05d6ceb682d7516781a4ec62eeb34702578",
+            url = "https://github.com/bazelbuild/rules_python/releases/download/0.24.0/rules_python-0.24.0.tar.gz",
+            strip_prefix = "rules_python-0.24.0",
         )
 
     if "com_google_absl" not in native.existing_rules():

--- a/bazel/benchmark_deps.bzl
+++ b/bazel/benchmark_deps.bzl
@@ -7,7 +7,7 @@ def benchmark_deps():
     if "bazel_skylib" not in native.existing_rules():
         http_archive(
             name = "bazel_skylib",
-            sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa ",
+            sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
             urls = [
                 "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
                 "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",

--- a/bindings/python/nanobind.BUILD
+++ b/bindings/python/nanobind.BUILD
@@ -1,3 +1,12 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "symboltable",
+    srcs = ["cmake/darwin-ld-cpython.sym"],
+)
+
 cc_library(
     name = "nanobind",
     srcs = glob([
@@ -12,6 +21,13 @@ cc_library(
             "ext/robin_map/include/tsl/*.h",
         ],
     ),
+    linkopts = select({
+        "@platforms//os:macos": ["-Wl,@$(location :cmake/darwin-ld-cpython.sym)"],
+        "//conditions:default": [],
+    }),
+    additional_linker_inputs = select({
+        "@platforms//os:macos": [":cmake/darwin-ld-cpython.sym"],
+        "//conditions:default": [],
+    }),
     deps = ["@python_headers"],
-    visibility = ["//visibility:public"],
 )

--- a/bindings/python/python_headers.BUILD
+++ b/bindings/python/python_headers.BUILD
@@ -1,3 +1,7 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
 cc_library(
     name = "python_headers",
     hdrs = glob(["**/*.h"]),

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,9 @@ class BuildBazelExtension(build_ext.build_ext):
     def run(self):
         for ext in self.extensions:
             self.bazel_build(ext)
-        build_ext.build_ext.run(self)
+        super().run()
+        # explicitly call `bazel shutdown` for graceful exit
+        self.spawn(["bazel", "shutdown"])
 
     def bazel_build(self, ext: BazelExtension):
         """Runs the bazel build to create the package."""
@@ -97,9 +99,6 @@ class BuildBazelExtension(build_ext.build_ext):
 
             ext_dest_path = Path(self.get_ext_fullpath(ext.name))
             shutil.copyfile(ext_bazel_bin_path, ext_dest_path)
-
-            # explicitly call `bazel shutdown` for graceful exit
-            self.spawn(["bazel", "shutdown"])
 
 
 setuptools.setup(


### PR DESCRIPTION
This change needs https://github.com/bazelbuild/bazel/pull/18952 to be merged first. 

Fixes macOS linkage of GBM's nanobind bindings on macOS by supplying a linker response file instead of `-undefined dynamic_lookup`. The latter has since been deprecated on macOS.