### PR TITLE
Bump nanobind-bazel to v2.1.0, add stubgen target

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,4 +38,4 @@ use_repo(pip, "tools_pip_deps")
 
 # -- bazel_dep definitions -- #
 
-bazel_dep(name = "nanobind_bazel", version = "2.0.0", dev_dependency = True)
+bazel_dep(name = "nanobind_bazel", version = "2.1.0", dev_dependency = True)

--- a/bindings/python/google_benchmark/BUILD
+++ b/bindings/python/google_benchmark/BUILD
@@ -1,4 +1,4 @@
-load("@nanobind_bazel//:build_defs.bzl", "nanobind_extension")
+load("@nanobind_bazel//:build_defs.bzl", "nanobind_extension", "nanobind_stubgen")
 
 py_library(
     name = "google_benchmark",
@@ -13,6 +13,12 @@ nanobind_extension(
     name = "_benchmark",
     srcs = ["benchmark.cc"],
     deps = ["//:benchmark"],
+)
+
+nanobind_stubgen(
+    name = "benchmark_stubgen",
+    marker_file = "bindings/python/google_benchmark/py.typed",
+    module = ":_benchmark",
 )
 
 py_test(


### PR DESCRIPTION
Adds a stub file for the `google_benchmark._benchmark` submodule, generated with the new `nanobind_stubgen` rule released in nanobind_bazel v2.1.0.

Tweaks the setup.py logic a little bit to package stub files with the rest of the build artifacts. Also explicitly adds the generated stub and marker files to the list of package data artifacts.