### PR TITLE
Add -lkstat to the .pc for Solaris

### DIFF
--- a/cmake/benchmark.pc.in
+++ b/cmake/benchmark.pc.in
@@ -8,5 +8,5 @@ Description: Google microbenchmark framework
 Version: @VERSION@
 
 Libs: -L${libdir} -lbenchmark
-Libs.private: -lpthread @pkg_config_private_libs@
+Libs.private: -lpthread @BENCHMARK_PRIVATE_LINK_LIBRARIES@
 Cflags: -I${includedir}

--- a/cmake/benchmark.pc.in
+++ b/cmake/benchmark.pc.in
@@ -8,5 +8,5 @@ Description: Google microbenchmark framework
 Version: @VERSION@
 
 Libs: -L${libdir} -lbenchmark
-Libs.private: -lpthread
+Libs.private: -lpthread @pkg_config_private_libs@
 Cflags: -I${includedir}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 # We need extra libraries on Solaris
 if(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
   target_link_libraries(benchmark PRIVATE kstat)
-  set(pkg_config_private_libs -lkstat)
+  set(BENCHMARK_PRIVATE_LINK_LIBRARIES -lkstat)
 endif()
 
 if (NOT BUILD_SHARED_LIBS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,7 @@ endif()
 # We need extra libraries on Solaris
 if(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
   target_link_libraries(benchmark PRIVATE kstat)
+  set(pkg_config_private_libs -lkstat)
 endif()
 
 if (NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
This fixes linking for projects that rely on pkg-config to generate the link line on Solaris.

Test plan: Built the project locally on Solaris and verified -kstat appears in the .pc file

```
$ cat lib/pkgconfig/benchmark.pc  | grep Libs.private
Libs.private: -lpthread -lkstat
```