### PR TITLE
Set -Wno-unused-variable for tests

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -18,6 +18,9 @@ TEST_COPTS = [
     #    "-Wshorten-64-to-32",
     "-Wfloat-equal",
     "-fstrict-aliasing",
+    ## assert() are used a lot in tests upstream, which may be optimised out leading to
+    ## unused-variable warning.
+    "-Wno-unused-variable",
 ]
 
 # Some of the issues with DoNotOptimize only occur when optimization is enabled


### PR DESCRIPTION
We  used assert() a lot in tests and that can cause build breakages in some of the opt builds (since assert() are removed)

it's not practical to sprinkle "(void)" everywhere so I think setting this warning option is the best option for now.