### PR TITLE
[#1487] ensure background color is preserved

### DIFF
--- a/src/colorprint.cc
+++ b/src/colorprint.cc
@@ -135,19 +135,25 @@ void ColorPrintf(std::ostream& out, LogColor color, const char* fmt,
   // Gets the current text color.
   CONSOLE_SCREEN_BUFFER_INFO buffer_info;
   GetConsoleScreenBufferInfo(stdout_handle, &buffer_info);
-  const WORD old_color_attrs = buffer_info.wAttributes;
+  const WORD original_color_attrs = buffer_info.wAttributes;
 
   // We need to flush the stream buffers into the console before each
   // SetConsoleTextAttribute call lest it affect the text that is already
   // printed but has not yet reached the console.
   out.flush();
-  SetConsoleTextAttribute(stdout_handle,
-                          GetPlatformColorCode(color) | FOREGROUND_INTENSITY);
+
+  const WORD original_background_attrs =
+      original_color_attrs & (BACKGROUND_RED | BACKGROUND_GREEN |
+                              BACKGROUND_BLUE | BACKGROUND_INTENSITY);
+
+  SetConsoleTextAttribute(stdout_handle, GetPlatformColorCode(color) |
+                                             FOREGROUND_INTENSITY |
+                                             original_background_attrs);
   out << FormatString(fmt, args);
 
   out.flush();
-  // Restores the text color.
-  SetConsoleTextAttribute(stdout_handle, old_color_attrs);
+  // Restores the text and background color.
+  SetConsoleTextAttribute(stdout_handle, original_color_attrs);
 #else
   const char* color_code = GetPlatformColorCode(color);
   if (color_code) out << FormatString("\033[0;3%sm", color_code);


### PR DESCRIPTION
As raised in issue 1487, the color of the background on Windows was assumed to be black.  This means that when printing results in, for example, green, you ended up with green on black regardless of the original background color.

This update retains the background colors when printing.

This naturally raises another topic of, does the output color want to be determined by the background color when printing?  I.e we would now end up printing green text on a green background if that were the case.  Maybe this can be captured in another request if it's desirable.