### PR TITLE
Docs: Bump minimum required C++ version from C++11 to C++14

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ IRC channels:
 
 ## Requirements
 
-The library can be used with C++03. However, it requires C++11 to build,
+The library can be used with C++03. However, it requires C++14 to build,
 including compiler and standard library support.
 
 _See [dependencies.md](docs/dependencies.md) for more details regarding supported


### PR DESCRIPTION
This is follow-up to https://github.com/google/benchmark/pull/1799.