### PR TITLE
Increase the kMaxIterations limit

### DIFF
--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -64,7 +64,7 @@ MemoryManager* memory_manager = nullptr;
 
 namespace {
 
-static constexpr IterationCount kMaxIterations = 1000000000;
+static constexpr IterationCount kMaxIterations = 1000000000000;
 const double kDefaultMinTime =
     std::strtod(::benchmark::kDefaultMinTimeStr, /*p_end*/ nullptr);
 


### PR DESCRIPTION
This pull request fixes #1663. Note that as a result of this change, the columns in the console output can become misaligned if the actual iteration count is too high. This will be dealt with separately (see also #1664).