### PR TITLE
Fix spurious warning 'misc-use-anonymous-namespace' (#1860)

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1554,6 +1554,7 @@ class Fixture : public internal::Benchmark {
   BaseClass##_##Method##_Benchmark
 
 #define BENCHMARK_PRIVATE_DECLARE(n)                                 \
+  /* NOLINTNEXTLINE(misc-use-anonymous-namespace) */                 \
   static ::benchmark::internal::Benchmark* BENCHMARK_PRIVATE_NAME(n) \
       BENCHMARK_UNUSED
 


### PR DESCRIPTION
Disables 'misc-use-anonymous-namespace' for usage of the BENCHMARK macro. This warning is spurious, and the variable declared by the BENCHMARK macro can't be moved into an annonymous namespace.

We don't want to disable it globally, but it can be disabled locally, for the `BENCHMARK` statement, as this warning appears downstream for users.

See:
https://clang.llvm.org/extra/clang-tidy/#suppressing-undesired-diagnostics

Before: (warning shown)

![image](https://github.com/user-attachments/assets/6bcf43f5-5836-4756-9aa2-8a714e67f591)

After: (no warnings)

![image](https://github.com/user-attachments/assets/6a5120b5-a50d-42a9-9ad9-942536092d14)
