### PR TITLE
Fix per-thread timing error on z/OS

### DIFF
--- a/src/timers.cc
+++ b/src/timers.cc
@@ -182,6 +182,9 @@ double ThreadCPUUsage() {
   // RTEMS doesn't support CLOCK_THREAD_CPUTIME_ID. See
   // https://github.com/RTEMS/rtems/blob/master/cpukit/posix/src/clockgettime.c
   return ProcessCPUUsage();
+#elif defined(BENCHMARK_OS_ZOS)
+  // z/OS doesn't support CLOCK_THREAD_CPUTIME_ID.
+  return ProcessCPUUsage();
 #elif defined(BENCHMARK_OS_SOLARIS)
   struct rusage ru;
   if (getrusage(RUSAGE_LWP, &ru) == 0) return MakeTime(ru);


### PR DESCRIPTION
This patch calls ProcessCPUUsage() for z/OS because we do not support CLOCK_THREAD_CPUTIME_ID. This fixes the following [issue](https://github.com/google/benchmark/issues/1718) 