### PR TITLE
Fix C4459: Rename a function parameter `profiler_manager` to avoid hiding the global declaration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,10 @@ if (MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
+  if(BENCHMARK_ENABLE_WERROR)
+      add_cxx_compiler_flag(-WX)
+  endif()
+
   if (NOT BENCHMARK_ENABLE_EXCEPTIONS)
     add_cxx_compiler_flag(-EHs-)
     add_cxx_compiler_flag(-EHa-)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,10 @@ if (MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
+  # Disable padding warning because we did it intentionally
+  # C4324: 'benchmark::State': structure was padded due to alignment specifier
+  add_cxx_compiler_flag(-wd4324)
+
   if(BENCHMARK_ENABLE_WERROR)
       add_cxx_compiler_flag(-WX)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,10 +150,6 @@ if (MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
-  # Disable padding warning because we did it intentionally
-  # C4324: 'benchmark::State': structure was padded due to alignment specifier
-  add_cxx_compiler_flag(-wd4324)
-
   if(BENCHMARK_ENABLE_WERROR)
       add_cxx_compiler_flag(-WX)
   endif()

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -796,9 +796,15 @@ enum Skipped
 
 }  // namespace internal
 
+#if defined(_MSC_VER) 
+#pragma warning(push)
+// C4324: 'benchmark::State': structure was padded due to alignment specifier
+#pragma warning(disable : 4324) 
+#endif  // _MSC_VER_
 // State is passed to a running Benchmark and contains state for the
 // benchmark to use.
 class BENCHMARK_EXPORT BENCHMARK_INTERNAL_CACHELINE_ALIGNED State {
+
  public:
   struct StateIterator;
   friend struct StateIterator;
@@ -1063,6 +1069,9 @@ class BENCHMARK_EXPORT BENCHMARK_INTERNAL_CACHELINE_ALIGNED State {
 
   friend class internal::BenchmarkInstance;
 };
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif // _MSC_VER_
 
 inline BENCHMARK_ALWAYS_INLINE bool State::KeepRunning() {
   return KeepRunningInternal(1, /*is_batch=*/false);

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -796,10 +796,10 @@ enum Skipped
 
 }  // namespace internal
 
-#if defined(_MSC_VER) 
+#if defined(_MSC_VER)
 #pragma warning(push)
 // C4324: 'benchmark::State': structure was padded due to alignment specifier
-#pragma warning(disable : 4324) 
+#pragma warning(disable : 4324)
 #endif  // _MSC_VER_
 // State is passed to a running Benchmark and contains state for the
 // benchmark to use.
@@ -1070,7 +1070,7 @@ class BENCHMARK_EXPORT BENCHMARK_INTERNAL_CACHELINE_ALIGNED State {
 };
 #if defined(_MSC_VER)
 #pragma warning(pop)
-#endif // _MSC_VER_
+#endif  // _MSC_VER_
 
 inline BENCHMARK_ALWAYS_INLINE bool State::KeepRunning() {
   return KeepRunningInternal(1, /*is_batch=*/false);

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -804,7 +804,6 @@ enum Skipped
 // State is passed to a running Benchmark and contains state for the
 // benchmark to use.
 class BENCHMARK_EXPORT BENCHMARK_INTERNAL_CACHELINE_ALIGNED State {
-
  public:
   struct StateIterator;
   friend struct StateIterator;

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -126,14 +126,14 @@ BenchmarkReporter::Run CreateRunReport(
 void RunInThread(const BenchmarkInstance* b, IterationCount iters,
                  int thread_id, ThreadManager* manager,
                  PerfCountersMeasurement* perf_counters_measurement,
-                 ProfilerManager* profiler_manager) {
+                 ProfilerManager* profiler_manager_) {
   internal::ThreadTimer timer(
       b->measure_process_cpu_time()
           ? internal::ThreadTimer::CreateProcessCpuTime()
           : internal::ThreadTimer::Create());
 
   State st = b->Run(iters, thread_id, &timer, manager,
-                    perf_counters_measurement, profiler_manager);
+                    perf_counters_measurement, profiler_manager_);
   BM_CHECK(st.skipped() || st.iterations() >= st.max_iterations)
       << "Benchmark returned before State::KeepRunning() returned false!";
   {


### PR DESCRIPTION
Hello.
Thank you for your library!
I tried to upgrade from 1.8.5 to 1.9.0 and I faced with an error:
```
D:\a\_work\1\s\benchmarks\google-benchmark\src\benchmark_runner.cc(129,35): error C2220: the following warning is treated as an error
                 ProfilerManager* profiler_manager) {
                                  ^
D:\a\_work\1\s\benchmarks\google-benchmark\src\benchmark_runner.cc(129,35): warning C4459: declaration of 'profiler_manager' hides global declaration
D:\a\_work\1\s\benchmarks\google-benchmark\src\benchmark_runner.cc(65,18): note: see declaration of 'benchmark::internal::profiler_manager'
ProfilerManager* profiler_manager = nullptr;
                 ^
```
Would you mind a slight renaming to solve the issue?
Feel free to suggest a better name...