### PR TITLE
State: Initialize counters with kAvgIteration in constructor

### DIFF
--- a/test/perf_counters_test.cc
+++ b/test/perf_counters_test.cc
@@ -67,22 +67,17 @@ static void CheckSimple(Results const& e) {
 double withoutPauseResumeInstrCount = 0.0;
 double withPauseResumeInstrCount = 0.0;
 
-static void CheckInstrCount(double* counter, Results const& e) {
-  BM_CHECK_GT(e.NumIterations(), 0);
-  *counter = e.GetAs<double>("INSTRUCTIONS") / e.NumIterations();
+static void SaveInstrCountWithoutResume(Results const& e) {
+  withoutPauseResumeInstrCount = e.GetAs<double>("INSTRUCTIONS");
 }
 
-static void CheckInstrCountWithoutResume(Results const& e) {
-  CheckInstrCount(&withoutPauseResumeInstrCount, e);
-}
-
-static void CheckInstrCountWithResume(Results const& e) {
-  CheckInstrCount(&withPauseResumeInstrCount, e);
+static void SaveInstrCountWithResume(Results const& e) {
+  withPauseResumeInstrCount = e.GetAs<double>("INSTRUCTIONS");
 }
 
 CHECK_BENCHMARK_RESULTS("BM_Simple", &CheckSimple);
-CHECK_BENCHMARK_RESULTS("BM_WithoutPauseResume", &CheckInstrCountWithoutResume);
-CHECK_BENCHMARK_RESULTS("BM_WithPauseResume", &CheckInstrCountWithResume);
+CHECK_BENCHMARK_RESULTS("BM_WithoutPauseResume", &SaveInstrCountWithoutResume);
+CHECK_BENCHMARK_RESULTS("BM_WithPauseResume", &SaveInstrCountWithResume);
 
 int main(int argc, char* argv[]) {
   if (!benchmark::internal::PerfCounters::kSupported) {


### PR DESCRIPTION
Previously, `counters` was updated in `PauseTiming()` with
`counters[name] += Counter(measurement, kAvgIteration)`.

The first `counters[name]` call inserts a counter with no flags.

There is no `operator+=` for `Counter`, so the insertion is done
by converting the `Counter` to a `double`, then constructing a
`Counter` to insert from the `double`, which drops the flags.

Pre-insert the `Counter` with the correct flags, then only
update `Counter::value`.

Introduced in https://github.com/google/benchmark/commit/1c64a36c5b8ee75d462b3fe7a9d020c66a2a1094 ([perf-counters] Fix pause/resume (https://github.com/google/benchmark/pull/1643)).