### PR TITLE
Fix typo in GetBenchmarkVersion()

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -303,7 +303,7 @@ class BenchmarkReporter;
 const char kDefaultMinTimeStr[] = "0.5s";
 
 // Returns the version of the library.
-BENCHMARK_EXPORT std::string GetBenchmarkVersiom();
+BENCHMARK_EXPORT std::string GetBenchmarkVersion();
 
 BENCHMARK_EXPORT void PrintDefaultHelp();
 

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -748,7 +748,7 @@ int InitializeStreams() {
 
 }  // end namespace internal
 
-std::string GetBenchmarkVersiom() { return {BENCHMARK_VERSION}; }
+std::string GetBenchmarkVersion() { return {BENCHMARK_VERSION}; }
 
 void PrintDefaultHelp() {
   fprintf(stdout,

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -167,7 +167,7 @@ bool JSONReporter::ReportContext(const Context& context) {
   }
   out << "],\n";
 
-  out << indent << FormatKV("library_version", GetBenchmarkVersiom());
+  out << indent << FormatKV("library_version", GetBenchmarkVersion());
   out << ",\n";
 
 #if defined(NDEBUG)


### PR DESCRIPTION
I just stumbled upon this when trying to fix a google_benchmark roll into V8.