### PR TITLE
Upgrade google/benchmark to use nanobind-bazel v2.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,4 +38,4 @@ use_repo(pip, "tools_pip_deps")
 
 # -- bazel_dep definitions -- #
 
-bazel_dep(name = "nanobind_bazel", version = "1.0.0", dev_dependency = True)
+bazel_dep(name = "nanobind_bazel", version = "2.0.0", dev_dependency = True)

--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -118,7 +118,7 @@ NB_MODULE(_benchmark, m) {
   using benchmark::Counter;
   nb::class_<Counter> py_counter(m, "Counter");
 
-  nb::enum_<Counter::Flags>(py_counter, "Flags")
+  nb::enum_<Counter::Flags>(py_counter, "Flags", nb::is_arithmetic())
       .value("kDefaults", Counter::Flags::kDefaults)
       .value("kIsRate", Counter::Flags::kIsRate)
       .value("kAvgThreads", Counter::Flags::kAvgThreads)
@@ -130,7 +130,7 @@ NB_MODULE(_benchmark, m) {
       .value("kAvgIterationsRate", Counter::Flags::kAvgIterationsRate)
       .value("kInvert", Counter::Flags::kInvert)
       .export_values()
-      .def(nb::self | nb::self);
+      .def("__or__", [](Counter::Flags a, Counter::Flags b) { return a | b; });
 
   nb::enum_<Counter::OneK>(py_counter, "OneK")
       .value("kIs1000", Counter::OneK::kIs1000)


### PR DESCRIPTION
This enables binding extension builds with nanobind@v2.

Due to some backwards-incompatible changes in the treatment of enums, `Counter::Flags` (a flag-based enum) needs to be explicitly marked as arithmetic; setting flags is done as before with the logical "or" operator (now bound like any other class method as `__or__()`, the Python logical or operator slot).

The bindings changes were suggested by @hawkinsp in the corresponding issue on the repo, see https://github.com/google/benchmark/issues/1790.

----------------------------

Fixes #1790.