### PR TITLE
Add `nb::is_flag()` annotation to Counter::Flags

### DIFF
--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -118,7 +118,7 @@ NB_MODULE(_benchmark, m) {
   using benchmark::Counter;
   nb::class_<Counter> py_counter(m, "Counter");
 
-  nb::enum_<Counter::Flags>(py_counter, "Flags", nb::is_arithmetic())
+  nb::enum_<Counter::Flags>(py_counter, "Flags", nb::is_arithmetic(), nb::is_flag())
       .value("kDefaults", Counter::Flags::kDefaults)
       .value("kIsRate", Counter::Flags::kIsRate)
       .value("kAvgThreads", Counter::Flags::kAvgThreads)
@@ -129,10 +129,7 @@ NB_MODULE(_benchmark, m) {
       .value("kAvgIterations", Counter::Flags::kAvgIterations)
       .value("kAvgIterationsRate", Counter::Flags::kAvgIterationsRate)
       .value("kInvert", Counter::Flags::kInvert)
-      .export_values()
-      .def("__or__", [](Counter::Flags a, Counter::Flags b) {
-        return static_cast<int>(a) | static_cast<int>(b);
-      });
+      .export_values();
 
   nb::enum_<Counter::OneK>(py_counter, "OneK")
       .value("kIs1000", Counter::OneK::kIs1000)
@@ -140,13 +137,9 @@ NB_MODULE(_benchmark, m) {
       .export_values();
 
   py_counter
-      .def(
-          "__init__",
-          [](Counter* c, double value, int flags, Counter::OneK oneK) {
-            new (c) Counter(value, static_cast<Counter::Flags>(flags), oneK);
-          },
-          nb::arg("value") = 0., nb::arg("flags") = Counter::kDefaults,
-          nb::arg("k") = Counter::kIs1000)
+      .def(nb::init<double, Counter::Flags, Counter::OneK>(),
+           nb::arg("value") = 0., nb::arg("flags") = Counter::kDefaults,
+           nb::arg("k") = Counter::kIs1000)
       .def("__init__",
            ([](Counter* c, double value) { new (c) Counter(value); }))
       .def_rw("value", &Counter::value)


### PR DESCRIPTION
This saves us the definition of `__or__`, because we can just use the one from `enum.IntFlag`.

cc @hawkinsp for a review, since you mentioned this should be possible after flag enum support is added to nanobind, which it is now, starting in v2.2.0.

I did have to use both `nb::is_arithmetic()` and `nb::is_flag()` due to combination issues, but it seems the C++ side is aware of this: https://github.com/google/benchmark/blob/4e3f2d8b6728d628b3baa77a8d2359dd8e35bab5/include/benchmark/benchmark.h#L720-L726