### PR TITLE
Re-enable `windows-latest` tests for newer Bazel

### DIFF
--- a/.github/install_bazel.sh
+++ b/.github/install_bazel.sh
@@ -5,7 +5,7 @@ if ! bazel version; then
   fi
   echo "Installing wget and downloading $arch Bazel binary from GitHub releases."
   yum install -y wget
-  wget "https://github.com/bazelbuild/bazel/releases/download/6.0.0/bazel-6.0.0-linux-$arch" -O /usr/local/bin/bazel
+  wget "https://github.com/bazelbuild/bazel/releases/download/6.3.0/bazel-6.3.0-linux-$arch" -O /usr/local/bin/bazel
   chmod +x /usr/local/bin/bazel
 else
   # bazel is installed for the correct architecture

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         bzlmod: [false, true]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,7 +46,7 @@ jobs:
           platforms: all
 
       - name: Build wheels on ${{ matrix.os }} using cibuildwheel
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.14.1
         env:
           CIBW_BUILD: 'cp38-* cp39-* cp310-* cp311-*'
           CIBW_SKIP: "*-musllinux_*"


### PR DESCRIPTION
The Windows toolchain detection fix made it into Bazel 6.3.0 (https://github.com/bazelbuild/bazel/pull/18960), so the CI should work again with the re-enabled `windows-latest` marker _if Bazel 6.3.0 is already installed in the newest `windows-latest` image_.

Also, require Bazel 6.3.0 in the Linux container setup in `cibuildwheel`, and bump `cibuildwheel` to v2.14.1 (July 2023) in anticipation of building Python 3.12 wheels (SABI builds with nanobind!).