### PR TITLE
Fix editable install by unsetting `build_ext.copy_extensions_to_source`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,14 @@ class BuildBazelExtension(build_ext.build_ext):
         # explicitly call `bazel shutdown` for graceful exit
         self.spawn(["bazel", "shutdown"])
 
+    def copy_extensions_to_source(self):
+        """
+        Copy generated extensions into the source tree.
+        This is done in the ``bazel_build`` method, so it's not necessary to
+        do again in the `build_ext` base class.
+        """
+        pass
+
     def bazel_build(self, ext: BazelExtension) -> None:
         """Runs the bazel build to create the package."""
         with temp_fill_include_path("WORKSPACE"):


### PR DESCRIPTION
This method was the culprit for the recent editable install breakage, since it just tries to copy the generated extension file without checking its existence.

Since the `BazelExtension` uses a non-standard location to store the build artifacts, calling the copy method fails the build since the extension is not found in the expected location.

But, since we already copy the file into the source tree as part of the `BazelExtension.bazel_build` method, it's fine - the extension appears in the right place, and the egg info is generated correctly as well.

This method also does not affect the general install, so it solves the editable problem without regressing the fixed install.