### PR TITLE
cycleclock: Use cock_gettime() as fallback for any Linux architecture

### DIFF
--- a/src/cycleclock.h
+++ b/src/cycleclock.h
@@ -229,10 +229,12 @@ inline BENCHMARK_ALWAYS_INLINE int64_t Now() {
   struct timeval tv;
   gettimeofday(&tv, nullptr);
   return static_cast<int64_t>(tv.tv_sec) * 1000000 + tv.tv_usec;
-#elif defined(__hppa__)
+#elif defined(__hppa__) || defined(__linux__)
+  // Fallback for all other architectures with a recent Linux kernel, e.g.:
   // HP PA-RISC provides a user-readable clock counter (cr16), but
   // it's not syncronized across CPUs and only 32-bit wide when programs
   // are built as 32-bit binaries.
+  // Same for SH-4 and possibly others.
   // Use clock_gettime(CLOCK_MONOTONIC, ...) instead of gettimeofday
   // because is provides nanosecond resolution.
   // Initialize to always return 0 if clock_gettime fails.


### PR DESCRIPTION
The Linux kernel provides the clock_gettime() functions since a long time already, so it's possible to use it as a generic fallback option for any architecture if no other (better) possibility has been provided instead.

I noticed the benchmark package failed to build on debian on the SH-4 architecture, so with this change SH-4 is now the first user of this fallback option.