### PR TITLE
Typofix to unbreak OpenBSD build

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -158,7 +158,7 @@ ValueUnion GetSysctlImp(std::string const& name) {
       mib[1] = HW_CPUSPEED;
     }
 
-    if (sysctl(mib, 2, buff.data(), &buff.Size, nullptr, 0) == -1) {
+    if (sysctl(mib, 2, buff.data(), &buff.size, nullptr, 0) == -1) {
       return ValueUnion();
     }
     return buff;


### PR DESCRIPTION
```
/usr/ports/pobj/benchmark-1.8.2/benchmark-1.8.2/src/sysinfo.cc:161:43: error: no member named 'Size' in 'benchmark::(anonymous namespace)::ValueUnion'; did you mean 'size'?
    if (sysctl(mib, 2, buff.data(), &buff.Size, nullptr, 0) == -1) {
                                          ^~~~
                                          size
/usr/ports/pobj/benchmark-1.8.2/benchmark-1.8.2/src/sysinfo.cc:111:15: note: 'size' declared here
  std::size_t size;
              ^
1 error generated.
```
