### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/test_bindings.yml
+++ b/.github/workflows/test_bindings.yml
@@ -13,17 +13,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-2019 ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
-      - name: Install GBM Python bindings on ${{ matrix.os}}
-        run:
-          python -m pip install wheel .
+      - name: Install GBM Python bindings on ${{ matrix.os }}
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install .
       - name: Run bindings example on ${{ matrix.os }}
         run:
           python bindings/python/google_benchmark/example.py

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Python 3.11
         uses: actions/setup-python@v4
@@ -33,11 +33,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Check out Google Benchmark
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
@@ -46,9 +46,9 @@ jobs:
           platforms: all
 
       - name: Build wheels on ${{ matrix.os }} using cibuildwheel
-        uses: pypa/cibuildwheel@v2.14.1
+        uses: pypa/cibuildwheel@v2.16.2
         env:
-          CIBW_BUILD: 'cp38-* cp39-* cp310-* cp311-*'
+          CIBW_BUILD: 'cp38-* cp39-* cp310-* cp311-* cp312-*'
           CIBW_SKIP: "*-musllinux_*"
           CIBW_TEST_SKIP: "*-macosx_arm64"
           CIBW_ARCHS_LINUX: x86_64 aarch64
@@ -67,13 +67,11 @@ jobs:
     name: Publish google-benchmark wheels to PyPI
     needs: [build_sdist, build_wheels]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/download-artifact@v3
       with:
         name: dist
         path: dist
-
-    - uses: pypa/gh-action-pypi-publish@v1.6.4
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_PASSWORD }}
+    - uses: pypa/gh-action-pypi-publish@v1.8.10

--- a/bazel/benchmark_deps.bzl
+++ b/bazel/benchmark_deps.bzl
@@ -48,7 +48,7 @@ def benchmark_deps():
         new_git_repository(
             name = "nanobind",
             remote = "https://github.com/wjakob/nanobind.git",
-            tag = "v1.4.0",
+            tag = "v1.6.2",
             build_file = "@//bindings/python:nanobind.BUILD",
             recursive_init_submodules = True,
         )

--- a/bazel/benchmark_deps.bzl
+++ b/bazel/benchmark_deps.bzl
@@ -48,7 +48,7 @@ def benchmark_deps():
         new_git_repository(
             name = "nanobind",
             remote = "https://github.com/wjakob/nanobind.git",
-            tag = "v1.6.2",
+            tag = "v1.7.0",
             build_file = "@//bindings/python:nanobind.BUILD",
             recursive_init_submodules = True,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Testing",
     "Topic :: System :: Benchmark",
 ]


### PR DESCRIPTION
These commits contain a few changes:

- nanobind bump to v1.6.2 (Sep 2023). (0a816f05653eada761d6a3caf6daa34822f02ad7)
- GitHub Actions `checkout` to v4, reset to `windows-latest` as Windows runner image. (609415eee9a21b4a9b7653eb2503df08b38fae80)
- Python 3.12 wheel builds via `cibuildwheel` version bump and envvar change. (609415eee9a21b4a9b7653eb2503df08b38fae80)
- The move to [trusted publishing](https://github.com/marketplace/actions/pypi-publish#trusted-publishing) for PyPI wheel releases. (609415eee9a21b4a9b7653eb2503df08b38fae80)

Related: I am currently working on a project using `setuptools_scm` as an addition in the build step, which makes manual version bumping for the Python bindings unnecessary (the package parses the new version out of a tag name created e.g. by a GitHub release), in case there is interest in opting into that.