### PR TITLE
[bazel] Use `includes` instead of `strip_include_prefix`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -73,6 +73,7 @@ cc_library(
         ":perfcounters": ["HAVE_LIBPFM"],
         "//conditions:default": [],
     }),
+    includes = ["include"],
     linkopts = select({
         ":windows": ["-DEFAULTLIB:shlwapi.lib"],
         "//conditions:default": ["-pthread"],
@@ -87,7 +88,6 @@ cc_library(
         "_LARGEFILE64_SOURCE",
         "_LARGEFILE_SOURCE",
     ],
-    strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = select({
         ":perfcounters": ["@libpfm"],
@@ -102,7 +102,7 @@ cc_library(
         "include/benchmark/benchmark.h",
         "include/benchmark/export.h",
     ],
-    strip_include_prefix = "include",
+    includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [":benchmark"],
 )


### PR DESCRIPTION
When using `includes`, consumers will apply the headers using `-isystem`, instead of `-I`. This will allow diagnostics of consumers to not apply to `benchmark`.

More info:

https://bazel.build/reference/be/c-cpp#cc_library.includes

https://bazel.build/reference/be/c-cpp#cc_library.strip_include_prefix

gtest uses `includes` as well:
https://github.com/google/googletest/blob/1d17ea141d2c11b8917d2c7d029f1c4e2b9769b2/BUILD.bazel#L120