### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ On a unix system, the build directory should now look something like this:
 Next, you can run the tests to check the build.
 
 ```bash
-$ cmake -E chdir "build" ctest --build-config Release
+cmake -E chdir "build" ctest --build-config Release
 ```
 
 If you want to install the library globally, also run:


### PR DESCRIPTION
Remove the `$` at the start of the bash command to run the tests so that it can be copy-pasted by a user without any errors

This change is consistent with the other 1-line bash snippets in the readme