### PR TITLE
Add a Python matrix to ensure the bindings build on all supported versions

### DIFF
--- a/.github/workflows/test_bindings.yml
+++ b/.github/workflows/test_bindings.yml
@@ -8,23 +8,23 @@ on:
 
 jobs:
   python_bindings:
-    name: Test GBM Python bindings on ${{ matrix.os }}
+    name: Test GBM Python ${{ matrix.python-version }} bindings on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.11
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ matrix.python-version }}
       - name: Install GBM Python bindings on ${{ matrix.os }}
         run: python -m pip install .
-      - name: Run bindings example on ${{ matrix.os }}
-        run:
-          python bindings/python/google_benchmark/example.py
+      - name: Run example on ${{ matrix.os }} under Python ${{ matrix.python-version }}
+        run: python bindings/python/google_benchmark/example.py

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,7 +53,7 @@ jobs:
           platforms: all
 
       - name: Build wheels on ${{ matrix.os }} using cibuildwheel
-        uses: pypa/cibuildwheel@v2.20
+        uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_BUILD: "cp310-* cp311-* cp312-*"
           CIBW_BUILD_FRONTEND: "build[uv]"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   -   repo: https://github.com/keith/pre-commit-buildifier
-      rev: 7.1.2
+      rev: 7.3.1
       hooks:
       -   id: buildifier
       -   id: buildifier-lint
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.1
+    rev: v1.13.0
     hooks:
       - id: mypy
         types_or: [ python, pyi ]
         args: [ "--ignore-missing-imports", "--scripts-are-modules" ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.1
+    rev: v0.7.2
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]


### PR DESCRIPTION
Also contains a run of `pre-commit autoupdate`, and a bump of cibuildwheel to its latest tag for CPython 3.13 support.

But, since we build for 3.10+ with SABI from 3.12 onwards, we don't even need a dedicated Python 3.13 build job - the wheels from 3.12 can be reused.