### PR TITLE
Remove if statement from wheel upload job

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -90,7 +90,6 @@ jobs:
     name: Publish google-benchmark wheels to PyPI
     needs: [merge_wheels]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
This to see if it works with the new artifact download config.

-----------

Sorry about that, I wired the wheel upload to be skipped if the job wasn't triggered by a release.