### PR TITLE
Issue 1734: Streams not flushed if not running actual benchmarks

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -617,8 +617,6 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
   if (FLAGS_benchmark_list_tests) {
     for (auto const& benchmark : benchmarks)
       Out << benchmark.name().str() << "\n";
-    Out.flush();
-    Err.flush();
   } else {
     internal::RunBenchmarks(benchmarks, display_reporter, file_reporter);
   }

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -577,12 +577,14 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
     Err << "A custom file reporter was provided but "
            "--benchmark_out=<file> was not specified."
         << std::endl;
+    Err.flush();
     std::exit(1);
   }
   if (!fname.empty()) {
     output_file.open(fname);
     if (!output_file.is_open()) {
       Err << "invalid file name: '" << fname << "'" << std::endl;
+      Err.flush();
       std::exit(1);
     }
     if (!file_reporter) {
@@ -597,16 +599,22 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
   }
 
   std::vector<internal::BenchmarkInstance> benchmarks;
-  if (!FindBenchmarksInternal(spec, &benchmarks, &Err)) return 0;
+  if (!FindBenchmarksInternal(spec, &benchmarks, &Err)) {
+    Out.flush();
+    Err.flush();
+    return 0;
+  }
 
   if (benchmarks.empty()) {
     Err << "Failed to match any benchmarks against regex: " << spec << "\n";
+    Err.flush();
     return 0;
   }
 
   if (FLAGS_benchmark_list_tests) {
     for (auto const& benchmark : benchmarks)
       Out << benchmark.name().str() << "\n";
+    Out.flush();
   } else {
     internal::RunBenchmarks(benchmarks, display_reporter, file_reporter);
   }

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -577,6 +577,7 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
     Err << "A custom file reporter was provided but "
            "--benchmark_out=<file> was not specified."
         << std::endl;
+    Out.flush();
     Err.flush();
     std::exit(1);
   }
@@ -584,6 +585,7 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
     output_file.open(fname);
     if (!output_file.is_open()) {
       Err << "invalid file name: '" << fname << "'" << std::endl;
+      Out.flush();
       Err.flush();
       std::exit(1);
     }
@@ -607,6 +609,7 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
 
   if (benchmarks.empty()) {
     Err << "Failed to match any benchmarks against regex: " << spec << "\n";
+    Out.flush();
     Err.flush();
     return 0;
   }
@@ -615,10 +618,13 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
     for (auto const& benchmark : benchmarks)
       Out << benchmark.name().str() << "\n";
     Out.flush();
+    Err.flush();
   } else {
     internal::RunBenchmarks(benchmarks, display_reporter, file_reporter);
   }
 
+  Out.flush();
+  Err.flush();
   return benchmarks.size();
 }
 


### PR DESCRIPTION
If the call paths in RunSpecifiedBenchmarks do not go into internal::RunBenchmarks, the Out and Err streams are flushed before exiting.