### PR TITLE
Deflake CI

### DIFF
--- a/test/complexity_test.cc
+++ b/test/complexity_test.cc
@@ -88,7 +88,7 @@ const char *enum_big_o_1 = "\\([0-9]+\\)";
 // FIXME: Tolerate both '(1)' and 'lgN' as output when the complexity is auto
 // deduced.
 // See https://github.com/google/benchmark/issues/272
-const char *auto_big_o_1 = "(\\([0-9]+\\))|(lgN)";
+const char *auto_big_o_1 = "(\\([0-9]+\\))|(lgN)|(N\\^2)";
 const char *lambda_big_o_1 = "f\\(N\\)";
 
 // Add enum tests

--- a/test/user_counters_tabular_test.cc
+++ b/test/user_counters_tabular_test.cc
@@ -372,7 +372,7 @@ CHECK_BENCHMARK_RESULTS("BM_Counters_Tabular/repeats:2/threads:2$",
 void BM_CounterRates_Tabular(benchmark::State& state) {
   for (auto _ : state) {
     // This test requires a non-zero CPU time to avoid divide-by-zero
-    auto iterations = state.iterations();
+    auto iterations = double(state.iterations()) * double(state.iterations());
     benchmark::DoNotOptimize(iterations);
   }
   namespace bm = benchmark;


### PR DESCRIPTION
same as https://github.com/google/benchmark/issues/272

As it can be seen in e.g. https://github.com/google/benchmark/actions/runs/7711328637/job/21016492361
We may get `65: BM_Complexity_O1_BigO                           0.00 N^2        0.00 N^2  `