### PR TITLE
Replace isort hook with ruff builtin import sorting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,6 @@ repos:
     rev: 23.10.1
     hooks:
       - id: black
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args: [--profile, black]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.3
     hooks:

--- a/bindings/python/google_benchmark/__init__.py
+++ b/bindings/python/google_benchmark/__init__.py
@@ -29,6 +29,7 @@ Example usage:
 import atexit
 
 from absl import app
+
 from google_benchmark import _benchmark
 from google_benchmark._benchmark import (
     Counter,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,12 +61,6 @@ include = "\\.pyi?$"
 line-length = 80
 target-version = ["py311"]
 
-# Black-compatible settings for isort
-# See https://black.readthedocs.io/en/stable/
-[tool.isort]
-line_length = "80"
-profile = "black"
-
 [tool.mypy]
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -80,11 +74,14 @@ module = ["yaml"]
 ignore_missing_imports = true
 
 [tool.ruff]
-# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F", "W"]
+# explicitly tell ruff the source directory to correctly identify first-party package.
+src = ["bindings/python"]
+line-length = 80
+# Enable pycodestyle (`E`, `W`), Pyflakes (`F`), and isort (`I`) codes by default.
+select = ["E", "F", "I", "W"]
 ignore = [
-    # whitespace before colon (:), rely on black for formatting (in particular, allow spaces before ":" in list/array slices)
+    # whitespace before colon (:), rely on black for formatting.
     "E203",
-    # line too long, rely on black for reformatting of these, since sometimes URLs or comments can be longer
+    # line too long, rely on black for formatting.
     "E501",
 ]


### PR DESCRIPTION
This behaves the same, and saves a pre-commit step. ruff just needs an additional package location hint to correctly map first-part packages (in this case, `google_benchmark`).

This revealed a misformat in the `google_benchmark/__init__.py`, which is now fixed.