### PR TITLE
benchmark.cc: Fix benchmarks_with_threads condition

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -383,7 +383,7 @@ void RunBenchmarks(const std::vector<BenchmarkInstance>& benchmarks,
       BenchmarkReporter::PerFamilyRunReports* reports_for_family = nullptr;
       if (benchmark.complexity() != oNone)
         reports_for_family = &per_family_reports[benchmark.family_index()];
-      benchmarks_with_threads += (benchmark.threads() > 0);
+      benchmarks_with_threads += (benchmark.threads() > 1);
       runners.emplace_back(benchmark, &perfcounters, reports_for_family);
       int num_repeats_of_this_instance = runners.back().GetNumRepeats();
       num_repetitions_total += num_repeats_of_this_instance;


### PR DESCRIPTION
Change condition for `benchmarks_with_threads` from `benchmark.threads() > 0` to `> 1`.  `threads()` appears to always be `>= 1`.

Introduced in fbc6efa (Refactoring of PerfCounters infrastructure (#1559))