### PR TITLE
feat: benchmark_list_tests benchmark-format=json

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -639,7 +639,7 @@ class Counter {
   Counter(double v = 0., Flags f = kDefaults, OneK k = kIs1000)
       : value(v), flags(f), oneK(k) {}
 
-  BENCHMARK_ALWAYS_INLINE operator double const &() const { return value; }
+  BENCHMARK_ALWAYS_INLINE operator double const&() const { return value; }
   BENCHMARK_ALWAYS_INLINE operator double&() { return value; }
 };
 
@@ -1878,6 +1878,19 @@ class BENCHMARK_EXPORT BenchmarkReporter {
   // REQUIRES: 'out' is non-null.
   static void PrintBasicContext(std::ostream* out, Context const& context);
 
+  /**
+   * @brief Lists and describes the provided benchmarks.
+   *
+   * This static method is intended to be overridden by derived classes
+   * to provide specific implementations for listing benchmarks.
+   * It can be used for outputting, logging, or any other operation
+   * needed to handle or display the benchmarks' names and metadata.
+   *
+   * @param benchmarks A vector containing names and details of benchmarks
+   *                   that need to be listed or processed.
+   */
+  static void List(const std::vector<internal::BenchmarkInstance>& benchmarks);
+
  private:
   std::ostream* output_stream_;
   std::ostream* error_stream_;
@@ -1899,6 +1912,7 @@ class BENCHMARK_EXPORT ConsoleReporter : public BenchmarkReporter {
 
   bool ReportContext(const Context& context) BENCHMARK_OVERRIDE;
   void ReportRuns(const std::vector<Run>& reports) BENCHMARK_OVERRIDE;
+  static void List(const std::vector<internal::BenchmarkInstance>& benchmarks);
 
  protected:
   virtual void PrintRunData(const Run& report);
@@ -1916,6 +1930,7 @@ class BENCHMARK_EXPORT JSONReporter : public BenchmarkReporter {
   bool ReportContext(const Context& context) BENCHMARK_OVERRIDE;
   void ReportRuns(const std::vector<Run>& reports) BENCHMARK_OVERRIDE;
   void Finalize() BENCHMARK_OVERRIDE;
+  static void List(const std::vector<internal::BenchmarkInstance>& benchmarks);
 
  private:
   void PrintRunData(const Run& report);
@@ -1930,6 +1945,7 @@ class BENCHMARK_EXPORT BENCHMARK_DEPRECATED_MSG(
   CSVReporter() : printed_header_(false) {}
   bool ReportContext(const Context& context) BENCHMARK_OVERRIDE;
   void ReportRuns(const std::vector<Run>& reports) BENCHMARK_OVERRIDE;
+  static void List(const std::vector<internal::BenchmarkInstance>& benchmarks);
 
  private:
   void PrintRunData(const Run& report);

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -593,8 +593,12 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
   }
 
   if (FLAGS_benchmark_list_tests) {
-    for (auto const& benchmark : benchmarks)
-      Out << benchmark.name().str() << "\n";
+    if (FLAGS_benchmark_format == "json") {
+      dynamic_cast<JSONReporter*>(display_reporter)->List(benchmarks);
+        } else {
+      //ConsoleReporter::List(benchmarks);
+      dynamic_cast<ConsoleReporter*>(display_reporter)->List(benchmarks);
+    }
   } else {
     internal::RunBenchmarks(benchmarks, display_reporter, file_reporter);
   }

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -203,4 +203,13 @@ void ConsoleReporter::PrintRunData(const Run& result) {
   printer(Out, COLOR_DEFAULT, "\n");
 }
 
+BENCHMARK_EXPORT
+void ConsoleReporter::List(
+    const std::vector<internal::BenchmarkInstance>& benchmarks) {
+  std::ostream& Out = GetOutputStream();
+  for (auto const& benchmark : benchmarks) {
+    Out << benchmark.name().str() << "\n";
+  }
+}
+
 }  // end namespace benchmark

--- a/src/csv_reporter.cc
+++ b/src/csv_reporter.cc
@@ -158,4 +158,10 @@ void CSVReporter::PrintRunData(const Run& run) {
   Out << '\n';
 }
 
+void CSVReporter::List(
+    const std::vector<internal::BenchmarkInstance>& benchmarks) {
+  std::ostream& err = GetErrorStream();
+  err << "List() method is not implemented for CSVReporter.\n";
+}
+
 }  // end namespace benchmark

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -317,4 +317,18 @@ void JSONReporter::PrintRunData(Run const& run) {
 const int64_t MemoryManager::TombstoneValue =
     std::numeric_limits<int64_t>::max();
 
+void JSONReporter::List(
+    const std::vector<internal::BenchmarkInstance>& benchmarks) {
+  std::ostream& Out = GetOutputStream();
+  Out << "[";
+  for (size_t i = 0; i < benchmarks.size(); ++i) {
+    const auto& benchmark = benchmarks[i];
+    Out << "{ \"name\": \"" << benchmark.name().str() << "\" }";
+    if (i != benchmarks.size() - 1) {
+      Out << ", ";
+    }
+  }
+  Out << "]";
+}
+
 }  // end namespace benchmark


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Benchmark!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from the main
- [x] My pull request is against main
- [x] My code follows the Google Style Guide
- [x] I ran `clang-format`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
- Fixes #1642 

### Proposed Changes

To output the benchmark list in JSON format.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

Unable to get the desired output for the automation purpose in the JSN format.

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

Added the support for the use of `--benchmark_list_tests` together with `--benchmark-format=json`.

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

With this change, the user will be able to get the benchmark output easily in JSON format for better machine use cases.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

I haven't tested this, as soon as I got confirmation that these are the required changes that will update the status of the Test Coverage.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behavior, include
           information about the browser and device that you used for
           testing. -->

### Documentation

Documentation needs to be done for this as it's a feature request once this will pass all the test cases I will add the required document for this.

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
