### PR TITLE
hotfix: Correct pypi-publishing action tag to v1.8.14

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -87,4 +87,4 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: dist
-      - uses: pypa/gh-action-pypi-publish@v1
+      - uses: pypa/gh-action-pypi-publish@v1.8.14

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ repos:
       -   id: buildifier
       -   id: buildifier-lint
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.10.0
     hooks:
       - id: mypy
         types_or: [ python, pyi ]
         args: [ "--ignore-missing-imports", "--scripts-are-modules" ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.1
+    rev: v0.4.5
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]


### PR DESCRIPTION
Also bump pre-commit dependencies via `pre-commit autoupdate`.

--------------------

Addresses the failure seen in https://github.com/google/benchmark/actions/runs/9209442873/job/25336054125.

There might still be problems afterwards if trusted publishing is not set up on the google/benchmark PyPI account, which I cannot confirm. But I'm standing by in case of further problems.