### PR TITLE
Add Missing `\n` at the End of Error Log String

### DIFF
--- a/src/perf_counters.cc
+++ b/src/perf_counters.cc
@@ -254,7 +254,7 @@ bool PerfCounters::IsCounterSupported(const std::string&) { return false; }
 PerfCounters PerfCounters::Create(
     const std::vector<std::string>& counter_names) {
   if (!counter_names.empty()) {
-    GetErrorLogInstance() << "Performance counters not supported.";
+    GetErrorLogInstance() << "Performance counters not supported.\n";
   }
   return NoCounters();
 }


### PR DESCRIPTION
Closes https://github.com/google/benchmark/issues/1699