### PR TITLE
Upgrade core bazel dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,12 +3,12 @@ module(
     version = "1.8.3",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.4.2")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.6")
-bazel_dep(name = "rules_foreign_cc", version = "0.9.0")
+bazel_dep(name = "rules_foreign_cc", version = "0.10.1")
 bazel_dep(name = "rules_cc", version = "0.0.6")
 
-bazel_dep(name = "rules_python", version = "0.24.0", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "0.27.1", dev_dependency = True)
 bazel_dep(name = "googletest", version = "1.12.1", dev_dependency = True, repo_name = "com_google_googletest")
 
 bazel_dep(name = "libpfm", version = "4.11.0")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,12 +8,20 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 
 rules_foreign_cc_dependencies()
 
-load("@rules_python//python:pip.bzl", pip3_install = "pip_install")
+load("@rules_python//python:repositories.bzl", "py_repositories")
 
-pip3_install(
+py_repositories()
+
+load("@rules_python//python:pip.bzl", "pip_parse")
+
+pip_parse(
     name = "tools_pip_deps",
-    requirements = "//tools:requirements.txt",
+    requirements_lock = "//tools:requirements.txt",
 )
+
+load("@tools_pip_deps//:requirements.bzl", "install_deps")
+
+install_deps()
 
 new_local_repository(
     name = "python_headers",

--- a/bazel/benchmark_deps.bzl
+++ b/bazel/benchmark_deps.bzl
@@ -11,49 +11,41 @@ def benchmark_deps():
     if "bazel_skylib" not in native.existing_rules():
         http_archive(
             name = "bazel_skylib",
-            sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
+            sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
-                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
             ],
         )
 
     if "rules_foreign_cc" not in native.existing_rules():
         http_archive(
             name = "rules_foreign_cc",
-            sha256 = "2a4d07cd64b0719b39a7c12218a3e507672b82a97b98c6a89d38565894cf7c51",
-            strip_prefix = "rules_foreign_cc-0.9.0",
-            url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.9.0.tar.gz",
+            sha256 = "476303bd0f1b04cc311fc258f1708a5f6ef82d3091e53fd1977fa20383425a6a",
+            strip_prefix = "rules_foreign_cc-0.10.1",
+            url = "https://github.com/bazelbuild/rules_foreign_cc/releases/download/0.10.1/rules_foreign_cc-0.10.1.tar.gz",
         )
 
     if "rules_python" not in native.existing_rules():
         http_archive(
             name = "rules_python",
-            sha256 = "0a8003b044294d7840ac7d9d73eef05d6ceb682d7516781a4ec62eeb34702578",
-            url = "https://github.com/bazelbuild/rules_python/releases/download/0.24.0/rules_python-0.24.0.tar.gz",
-            strip_prefix = "rules_python-0.24.0",
-        )
-
-    if "com_google_absl" not in native.existing_rules():
-        http_archive(
-            name = "com_google_absl",
-            sha256 = "f41868f7a938605c92936230081175d1eae87f6ea2c248f41077c8f88316f111",
-            strip_prefix = "abseil-cpp-20200225.2",
-            urls = ["https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz"],
+            sha256 = "e85ae30de33625a63eca7fc40a94fea845e641888e52f32b6beea91e8b1b2793",
+            strip_prefix = "rules_python-0.27.1",
+            url = "https://github.com/bazelbuild/rules_python/releases/download/0.27.1/rules_python-0.27.1.tar.gz",
         )
 
     if "com_google_googletest" not in native.existing_rules():
         new_git_repository(
             name = "com_google_googletest",
             remote = "https://github.com/google/googletest.git",
-            tag = "release-1.11.0",
+            tag = "release-1.12.1",
         )
 
     if "nanobind" not in native.existing_rules():
         new_git_repository(
             name = "nanobind",
             remote = "https://github.com/wjakob/nanobind.git",
-            tag = "v1.7.0",
+            tag = "v1.8.0",
             build_file = "@//bindings/python:nanobind.BUILD",
             recursive_init_submodules = True,
         )


### PR DESCRIPTION
Bumps `rules_foreign_cc` to v0.10.1 (October 2023), `bazel_skylib` to v1.5.0 (November 2023), `rules_python` to v0.27.1 (December 2023), and `nanobind` to v1.8.0 (November 2023).

Also syncs GoogleTest to v1.12.1 (the last C++11 supporting version) to be the same as in MODULE.bazel.

Since the latest `rules_python` changed its setup calling convention, that is updated also in the WORKSPACE file.

FYI: I removed absl (`com_google_absl` in the Bazel deps), since it appears to be currently unused.