### PR TITLE
Add artifact name to download before wheel PyPI upload

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -77,7 +77,7 @@ jobs:
   merge_wheels:
     name: Merge all built wheels into one artifact
     runs-on: ubuntu-latest
-    needs: build_wheels
+    needs: [build_sdist, build_wheels]
     steps:
       - name: Merge wheels
         uses: actions/upload-artifact/merge@v4
@@ -96,5 +96,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
+          name: dist
           path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Otherwise, the folder structure gets messed up, and twine errors out.

-------------

I researched a bit about why https://github.com/google/benchmark/actions/runs/12072915457 failed, and after reviewing a few cibuildwheel configs, I think it's related to the artifact name in combination with the deletion of the individual artifacts. 

After merging this, you should be able to rerun the release workflow on current `main` to upload v1.9.1 wheels.