### PR TITLE
CMake: unbreak version handling for tarballs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ get_git_version(GIT_VERSION)
 
 # If no git version can be determined, use the version
 # from the project() command
-if ("${GIT_VERSION}" STREQUAL "0.0.0")
+if ("${GIT_VERSION}" STREQUAL "v0.0.0")
   set(VERSION "v${benchmark_VERSION}")
 else()
   set(VERSION "${GIT_VERSION}")


### PR DESCRIPTION
#1742 changed the placeholder version from `0.0.0` to `v0.0.0`, but this line which was further dealing with it, was not updated.

Fixes https://github.com/google/benchmark/issues/1792