### PR TITLE
fix(cmakelists.txt): enforce CMake to find PFM or fail when BENCHMARK…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,7 +312,7 @@ find_package(Threads REQUIRED)
 cxx_feature_check(PTHREAD_AFFINITY)
 
 if (BENCHMARK_ENABLE_LIBPFM)
-  find_package(PFM)
+  find_package(PFM REQUIRED)
 endif()
 
 # Set up directories


### PR DESCRIPTION
Enforce CMake to find PFM or fail when `BENCHMARK_ENABLE_LIBPFM` is `ON`

fix #1702