### PR TITLE
clang-tidy broke the world

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,5 @@
 Checks:          'clang-analyzer-*,readability-redundant-*,performance-*'
 WarningsAsErrors: 'clang-analyzer-*,readability-redundant-*,performance-*'
 HeaderFilterRegex: '.*'
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 User:            user


### PR DESCRIPTION
`AnalyzeTemporaryDtors` option is no longer recognized by clang-tidy-18, and that renders the whole config invalid and completely ignored. What are they thinking?