### PR TITLE
Bump oldest supported Python to 3.10, eliminate setuptools-scm

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: "3.12"
       - run: python -m pip install build
       - name: Build sdist
         run: python -m build --sdist
@@ -40,16 +40,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-python@v5
+        name: Install Python 3.12
+        with:
+          python-version: "3.12"
+      - run: pip install --upgrade pip uv
+
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
-      - name: Build 3.8 wheels on ${{ matrix.os }} using cibuildwheel
+      - name: Build wheels on ${{ matrix.os }} using cibuildwheel
         uses: pypa/cibuildwheel@v2.20
         env:
-          CIBW_BUILD: "cp38-*"
+          CIBW_BUILD: "cp310-* cp311-* cp312-*"
+          CIBW_BUILD_FRONTEND: "build[uv]"
           CIBW_SKIP: "*-musllinux_*"
           CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
           CIBW_ARCHS_LINUX: auto64 aarch64
@@ -58,58 +65,8 @@ jobs:
           # Grab the rootless Bazel installation inside the container.
           CIBW_ENVIRONMENT_LINUX: PATH=$PATH:$HOME/bin
           CIBW_TEST_COMMAND: python {project}/bindings/python/google_benchmark/example.py
-
-      - name: Build 3.9 wheels on ${{ matrix.os }} using cibuildwheel
-        uses: pypa/cibuildwheel@v2.20
-        env:
-          CIBW_BUILD: "cp39-*"
-          CIBW_SKIP: "*-musllinux_*"
-          CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
-          CIBW_ARCHS_LINUX: auto64 aarch64
-          CIBW_ARCHS_WINDOWS: auto64
-          CIBW_BEFORE_ALL_LINUX: bash .github/install_bazel.sh
-          # Grab the rootless Bazel installation inside the container.
-          CIBW_ENVIRONMENT_LINUX: PATH=$PATH:$HOME/bin
-          CIBW_TEST_COMMAND: python {project}/bindings/python/google_benchmark/example.py
-
-      - name: Build 3.10 wheels on ${{ matrix.os }} using cibuildwheel
-        uses: pypa/cibuildwheel@v2.20
-        env:
-          CIBW_BUILD: "cp310-*"
-          CIBW_SKIP: "*-musllinux_*"
-          CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
-          CIBW_ARCHS_LINUX: auto64 aarch64
-          CIBW_ARCHS_WINDOWS: auto64
-          CIBW_BEFORE_ALL_LINUX: bash .github/install_bazel.sh
-          # Grab the rootless Bazel installation inside the container.
-          CIBW_ENVIRONMENT_LINUX: PATH=$PATH:$HOME/bin
-          CIBW_TEST_COMMAND: python {project}/bindings/python/google_benchmark/example.py
-
-      - name: Build 3.11 wheels on ${{ matrix.os }} using cibuildwheel
-        uses: pypa/cibuildwheel@v2.20
-        env:
-          CIBW_BUILD: "cp311-*"
-          CIBW_SKIP: "*-musllinux_*"
-          CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
-          CIBW_ARCHS_LINUX: auto64 aarch64
-          CIBW_ARCHS_WINDOWS: auto64
-          CIBW_BEFORE_ALL_LINUX: bash .github/install_bazel.sh
-          # Grab the rootless Bazel installation inside the container.
-          CIBW_ENVIRONMENT_LINUX: PATH=$PATH:$HOME/bin
-          CIBW_TEST_COMMAND: python {project}/bindings/python/google_benchmark/example.py
-
-      - name: Build 3.12 wheels on ${{ matrix.os }} using cibuildwheel
-        uses: pypa/cibuildwheel@v2.20
-        env:
-          CIBW_BUILD: "cp312-*"
-          CIBW_SKIP: "*-musllinux_*"
-          CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
-          CIBW_ARCHS_LINUX: auto64 aarch64
-          CIBW_ARCHS_WINDOWS: auto64
-          CIBW_BEFORE_ALL_LINUX: bash .github/install_bazel.sh
-          # Grab the rootless Bazel installation inside the container.
-          CIBW_ENVIRONMENT_LINUX: PATH=$PATH:$HOME/bin
-          CIBW_TEST_COMMAND: python {project}/bindings/python/google_benchmark/example.py
+          # unused by Bazel, but needed explicitly by delocate on MacOS.
+          MACOSX_DEPLOYMENT_TARGET: "10.14"
 
       - name: Upload Google Benchmark ${{ matrix.os }} wheels
         uses: actions/upload-artifact@v4
@@ -133,11 +90,11 @@ jobs:
     name: Publish google-benchmark wheels to PyPI
     needs: [merge_wheels]
     runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   -   repo: https://github.com/keith/pre-commit-buildifier
-      rev: 6.4.0
+      rev: 7.1.2
       hooks:
       -   id: buildifier
       -   id: buildifier-lint
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.0
+    rev: v1.11.1
     hooks:
       - id: mypy
         types_or: [ python, pyi ]
         args: [ "--ignore-missing-imports", "--scripts-are-modules" ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.10
+    rev: v0.6.1
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]

