### PR TITLE
allow BENCHMARK_VERSION to be undefined

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -757,7 +757,13 @@ int InitializeStreams() {
 
 }  // end namespace internal
 
-std::string GetBenchmarkVersion() { return {BENCHMARK_VERSION}; }
+std::string GetBenchmarkVersion() {
+#ifdef BENCHMARK_VERSION
+  return {BENCHMARK_VERSION};
+#else
+  return {""};
+#endif
+}
 
 void PrintDefaultHelp() {
   fprintf(stdout,


### PR DESCRIPTION
closes #1768 

motivation is to allow simpler override at compilation time
shouldn't impact anyone using the official build tools as it's all internal in that case

I haven't tested the bazel build output for the function `benchmark::GetBenchmarkVersion()` but I'm guessing it's without the extra quote from "stringification" given the modifications

I have tested the cmake build output for the funciton, and the string is without quotes with the proposed changes

PRed on my fork for testing [here](https://github.com/PhilipDeegan/benchmark/pull/1)
I can't explain the sanitizer failures so I'm figuring they are existing

