### PR TITLE
Dry Run Argument

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -92,6 +92,10 @@ BM_DEFINE_double(benchmark_min_warmup_time, 0.0);
 // standard deviation of the runs will be reported.
 BM_DEFINE_int32(benchmark_repetitions, 1);
 
+// If enabled, forces each benchmark to execute exactly one iteration and one repetition, 
+// bypassing any configured MinTime()/MinWarmUpTime()/Iterations()/Repetitions()
+BM_DEFINE_bool(benchmark_dry_run, false);
+
 // If set, enable random interleaving of repetitions of all benchmarks.
 // See http://github.com/google/benchmark/issues/1051 for details.
 BM_DEFINE_bool(benchmark_enable_random_interleaving, false);
@@ -717,6 +721,7 @@ void ParseCommandLineFlags(int* argc, char** argv) {
                         &FLAGS_benchmark_min_warmup_time) ||
         ParseInt32Flag(argv[i], "benchmark_repetitions",
                        &FLAGS_benchmark_repetitions) ||
+        ParseBoolFlag(argv[i], "benchmark_dry_run", &FLAGS_benchmark_dry_run) ||
         ParseBoolFlag(argv[i], "benchmark_enable_random_interleaving",
                       &FLAGS_benchmark_enable_random_interleaving) ||
         ParseBoolFlag(argv[i], "benchmark_report_aggregates_only",
@@ -783,6 +788,7 @@ void PrintDefaultHelp() {
           "          [--benchmark_min_time=`<integer>x` OR `<float>s` ]\n"
           "          [--benchmark_min_warmup_time=<min_warmup_time>]\n"
           "          [--benchmark_repetitions=<num_repetitions>]\n"
+          "          [--benchmark_dry_run={true|false}]\n"
           "          [--benchmark_enable_random_interleaving={true|false}]\n"
           "          [--benchmark_report_aggregates_only={true|false}]\n"
           "          [--benchmark_display_aggregates_only={true|false}]\n"

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -92,8 +92,9 @@ BM_DEFINE_double(benchmark_min_warmup_time, 0.0);
 // standard deviation of the runs will be reported.
 BM_DEFINE_int32(benchmark_repetitions, 1);
 
-// If enabled, forces each benchmark to execute exactly one iteration and one repetition, 
-// bypassing any configured MinTime()/MinWarmUpTime()/Iterations()/Repetitions()
+// If enabled, forces each benchmark to execute exactly one iteration and one
+// repetition, bypassing any configured
+// MinTime()/MinWarmUpTime()/Iterations()/Repetitions()
 BM_DEFINE_bool(benchmark_dry_run, false);
 
 // If set, enable random interleaving of repetitions of all benchmarks.
@@ -759,6 +760,9 @@ void ParseCommandLineFlags(int* argc, char** argv) {
   SetDefaultTimeUnitFromFlag(FLAGS_benchmark_time_unit);
   if (FLAGS_benchmark_color.empty()) {
     PrintUsageAndExit();
+  }
+  if (FLAGS_benchmark_dry_run) {
+    AddCustomContext("dry_run", "true");
   }
   for (const auto& kv : FLAGS_benchmark_context) {
     AddCustomContext(kv.first, kv.second);

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -80,10 +80,6 @@ BenchmarkReporter::Run CreateRunReport(
   BenchmarkReporter::Run report;
 
   report.run_name = b.name();
-
-  if (FLAGS_benchmark_dry_run) {
-    report.run_name.function_name.append("/dry_run");
-  }
   report.family_index = b.family_index();
   report.per_family_instance_index = b.per_family_instance_index();
   report.skipped = results.skipped_;
@@ -232,22 +228,32 @@ BenchmarkRunner::BenchmarkRunner(
     : b(b_),
       reports_for_family(reports_for_family_),
       parsed_benchtime_flag(ParseBenchMinTime(FLAGS_benchmark_min_time)),
-      min_time(FLAGS_benchmark_dry_run ? 0 : ComputeMinTime(b_, parsed_benchtime_flag)),
-      min_warmup_time(FLAGS_benchmark_dry_run ? 0
-                      : (!IsZero(b.min_time()) && b.min_warmup_time() > 0.0) ? b.min_warmup_time()
-                      : FLAGS_benchmark_min_warmup_time),
-      warmup_done(!(min_warmup_time > 0.0)),
-      repeats(FLAGS_benchmark_dry_run ? 1
-              : b.repetitions() != 0  ? b.repetitions()
-              : FLAGS_benchmark_repetitions),
       has_explicit_iteration_count(b.iterations() != 0 ||
                                    parsed_benchtime_flag.tag ==
                                        BenchTimeType::ITERS),
       pool(static_cast<size_t>(b.threads() - 1)),
-      iters(FLAGS_benchmark_dry_run ? 1
-            : has_explicit_iteration_count ? ComputeIters(b_, parsed_benchtime_flag)
-            : 1),
+      iters(has_explicit_iteration_count
+                ? ComputeIters(b_, parsed_benchtime_flag)
+                : 1),
       perf_counters_measurement_ptr(pcm_) {
+  if (FLAGS_benchmark_dry_run) {
+    min_time = 0;
+    min_warmup_time = 0;
+    warmup_done = true;
+    repeats = 1;
+    iters = 1;
+  } else {
+    min_time = ComputeMinTime(b_, parsed_benchtime_flag);
+    min_warmup_time = ((!IsZero(b.min_time()) && b.min_warmup_time() > 0.0)
+                           ? b.min_warmup_time()
+                           : FLAGS_benchmark_min_warmup_time);
+    warmup_done = !(min_warmup_time > 0.0);
+    repeats =
+        b.repetitions() != 0 ? b.repetitions() : FLAGS_benchmark_repetitions;
+    iters = has_explicit_iteration_count
+                ? ComputeIters(b_, parsed_benchtime_flag)
+                : 1;
+  }
   run_results.display_report_aggregates_only =
       (FLAGS_benchmark_report_aggregates_only ||
        FLAGS_benchmark_display_aggregates_only);
@@ -300,10 +306,6 @@ BenchmarkRunner::IterationResults BenchmarkRunner::DoNIterations() {
   BM_VLOG(2) << "Ran in " << i.results.cpu_time_used << "/"
              << i.results.real_time_used << "\n";
 
-  // In dry run mode, we report 1 iteration even if each thread runs a singular iteration.
-  if (FLAGS_benchmark_dry_run) {
-    i.results.iterations /= b.threads();
-  }
   // By using KeepRunningBatch a benchmark can iterate more times than
   // requested, so take the iteration count from i.results.
   i.iters = i.results.iterations / b.threads();
@@ -348,8 +350,7 @@ bool BenchmarkRunner::ShouldReportIterationResults(
   // Determine if this run should be reported;
   // Either it has run for a sufficient amount of time
   // or because an error was reported.
-  return i.results.skipped_ || 
-         FLAGS_benchmark_dry_run ||
+  return i.results.skipped_ || FLAGS_benchmark_dry_run ||
          i.iters >= kMaxIterations ||  // Too many iterations already.
          i.seconds >=
              GetMinTimeToApply() ||  // The elapsed time is large enough.

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -292,12 +292,6 @@ BenchmarkRunner::IterationResults BenchmarkRunner::DoNIterations() {
   // And get rid of the manager.
   manager.reset();
 
-  // Adjust real/manual time stats since they were reported per thread.
-  i.results.real_time_used /= b.threads();
-  i.results.manual_time_used /= b.threads();
-  // If we were measuring whole-process CPU usage, adjust the CPU time too.
-  if (b.measure_process_cpu_time()) i.results.cpu_time_used /= b.threads();
-
   BM_VLOG(2) << "Ran in " << i.results.cpu_time_used << "/"
              << i.results.real_time_used << "\n";
 

--- a/src/benchmark_runner.h
+++ b/src/benchmark_runner.h
@@ -28,6 +28,7 @@ namespace benchmark {
 BM_DECLARE_string(benchmark_min_time);
 BM_DECLARE_double(benchmark_min_warmup_time);
 BM_DECLARE_int32(benchmark_repetitions);
+BM_DECLARE_bool(benchmark_dry_run);
 BM_DECLARE_bool(benchmark_report_aggregates_only);
 BM_DECLARE_bool(benchmark_display_aggregates_only);
 BM_DECLARE_string(benchmark_perf_counters);

--- a/src/benchmark_runner.h
+++ b/src/benchmark_runner.h
@@ -90,10 +90,10 @@ class BenchmarkRunner {
   BenchmarkReporter::PerFamilyRunReports* reports_for_family;
 
   BenchTimeType parsed_benchtime_flag;
-  const double min_time;
-  const double min_warmup_time;
+  double min_time;
+  double min_warmup_time;
   bool warmup_done;
-  const int repeats;
+  int repeats;
   const bool has_explicit_iteration_count;
 
   int num_repetitions_done = 0;

--- a/src/perf_counters.cc
+++ b/src/perf_counters.cc
@@ -218,7 +218,7 @@ PerfCounters PerfCounters::Create(
       GetErrorLogInstance() << "***WARNING*** Failed to start counters. "
                                "Claring out all counters.\n";
 
-      // Close all peformance counters
+      // Close all performance counters
       for (int id : counter_ids) {
         ::close(id);
       }


### PR DESCRIPTION
Added the functionality for a dry run benchmark called through the cli argument --benchmark_dry_run.

**Changes**
- Added boolean flag for --benchmark_dry_run
- Added overriding logic and early stoping
- append /dry_run  to the benchmark name to indicate  there is a dry run
    - ex: BM_StringCreation/dry_run/100/min_time:0.300/repeats:4/threads:4

Please let me know if I need to make any change I will be happy to implement them!