--- a/bindings/python/google_benchmark/__init__.py
+++ b/bindings/python/google_benchmark/__init__.py
@@ -49,7 +49,8 @@ from google_benchmark._benchmark import (
     oNone as oNone,
     oNSquared as oNSquared,
 )
-from google_benchmark.version import __version__ as __version__
+
+__version__ = "1.9.0"
 
 
 class __OptionMaker:

--- a/bindings/python/google_benchmark/version.py
+++ b/bindings/python/google_benchmark/version.py
@@ -1,7 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("google-benchmark")
-except PackageNotFoundError:
-    # package is not installed
-    pass

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -11,3 +11,9 @@ distributions include newer versions, for example:
 * Ubuntu 20.04 provides CMake 3.16.3
 * Debian 11.4 provides CMake 3.18.4
 * Ubuntu 22.04 provides CMake 3.22.1
+
+## Python
+
+The Python bindings require Python 3.10+ as of v1.9.0 (2024-08-16) for installation from PyPI.
+Building from source for older versions probably still works, though. See the [user guide](python_bindings.md) for details on how to build from source.
+The minimum theoretically supported version is Python 3.8, since the used bindings generator (nanobind) only supports Python 3.8+.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -8,16 +8,24 @@
     * `git log $(git describe --abbrev=0 --tags)..HEAD` gives you the list of
       commits between the last annotated tag and HEAD
     * Pick the most interesting.
-* Create one last commit that updates the version saved in `CMakeLists.txt` and `MODULE.bazel`
-  to the release version you're creating. (This version will be used if benchmark is installed
-  from the archive you'll be creating in the next step.)
+* Create one last commit that updates the version saved in `CMakeLists.txt`, `MODULE.bazel`,
+  and `bindings/python/google_benchmark/__init__.py` to the release version you're creating.
+  (This version will be used if benchmark is installed from the archive you'll be creating
+  in the next step.)
 
 ```
-project (benchmark VERSION 1.8.0 LANGUAGES CXX)
+# CMakeLists.txt
+project (benchmark VERSION 1.9.0 LANGUAGES CXX)
 ```
 
 ```
-module(name = "com_github_google_benchmark", version="1.8.0")
+# MODULE.bazel
+module(name = "com_github_google_benchmark", version="1.9.0")
+```
+
+```
+# google_benchmark/__init__.py
+__version__ = "1.9.0"
 ```
 
 * Create a release through github's interface
@@ -28,4 +36,3 @@ module(name = "com_github_google_benchmark", version="1.8.0")
       * `git push --force --tags origin`
 * Confirm that the "Build and upload Python wheels" action runs to completion
     * Run it manually if it hasn't run.
-    * IMPORTANT: When re-running manually, make sure to select the newly created `<tag>` as the workflow version in the "Run workflow" tab on the GitHub Actions page. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools<73"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,21 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm[toml]", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "google_benchmark"
 description = "A library to benchmark code snippets."
-requires-python = ">=3.8"
-license = {file = "LICENSE"}
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
 keywords = ["benchmark"]
 
-authors = [
-    {name = "Google", email = "benchmark-discuss@googlegroups.com"},
-]
+authors = [{ name = "Google", email = "benchmark-discuss@googlegroups.com" }]
 
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -29,14 +25,10 @@ classifiers = [
 
 dynamic = ["readme", "version"]
 
-dependencies = [
-    "absl-py>=0.7.1",
-]
+dependencies = ["absl-py>=0.7.1"]
 
 [project.optional-dependencies]
-dev = [
-    "pre-commit>=3.3.3",
-]
+dev = ["pre-commit>=3.3.3"]
 
 [project.urls]
 Homepage = "https://github.com/google/benchmark"
@@ -45,7 +37,7 @@ Repository = "https://github.com/google/benchmark.git"
 Discord = "https://discord.gg/cz7UX7wKC2"
 
 [tool.setuptools]
-package-dir = {"" = "bindings/python"}
+package-dir = { "" = "bindings/python" }
 zip-safe = false
 
 [tool.setuptools.packages.find]
@@ -53,8 +45,7 @@ where = ["bindings/python"]
 
 [tool.setuptools.dynamic]
 readme = { file = "README.md", content-type = "text/markdown" }
-
-[tool.setuptools_scm]
+version = { attr = "google_benchmark.__version__" }
 
 [tool.mypy]
 check_untyped_defs = true

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,6 @@ class BuildBazelExtension(build_ext.build_ext):
             dirs[:] = [d for d in dirs if "runfiles" not in d]
 
             for f in files:
-                print(f)
                 fp = Path(f)
                 should_copy = False
                 # we do not want the bare .so file included


### PR DESCRIPTION
The version is now a string again, under the same attribute as it was before. This is a pragmatic decision in order to be able to upload wheels again, possibly directly from main.

We could in the future also set the Python version to a development version if we want to avoid accidental uploads of `main`.

Built on #1841.