### PR TITLE
fix: remove clang-cl compilation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,12 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if (MSVC)
   # Turn compiler warnings up to 11
   string(REGEX REPLACE "[-/]W[1-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /MP")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+
+  # MP flag only applies to cl, not cl frontends to other compilers (e.g. clang-cl, icx-cl etc)
+  if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+  endif()
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
   if(BENCHMARK_ENABLE_WERROR)


### PR DESCRIPTION
The `/MP` flag only applies to `cl`, not `cl` frontends to other compilers (e.g. `clang-cl`, `icx-cl` etc), whereas the `MSVC` cmake variable applies to every compiler with a `cl` frontend. Therefore, we need to reduce the scope of `/MP` to only MSVC's `cl`, so that the other `cl` frontends can compile without warnings.

Fixes https://github.com/google/benchmark/issues/1869

Reproduction steps to test solution on Windows with the LLVM toolchain installed:
```
cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_LINKER=lld-link -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
cmake --build build
ctest --test-dir build
```