### PR TITLE
Fix CMakeLists.txt for perf_counters_test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -164,7 +164,7 @@ compile_output_test(user_counters_test)
 add_test(NAME user_counters_test COMMAND user_counters_test --benchmark_min_time=0.01s)
 
 compile_output_test(perf_counters_test)
-add_test(NAME perf_counters_test COMMAND perf_counters_test --benchmark_min_time=0.01s --benchmark_perf_counters=CYCLES,BRANCHES)
+add_test(NAME perf_counters_test COMMAND perf_counters_test --benchmark_min_time=0.01s --benchmark_perf_counters=CYCLES,INSTRUCTIONS)
 
 compile_output_test(internal_threading_test)
 add_test(NAME internal_threading_test COMMAND internal_threading_test --benchmark_min_time=0.01s)


### PR DESCRIPTION
perf_counters_test fails because `benchmark/test/perf_counters_test.cc` has an INSTRUCTIONS counter. And doesn't have the BRANCHES one (since e441a8cb112a3c13629749ec8c3d65b2d170b10e).