### PR TITLE
cycleclock: Fix type conversion to match function return type on riscv64

### DIFF
--- a/src/cycleclock.h
+++ b/src/cycleclock.h
@@ -210,7 +210,7 @@ inline BENCHMARK_ALWAYS_INLINE int64_t Now() {
 #else
   uint64_t cycles;
   asm volatile("rdtime %0" : "=r"(cycles));
-  return cycles;
+  return static_cast<int64_t>(cycles);
 #endif
 #elif defined(__e2k__) || defined(__elbrus__)
   struct timeval tv;


### PR DESCRIPTION
Fixes builds with clang

src/cycleclock.h:213:10: error: implicit conversion changes signedness: 'uint64_t' (aka 'unsigned long') to 'int64_t' (aka 'long') [-Werror,-Wsign-conversion]
     213 |   return cycles;
         |   ~~~~~~ ^~~~~~
   1 error generated.