### PR TITLE
fix: fail to import gbench in bazel and python3.12

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -12,8 +12,8 @@ py_library(
 py_binary(
     name = "compare",
     srcs = ["compare.py"],
-    python_version = "PY3",
     imports = ["."],
+    python_version = "PY3",
     deps = [
         ":gbench",
     ],

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -13,6 +13,7 @@ py_binary(
     name = "compare",
     srcs = ["compare.py"],
     python_version = "PY3",
+    imports = ["."],
     deps = [
         ":gbench",
     ],


### PR DESCRIPTION
See #1720 