### PR TITLE
Verify RegisterProfilerManager doesn't overwrite an existing registration

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -663,6 +663,10 @@ void RegisterMemoryManager(MemoryManager* manager) {
 }
 
 void RegisterProfilerManager(ProfilerManager* manager) {
+  // Don't allow overwriting an existing manager.
+  if (manager != nullptr) {
+    BM_CHECK_EQ(internal::profiler_manager, nullptr);
+  }
   internal::profiler_manager = manager;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -254,6 +254,7 @@ if (BENCHMARK_ENABLE_GTEST_TESTS)
   add_gtest(perf_counters_gtest)
   add_gtest(time_unit_gtest)
   add_gtest(min_time_parse_gtest)
+  add_gtest(profiler_manager_gtest)
 endif(BENCHMARK_ENABLE_GTEST_TESTS)
 
 ###############################################################################

--- a/test/profiler_manager_gtest.cc
+++ b/test/profiler_manager_gtest.cc
@@ -1,0 +1,42 @@
+#include <memory>
+
+#include "benchmark/benchmark.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+class TestProfilerManager : public benchmark::ProfilerManager {
+ public:
+  void AfterSetupStart() override { ++start_called; }
+  void BeforeTeardownStop() override { ++stop_called; }
+
+  int start_called = 0;
+  int stop_called = 0;
+};
+
+void BM_empty(benchmark::State& state) {
+  for (auto _ : state) {
+    auto iterations = state.iterations();
+    benchmark::DoNotOptimize(iterations);
+  }
+}
+BENCHMARK(BM_empty);
+
+TEST(ProfilerManager, ReregisterManager) {
+#if GTEST_HAS_DEATH_TEST
+  // Tests only runnable in debug mode (when BM_CHECK is enabled).
+#ifndef NDEBUG
+#ifndef TEST_BENCHMARK_LIBRARY_HAS_NO_ASSERTIONS
+  ASSERT_DEATH_IF_SUPPORTED(
+      {
+        std::unique_ptr<TestProfilerManager> pm(new TestProfilerManager());
+        benchmark::RegisterProfilerManager(pm.get());
+        benchmark::RegisterProfilerManager(pm.get());
+      },
+      "RegisterProfilerManager");
+#endif
+#endif
+#endif
+}
+
+}  // namespace


### PR DESCRIPTION
Tested:
Configure with:
cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DBENCHMARK_DOWNLOAD_DEPENDENCIES=on
Then run:
ctest -R profiler_manager_gtest
Before change test fails (expected), after change test passes (expected)