### PR TITLE
Reapply size optimizations for clang & MSVC, LTO for Mac+Linux

### DIFF
--- a/bindings/python/nanobind.BUILD
+++ b/bindings/python/nanobind.BUILD
@@ -2,18 +2,38 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-filegroup(
-    name = "symboltable",
-    srcs = ["cmake/darwin-ld-cpython.sym"],
+config_setting(
+    name = "msvc_compiler",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "msvc-cl"},
 )
 
 cc_library(
     name = "nanobind",
     srcs = glob([
-        "src/*.cpp"
+        "src/*.cpp",
     ]),
-    copts = ["-fexceptions"],
-    includes = ["include", "ext/robin_map/include"],
+    additional_linker_inputs = select({
+        "@platforms//os:macos": [":cmake/darwin-ld-cpython.sym"],
+        "//conditions:default": [],
+    }),
+    copts = select({
+        ":msvc_compiler": [
+            "/EHsc",  # exceptions
+            "/Os",  # size optimizations
+        ],
+        "//conditions:default": [
+            "-fexceptions",
+            "-Os",
+        ],
+    }),
+    includes = [
+        "ext/robin_map/include",
+        "include",
+    ],
+    linkopts = select({
+        "@platforms//os:macos": ["-Wl,@$(location :cmake/darwin-ld-cpython.sym)"],
+        "//conditions:default": [],
+    }),
     textual_hdrs = glob(
         [
             "include/**/*.h",
@@ -21,13 +41,5 @@ cc_library(
             "ext/robin_map/include/tsl/*.h",
         ],
     ),
-    linkopts = select({
-        "@platforms//os:macos": ["-Wl,@$(location :cmake/darwin-ld-cpython.sym)"],
-        "//conditions:default": [],
-    }),
-    additional_linker_inputs = select({
-        "@platforms//os:macos": [":cmake/darwin-ld-cpython.sym"],
-        "//conditions:default": [],
-    }),
     deps = ["@python_headers"],
 )

--- a/bindings/python/nanobind.BUILD
+++ b/bindings/python/nanobind.BUILD
@@ -21,8 +21,10 @@ cc_library(
             "/EHsc",  # exceptions
             "/Os",  # size optimizations
         ],
+        # these should work on both clang and gcc.
         "//conditions:default": [
             "-fexceptions",
+            "-flto",
             "-Os",
         ],
     }),


### PR DESCRIPTION
Working towards cross-platform optimal nanobind building configurations.

Re: LTO:

The Windows case (the option name is "/GL") is more complicated, since there, the compiler options also need to be passed to the linker if LTO is enabled.

Since we are gating the linker options on platform at the moment instead of compiler, we need to implement a Bazel boolean flag for the case `"Platform == MacOS && Compiler == AnyOf(gcc, clang)"`.

I also applied `buildifier`, which formats Bazel files (BUILD, WORKSPACE, .bzl) nicely - we could integrate this in CI if there's interest.