### PR TITLE
Revert to token authentication for PyPI wheel uploads

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -81,10 +81,11 @@ jobs:
     name: Publish google-benchmark wheels to PyPI
     needs: [merge_wheels]
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           path: dist
-      - uses: pypa/gh-action-pypi-publish@v1.8.14
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Until the PyPI account is recovered, it should be possible to upload wheels with the GitHub secrets that were previously used.

Changes the PyPI upload action sourcing to point to the v1 stable release branch, which receives rolling updates and is the canonical way of including the wheel publishing action.

Uploading will probably need another release, because setuptools_scm needs to produce a clean tag that the PyPI API allows as an upload.