### PR TITLE
enable the /MP MSVC compiler argument for parallel compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if (MSVC)
   # Turn compiler warnings up to 11
   string(REGEX REPLACE "[-/]W[1-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /MP")
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
   if(BENCHMARK_ENABLE_WERROR)


### PR DESCRIPTION
As detailed here:

https://learn.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes?view=msvc-170

This enables parallel compilation.  The build generator can already parallelise at the *project* level i.e -j10 for example, but this enables parallel compilation.

On my machine, times without this change:

```
Debug = 32.02s
Release = 34.99s
```

And times with:

```
Debug = 11.30s
Release = 12.88s
```