### PR TITLE
Change Fixture to use non-const SetUp and TearDown in example

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -591,10 +591,10 @@ For Example:
 ```c++
 class MyFixture : public benchmark::Fixture {
 public:
-  void SetUp(const ::benchmark::State& state) {
+  void SetUp(::benchmark::State& state) {
   }
 
-  void TearDown(const ::benchmark::State& state) {
+  void TearDown(::benchmark::State& state) {
   }
 };
 


### PR DESCRIPTION
Const SetUp and TearDown were deprecated in https://github.com/google/benchmark/pull/285