### PR TITLE
Add enum value from newest Windows SDK

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -353,6 +353,10 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizesWindows() {
     C.size = static_cast<int>(cache.Size);
     C.type = "Unknown";
     switch (cache.Type) {
+      #ifdef NTDDI_WIN10_NI // Windows SDK version >= 10.0.26100.0
+      case CacheUnknown:
+        break;
+      #endif
       case CacheUnified:
         C.type = "Unified";
         break;


### PR DESCRIPTION
Windows SDK version 10.0.26100.0 adds a cache type value, `CacheUnknown`. This adds a case for that type to `sysinfo.cc`, which will otherwise complain about the switch statement being non-exhaustive when building with the new SDK.

Since the value doesn't exist in prior SDK versions, we only add the case conditionally. The condition can be removed if we ever decide to bump up the required SDK version.