### PR TITLE
Bump pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ repos:
       -   id: buildifier
       -   id: buildifier-lint
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.8.0
     hooks:
       - id: mypy
         types_or: [ python, pyi ]
         args: [ "--ignore-missing-imports", "--scripts-are-modules" ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.7
+    rev: v0.1.13
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]

--- a/tools/gbench/util.py
+++ b/tools/gbench/util.py
@@ -131,9 +131,7 @@ def load_benchmark_results(fname, benchmark_filter):
         if benchmark_filter is None:
             return True
         name = benchmark.get("run_name", None) or benchmark["name"]
-        if re.search(benchmark_filter, name):
-            return True
-        return False
+        return re.search(benchmark_filter, name) is not None
 
     with open(fname, "r") as f:
         results = json.load(f)


### PR DESCRIPTION
Bumps `mypy` to v1.8.0, and `ruff` to v0.1.13.

Also fix a mypy error in `tools.gbench.util` - the condition behaves the same as before, but in the new mypy version, the old condition results in an unreachable code error for the final `return False` statement.

This is most likely a bug in mypy's reachability analysis, but the fix is easy enough here to circumvent it.