### PR TITLE
Version string correction in pkg-config files

### DIFF
--- a/cmake/benchmark.pc.in
+++ b/cmake/benchmark.pc.in
@@ -5,7 +5,7 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: Google microbenchmark framework
-Version: @VERSION@
+Version: @NORMALIZED_VERSION@
 
 Libs: -L${libdir} -lbenchmark
 Libs.private: -lpthread @BENCHMARK_PRIVATE_LINK_LIBRARIES@

--- a/cmake/benchmark_main.pc.in
+++ b/cmake/benchmark_main.pc.in
@@ -2,6 +2,6 @@ libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 
 Name: @PROJECT_NAME@
 Description: Google microbenchmark framework (with main() function)
-Version: @VERSION@
+Version: @NORMALIZED_VERSION@
 Requires: benchmark
 Libs: -L${libdir} -lbenchmark_main


### PR DESCRIPTION
According to issue #1857, the version in the pkg-config files is changed so that they have the nomatized version instead of the version.  