### PR TITLE
Run `pre-commit autoupdate`, fix stale pyproject.toml comments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   -   repo: https://github.com/keith/pre-commit-buildifier
-      rev: 6.3.3.1
+      rev: 6.4.0
       hooks:
       -   id: buildifier
       -   id: buildifier-lint
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.6.1
+    rev: v1.7.1
     hooks:
       - id: mypy
         types_or: [ python, pyi ]
         args: [ "--ignore-missing-imports", "--scripts-are-modules" ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.5
+    rev: v0.1.7
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,15 +71,14 @@ ignore_missing_imports = true
 [tool.ruff]
 # explicitly tell ruff the source directory to correctly identify first-party package.
 src = ["bindings/python"]
+
 line-length = 80
 target-version = "py311"
+
 # Enable pycodestyle (`E`, `W`), Pyflakes (`F`), and isort (`I`) codes by default.
 select = ["E", "F", "I", "W"]
 ignore = [
-    # whitespace before colon (:)
-    "E203",
-    # line too long
-    "E501",
+    "E501", # line too long
 ]
 
 [tool.ruff.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,9 @@ target-version = "py311"
 # Enable pycodestyle (`E`, `W`), Pyflakes (`F`), and isort (`I`) codes by default.
 select = ["E", "F", "I", "W"]
 ignore = [
-    # whitespace before colon (:), rely on black for formatting.
+    # whitespace before colon (:)
     "E203",
-    # line too long, rely on black for formatting.
+    # line too long
     "E501",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ class BuildBazelExtension(build_ext.build_ext):
                 "bazel",
                 "build",
                 ext.bazel_target,
+                "--enable_bzlmod=false",
                 f"--symlink_prefix={temp_path / 'bazel-'}",
                 f"--compilation_mode={'dbg' if self.debug else 'opt'}",
                 # C++17 is required by nanobind


### PR DESCRIPTION
`black` was replaced by `ruff-format`, so the comments were stale.