### PR TITLE
Find libpfm dependency in installed CMake configs

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -4,4 +4,8 @@ include (CMakeFindDependencyMacro)
 
 find_dependency (Threads)
 
+if (@BENCHMARK_ENABLE_LIBPFM@)
+    find_dependency (PFM)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")


### PR DESCRIPTION
Currently, Google Benchmark can be built and installed with support for libpfm, but this can cause a problem if that installation is later called upon by another CMake project. Indeed, while the installed CMake configuration script correctly identifies that it needs to link against libpfm, it doesn't try to find libpfm, meaning that the target will be unavailable. This commit fixes this potential configuration-time error by ensuring that an installation of Google Benchmark will correctly try to find the libpfm dependency when it is used elsewhere.