### PR TITLE
set library version in bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -51,6 +51,7 @@ cc_library(
     }),
     defines = [
         "BENCHMARK_STATIC_DEFINE",
+        "BENCHMARK_VERSION=\\\"" + (module_version() if module_version() != None else "") + "\\\"",
     ] + select({
         ":perfcounters": ["HAVE_LIBPFM"],
         "//conditions:default": [],

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -748,9 +748,7 @@ int InitializeStreams() {
 
 }  // end namespace internal
 
-std::string GetBenchmarkVersiom() {
-  return {BENCHMARK_VERSION};
-}
+std::string GetBenchmarkVersiom() { return {BENCHMARK_VERSION}; }
 
 void PrintDefaultHelp() {
   fprintf(stdout,

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -749,11 +749,7 @@ int InitializeStreams() {
 }  // end namespace internal
 
 std::string GetBenchmarkVersiom() {
-#if defined(BENCHMARK_VERSION)
   return {BENCHMARK_VERSION};
-#else
-  return "";
-#endif
 }
 
 void PrintDefaultHelp() {

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -752,7 +752,7 @@ std::string GetBenchmarkVersiom() {
 #if defined(BENCHMARK_VERSION)
   return {BENCHMARK_VERSION};
 #else
-  return "hello, bazel!";
+  return "";
 #endif
 }
 


### PR DESCRIPTION
note if bzlmod is disabled the version will be an empty string