### PR TITLE
Update nanobind_bazel to v2.2.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,4 +38,4 @@ use_repo(pip, "tools_pip_deps")
 
 # -- bazel_dep definitions -- #
 
-bazel_dep(name = "nanobind_bazel", version = "2.1.0", dev_dependency = True)
+bazel_dep(name = "nanobind_bazel", version = "2.2.0", dev_dependency = True)


### PR DESCRIPTION
Adds support for free-threaded nanobind extension builds, though we don't currently build a free-threaded wheel.