### PR TITLE
Add `setuptools_scm` for dynamic zero-config Python versioning

### DIFF
--- a/bindings/python/google_benchmark/__init__.py
+++ b/bindings/python/google_benchmark/__init__.py
@@ -32,44 +32,23 @@ from absl import app
 
 from google_benchmark import _benchmark
 from google_benchmark._benchmark import (
-    Counter,
-    State,
-    kMicrosecond,
-    kMillisecond,
-    kNanosecond,
-    kSecond,
-    o1,
-    oAuto,
-    oLambda,
-    oLogN,
-    oN,
-    oNCubed,
-    oNLogN,
-    oNone,
-    oNSquared,
+    Counter as Counter,
+    State as State,
+    kMicrosecond as kMicrosecond,
+    kMillisecond as kMillisecond,
+    kNanosecond as kNanosecond,
+    kSecond as kSecond,
+    o1 as o1,
+    oAuto as oAuto,
+    oLambda as oLambda,
+    oLogN as oLogN,
+    oN as oN,
+    oNCubed as oNCubed,
+    oNLogN as oNLogN,
+    oNone as oNone,
+    oNSquared as oNSquared,
 )
-
-__all__ = [
-    "register",
-    "main",
-    "Counter",
-    "kNanosecond",
-    "kMicrosecond",
-    "kMillisecond",
-    "kSecond",
-    "oNone",
-    "o1",
-    "oN",
-    "oNSquared",
-    "oNCubed",
-    "oLogN",
-    "oNLogN",
-    "oAuto",
-    "oLambda",
-    "State",
-]
-
-__version__ = "1.8.3"
+from google_benchmark.version import __version__ as __version__
 
 
 class __OptionMaker:

--- a/bindings/python/google_benchmark/version.py
+++ b/bindings/python/google_benchmark/version.py
@@ -1,0 +1,7 @@
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("google-benchmark")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/docs/python_bindings.md
+++ b/docs/python_bindings.md
@@ -3,7 +3,7 @@
 Python bindings are available as wheels on [PyPI](https://pypi.org/project/google-benchmark/) for importing and 
 using Google Benchmark directly in Python. 
 Currently, pre-built wheels exist for macOS (both ARM64 and Intel x86), Linux x86-64 and 64-bit Windows.
-Supported Python versions are Python 3.7 - 3.10.
+Supported Python versions are Python 3.8 - 3.12.
 
 To install Google Benchmark's Python bindings, run:
 
@@ -25,9 +25,9 @@ python3 -m venv venv --system-site-packages
 source venv/bin/activate  # .\venv\Scripts\Activate.ps1 on Windows
 
 # upgrade Python's system-wide packages
-python -m pip install --upgrade pip setuptools wheel
-# builds the wheel and stores it in the directory "wheelhouse".
-python -m pip wheel . -w wheelhouse
+python -m pip install --upgrade pip build
+# builds the wheel and stores it in the directory "dist".
+python -m build
 ```
 
 NB: Building wheels from source requires Bazel. For platform-specific instructions on how to install Bazel,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -8,9 +8,8 @@
     * `git log $(git describe --abbrev=0 --tags)..HEAD` gives you the list of
       commits between the last annotated tag and HEAD
     * Pick the most interesting.
-* Create one last commit that updates the version saved in `CMakeLists.txt`, `MODULE.bazel`
-  and the `__version__` variable in `bindings/python/google_benchmark/__init__.py`to the
-  release version you're creating. (This version will be used if benchmark is installed
+* Create one last commit that updates the version saved in `CMakeLists.txt` and `MODULE.bazel`
+  to the release version you're creating. (This version will be used if benchmark is installed
   from the archive you'll be creating in the next step.)
 
 ```
@@ -21,16 +20,6 @@ project (benchmark VERSION 1.8.0 LANGUAGES CXX)
 module(name = "com_github_google_benchmark", version="1.8.0")
 ```
 
-```python
-# bindings/python/google_benchmark/__init__.py
-
-# ...
-
-__version__ = "1.8.0"  # <-- change this to the release version you are creating
-
-# ...
-```
-
 * Create a release through github's interface
     * Note this will create a lightweight tag.
     * Update this to an annotated tag:
@@ -38,4 +27,5 @@ __version__ = "1.8.0"  # <-- change this to the release version you are creating
       * `git tag -a -f <tag> <tag>`
       * `git push --force --tags origin`
 * Confirm that the "Build and upload Python wheels" action runs to completion
-    * run it manually if it hasn't run
+    * Run it manually if it hasn't run.
+    * IMPORTANT: When re-running manually, make sure to select the newly created `<tag>` as the workflow version in the "Run workflow" tab on the GitHub Actions page. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=64", "setuptools-scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -52,8 +52,9 @@ zip-safe = false
 where = ["bindings/python"]
 
 [tool.setuptools.dynamic]
-version = { attr = "google_benchmark.__version__" }
 readme = { file = "README.md", content-type = "text/markdown" }
+
+[tool.setuptools_scm]
 
 [tool.black]
 # Source https://github.com/psf/black#configuration-format
@@ -85,3 +86,6 @@ ignore = [
     # line too long, rely on black for formatting.
     "E501",
 ]
+
+[tool.ruff.isort]
+combine-as-imports = true


### PR DESCRIPTION
This removes the need for manually bumping versions in the Python bindings.

For the wheel uploads, the correct semver version is inferred in the case of tagged commits, which is exactly the case in GitHub CI.

The docs were updated to reflect the changes in the release workflow.

We also add a runtime-useable version, which is the best practice mentioned in the `setuptools_scm` docs, see https://setuptools-scm.readthedocs.io/en/latest/usage/#version-at-runtime.

