### PR TITLE
Fix malformed clang invocation in build_ext.run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<73"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ class BuildBazelExtension(build_ext.build_ext):
     def run(self):
         for ext in self.extensions:
             self.bazel_build(ext)
-        super().run()
         # explicitly call `bazel shutdown` for graceful exit
         self.spawn(["bazel", "shutdown"])
 


### PR DESCRIPTION
The fix is, unsurprisingly, to not invoke clang at all, because we use Bazel to build everything anyway.

This also means that we can drop the setuptools pin.