### PR TITLE
Fix `pre-commit` GitHub Actions job

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev]"
+        pip install ".[dev]"
     - name: Cache pre-commit tools
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
For some reason, editable pip installs are now broken, which means that they will break the pre-commit workflow due to the `pip install -e .` instruction.

Since the normal install is unaffected, we can just drop the `-e` switch. It does not matter which mode is used, since the environment is only used for linting.

I debugged a little bit, and found the reason why editable installs do not work right now - I just have not figured out a way to
change the Bazel extension class to do the right thing yet. (Debugging `setuptools` is not nice, since a lot of the package is stub files, and each entry point loads a different command).