### PR TITLE
Refactor: Return frequency as double

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -736,7 +736,7 @@ double GetCPUCyclesPerSecond(CPUInfo::Scaling scaling) {
 #if defined BENCHMARK_OS_OPENBSD
   if (GetSysctl(freqStr, &hz)) return static_cast<double>(hz * 1000000);
 #else
-  if (GetSysctl(freqStr, &hz)) return hz;
+  if (GetSysctl(freqStr, &hz)) return static_cast<double>(hz);
 #endif
   fprintf(stderr, "Unable to determine clock rate from sysctl: %s: %s\n",
           freqStr, strerror(errno));


### PR DESCRIPTION
Adjusted the GetSysctl call in sysinfo.cc to ensure the frequency value is returned as a double rather than an integer.

Fixes https://github.com/google/benchmark/issues/1781.