### PR TITLE
Declare a Python 3.13 toolchain, revert setup.py toolchain target sele…

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,6 +27,7 @@ python.toolchain(
     is_default = True,
     python_version = "3.12",
 )
+python.toolchain(python_version = "3.13")
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_dependency = True)
 pip.parse(

--- a/setup.py
+++ b/setup.py
@@ -92,16 +92,10 @@ class BuildBazelExtension(build_ext.build_ext):
     def bazel_build(self, ext: BazelExtension) -> None:
         """Runs the bazel build to create the package."""
         temp_path = Path(self.build_temp)
-        if py_limited_api:
-            # We only need to know the minimum ABI version,
-            # since it is stable across minor versions by definition.
-            # The value here is calculated as the minimum of a) the minimum
-            # Python version required, and b) the stable ABI version target.
-            # NB: This needs to be kept in sync with [project.requires-python]
-            # in pyproject.toml.
-            python_version = "3.12"
-        else:
-            python_version = "{0}.{1}".format(*sys.version_info[:2])
+
+        # We round to the minor version, which makes rules_python
+        # look up the latest available patch version internally.
+        python_version = "{0}.{1}".format(*sys.version_info[:2])
 
         bazel_argv = [
             "bazel",


### PR DESCRIPTION
…ction

The new solution was too smart (read: dense), because it did not account for the fact that we look for the Windows libs of the interpreter building the wheel, not the hermetic one supplying the header files.

The fix is to just align the versions again, so that the libs and headers come from the same minor version.

---------------------

To address this once and for all, either the bug in rules_python needs to be fixed (I opened a [PR](https://github.com/bazelbuild/rules_python/pull/1820) there, but it stalled). I don't have a Windows machine for development right now, though :(