### PR TITLE
Fix error: 'WC_ERR_INVALID_CHARS' was not declared in this scope

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -429,10 +429,10 @@ std::string GetSystemName() {
   str = std::string(hostname, DWCOUNT);
 #else
   // `WideCharToMultiByte` returns `0` when conversion fails.
-  int len = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, hostname,
+  int len = WideCharToMultiByte(CP_UTF8, MB_ERR_INVALID_CHARS, hostname,
                                 DWCOUNT, NULL, 0, NULL, NULL);
   str.resize(len);
-  WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, hostname, DWCOUNT, &str[0],
+  WideCharToMultiByte(CP_UTF8, MB_ERR_INVALID_CHARS, hostname, DWCOUNT, &str[0],
                       str.size(), NULL, NULL);
 #endif
   return str;


### PR DESCRIPTION
When building [leveldb](https://github.com/google/leveldb),   add_test(NAME "leveldb_tests" COMMAND "leveldb_tests").
```
FAILED: third_party/benchmark/src/CMakeFiles/benchmark.dir/sysinfo.cc.obj 
D:\MingW\bin\g++.exe -DBENCHMARK_STATIC_DEFINE -DHAVE_STD_REGEX -DHAVE_STEADY_CLOCK -DUNICODE -D_UNICODE -IF:/Contribute/leveldb/cmake-build-debug/include -IF:/Contribute/leveldb/. -IF:/Contribute/leveldb/third_party/benchmark/include -IF:/Contribute/leveldb/third_party/benchmark/src -fno-exceptions -fno-rtti  -Wall  -Wextra  -Wshadow  -Wfloat-equal  -Werror  -Wsuggest-override  -pedantic  -pedantic-errors  -fstrict-aliasing  -Wno-deprecated-declarations  -Wno-deprecated  -fno-exceptions  -Wstrict-aliasing -g -std=c++11 -fvisibility=hidden -fno-keep-inline-dllexport -fdiagnostics-color=always -MD -MT third_party/benchmark/src/CMakeFiles/benchmark.dir/sysinfo.cc.obj -MF third_party\benchmark\src\CMakeFiles\benchmark.dir\sysinfo.cc.obj.d -o third_party/benchmark/src/CMakeFiles/benchmark.dir/sysinfo.cc.obj -c F:/Contribute/leveldb/third_party/benchmark/src/sysinfo.cc
F:/Contribute/leveldb/third_party/benchmark/src/sysinfo.cc: In function 'std::__cxx11::string benchmark::{anonymous}::GetSystemName()':
F:/Contribute/leveldb/third_party/benchmark/src/sysinfo.cc:432:42: error: 'WC_ERR_INVALID_CHARS' was not declared in this scope
   int len = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, hostname,
                                          ^~~~~~~~~~~~~~~~~~~~
F:/Contribute/leveldb/third_party/benchmark/src/sysinfo.cc:432:42: note: suggested alternative: 'MB_ERR_INVALID_CHARS'
   int len = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, hostname,
                                          ^~~~~~~~~~~~~~~~~~~~
                                          MB_ERR_INVALID_CHARS
```
