### PR TITLE
Switch out black for ruff format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,12 +10,9 @@ repos:
       - id: mypy
         types_or: [ python, pyi ]
         args: [ "--ignore-missing-imports", "--scripts-are-modules" ]
-  - repo: https://github.com/psf/black
-    rev: 23.10.1
-    hooks:
-      - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.3
+    rev: v0.1.5
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,6 @@ readme = { file = "README.md", content-type = "text/markdown" }
 
 [tool.setuptools_scm]
 
-[tool.black]
-# Source https://github.com/psf/black#configuration-format
-include = "\\.pyi?$"
-line-length = 80
-target-version = ["py311"]
-
 [tool.mypy]
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -78,6 +72,7 @@ ignore_missing_imports = true
 # explicitly tell ruff the source directory to correctly identify first-party package.
 src = ["bindings/python"]
 line-length = 80
+target-version = "py311"
 # Enable pycodestyle (`E`, `W`), Pyflakes (`F`), and isort (`I`) codes by default.
 select = ["E", "F", "I", "W"]
 ignore = [


### PR DESCRIPTION
Saves one pre-commit hook, some pyproject.toml configuration, and provides much better performance with identical behavior.

(Black style and `ruff format` style are only 99.x% compatible, but their deviations are very small, and none of them happen in this codebase. See also https://docs.astral.sh/ruff/formatter/#black-compatibility)