### PR TITLE
Remove the use of "Sanity" and replace it with "Safety" 

### DIFF
--- a/test/perf_counters_gtest.cc
+++ b/test/perf_counters_gtest.cc
@@ -41,7 +41,7 @@ TEST(PerfCountersTest, NegativeTest) {
     return;
   }
   EXPECT_TRUE(PerfCounters::Initialize());
-  // Sanity checks
+  // Safety checks
   // Create() will always create a valid object, even if passed no or
   // wrong arguments as the new behavior is to warn and drop unsupported
   // counters


### PR DESCRIPTION
This small fix will silence the term scan which catches words that conflict with the current words matter initiative. 