### PR TITLE
Enable vectors in `DoNotOptimize`

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -461,15 +461,15 @@ BENCHMARK_DEPRECATED_MSG(
     "The const-ref version of this method can permit "
     "undesired compiler optimizations in benchmarks")
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
-  asm volatile("" : : "r,m"(value) : "memory");
+  asm volatile("" : : "r,m,v"(value) : "memory");
 }
 
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
 #if defined(__clang__)
-  asm volatile("" : "+r,m"(value) : : "memory");
+  asm volatile("" : "+r,m,+v"(value) : : "memory");
 #else
-  asm volatile("" : "+m,r"(value) : : "memory");
+  asm volatile("" : "+m,r,v"(value) : : "memory");
 #endif
 }
 
@@ -477,9 +477,9 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp&& value) {
 #if defined(__clang__)
-  asm volatile("" : "+r,m"(value) : : "memory");
+  asm volatile("" : "+r,m,+v"(value) : : "memory");
 #else
-  asm volatile("" : "+m,r"(value) : : "memory");
+  asm volatile("" : "+m,r,v"(value) : : "memory");
 #endif
 }
 #endif
@@ -494,7 +494,7 @@ inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<std::is_trivially_copyable<Tp>::value &&
                             (sizeof(Tp) <= sizeof(Tp*))>::type
     DoNotOptimize(Tp const& value) {
-  asm volatile("" : : "r,m"(value) : "memory");
+  asm volatile("" : : "r,m,v"(value) : "memory");
 }
 
 template <class Tp>
@@ -505,7 +505,7 @@ inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<!std::is_trivially_copyable<Tp>::value ||
                             (sizeof(Tp) > sizeof(Tp*))>::type
     DoNotOptimize(Tp const& value) {
-  asm volatile("" : : "m"(value) : "memory");
+  asm volatile("" : : "m,v"(value) : "memory");
 }
 
 template <class Tp>
@@ -513,7 +513,7 @@ inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<std::is_trivially_copyable<Tp>::value &&
                             (sizeof(Tp) <= sizeof(Tp*))>::type
     DoNotOptimize(Tp& value) {
-  asm volatile("" : "+m,r"(value) : : "memory");
+  asm volatile("" : "+m,r,v"(value) : : "memory");
 }
 
 template <class Tp>
@@ -521,7 +521,7 @@ inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<!std::is_trivially_copyable<Tp>::value ||
                             (sizeof(Tp) > sizeof(Tp*))>::type
     DoNotOptimize(Tp& value) {
-  asm volatile("" : "+m"(value) : : "memory");
+  asm volatile("" : "+m,v"(value) : : "memory");
 }
 
 template <class Tp>
@@ -529,7 +529,7 @@ inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<std::is_trivially_copyable<Tp>::value &&
                             (sizeof(Tp) <= sizeof(Tp*))>::type
     DoNotOptimize(Tp&& value) {
-  asm volatile("" : "+m,r"(value) : : "memory");
+  asm volatile("" : "+m,r,v"(value) : : "memory");
 }
 
 template <class Tp>
@@ -537,7 +537,7 @@ inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<!std::is_trivially_copyable<Tp>::value ||
                             (sizeof(Tp) > sizeof(Tp*))>::type
     DoNotOptimize(Tp&& value) {
-  asm volatile("" : "+m"(value) : : "memory");
+  asm volatile("" : "+m,v"(value) : : "memory");
 }
 
 #else

--- a/test/donotoptimize_assembly_test.cc
+++ b/test/donotoptimize_assembly_test.cc
@@ -199,3 +199,51 @@ extern "C" void test_pointer_lvalue() {
   int *xp = &x;
   benchmark::DoNotOptimize(xp);
 }
+
+#if ((defined __clang__) || (defined __GNUC__)) && \
+    (defined __has_attribute) && (defined __x86_64__)
+#if __has_attribute(ext_vector_type)
+typedef float float4 __attribute__((ext_vector_type(4)));
+typedef float float8 __attribute__((ext_vector_type(8)));
+typedef float float16 __attribute__((ext_vector_type(16)));
+// CHECK-LABEL: test_pointer_f4_rvalue
+extern "C" void test_pointer_f4_rvalue() {
+  // CHECK: {{.*}}%xmm{{[0-9]+}}{{.*}}{{.*}}
+  // CHECK: ret
+  benchmark::DoNotOptimize(float4{});
+}
+// CHECK-LABEL: test_pointer_f8_rvalue
+extern "C" void test_pointer_f8_rvalue() {
+  // CHECK: {{.*}}%xmm{{[0-9]+}}{{.*}}{{.*}}
+  // CHECK: ret
+  benchmark::DoNotOptimize(float8{});
+}
+// CHECK-LABEL: test_pointer_f16_rvalue
+extern "C" void test_pointer_f16_rvalue() {
+  // CHECK: {{.*}}%xmm{{[0-9]+}}{{.*}}{{.*}}
+  // CHECK: ret
+  benchmark::DoNotOptimize(float16{});
+}
+// CHECK-LABEL: test_pointer_f4_lvalue
+extern "C" void test_pointer_f4_lvalue() {
+  // CHECK: {{.*}}%xmm{{[0-9]+}}{{.*}}{{.*}}
+  // CHECK: ret
+  float4 f4 = float4{};
+  benchmark::DoNotOptimize(f4);
+}
+// CHECK-LABEL: test_pointer_f8_lvalue
+extern "C" void test_pointer_f8_lvalue() {
+  // CHECK: {{.*}}%xmm{{[0-9]+}}{{.*}}{{.*}}
+  // CHECK: ret
+  float8 f8 = float8{};
+  benchmark::DoNotOptimize(f8);
+}
+// CHECK-LABEL: test_pointer_f16_lvalue
+extern "C" void test_pointer_f16_lvalue() {
+  // CHECK: {{.*}}%xmm{{[0-9]+}}{{.*}}{{.*}}
+  // CHECK: ret
+  float16 f16 = float16{};
+  benchmark::DoNotOptimize(f16);
+}
+#endif
+#endif


### PR DESCRIPTION
Just a QOL change to make benchmarks vector code easier.