### PR TITLE
[bazel] Remove selects on CPU

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,27 +18,9 @@ COPTS = [
 ]
 
 config_setting(
-    name = "qnx",
-    constraint_values = ["@platforms//os:qnx"],
-    values = {
-        "cpu": "x64_qnx",
-    },
-    visibility = [":__subpackages__"],
-)
-
-config_setting(
     name = "windows",
     constraint_values = ["@platforms//os:windows"],
-    values = {
-        "cpu": "x64_windows",
-    },
     visibility = [":__subpackages__"],
-)
-
-config_setting(
-    name = "macos",
-    constraint_values = ["@platforms//os:macos"],
-    visibility = ["//visibility:public"],
 )
 
 config_setting(


### PR DESCRIPTION
In a future version of bazel this produces a warning. In this case using
only the platform being windows is enough. Fixes:

```
WARNING: /.../benchmark/BUILD.bazel:29:15: in config_setting rule //:windows: select() on cpu is deprecated. Use platform constraints instead: https://bazel.build/docs/configurable-attributes#platforms.
```
