### PR TITLE
Check out repo at depth 0 for Python tests, bump Python and PyPI actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,16 +16,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.11
-        cache: 'pip'
+        cache: pip
         cache-dependency-path: pyproject.toml
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install ".[dev]"
+      run: python -m pip install ".[dev]"
     - name: Cache pre-commit tools
       uses: actions/cache@v3
       with:
@@ -35,5 +35,4 @@ jobs:
           ${{ env.PRE_COMMIT_HOME }}
         key: ${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}-linter-cache
     - name: Run pre-commit checks
-      run: |
-        pre-commit run --all-files --verbose --show-diff-on-failure
+      run: pre-commit run --all-files --verbose --show-diff-on-failure

--- a/.github/workflows/test_bindings.yml
+++ b/.github/workflows/test_bindings.yml
@@ -17,14 +17,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name: Install GBM Python bindings on ${{ matrix.os }}
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install .
+        run: python -m pip install .
       - name: Run bindings example on ${{ matrix.os }}
         run:
           python bindings/python/google_benchmark/example.py

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,17 +13,16 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 0
       - name: Install Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
-
-      - name: Build and check sdist
-        run: |
-          python setup.py sdist
-      - name: Upload sdist
-        uses: actions/upload-artifact@v3
+      - run: python -m pip install build
+      - name: Build sdist
+        run: python -m build --sdist
+      - uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist/*.tar.gz
@@ -38,10 +37,12 @@ jobs:
     steps:
       - name: Check out Google Benchmark
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
@@ -61,7 +62,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: dist
-          path: ./wheelhouse/*.whl
+          path: wheelhouse/*.whl
 
   pypi_upload:
     name: Publish google-benchmark wheels to PyPI
@@ -74,4 +75,4 @@ jobs:
       with:
         name: dist
         path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.8.10
+    - uses: pypa/gh-action-pypi-publish@v1.8.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm[toml]>=8"]
+requires = ["setuptools", "setuptools-scm[toml]", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
The reason for this is that `setuptools-scm` installs a version relative to the last release tag - if no tag is found, the default version is taken to be v0.1.0. This was the case in GitHub Actions, where only the PR branch is checked out.

Also unpins build system requirements in the `pyproject.toml`.

The sdist build system was changed to `build` from `python setup.py sdist` for forward compatibility - `build` is superior in every way, and the advertised solution by both cibuildwheel and PyPA itself.

Bump `actions/setup-python` to v5, `pypa/gh-action-pypi-publish` to v1.8.11, and `docker/setup-qemu-action` to v3.