### PR TITLE
Fix runtime crash when parsing /proc/cpuinfo fails

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -561,10 +561,12 @@ int GetNumCPUsImpl() {
 }
 
 int GetNumCPUs() {
-  const int num_cpus = GetNumCPUsImpl();
+  int num_cpus = GetNumCPUsImpl();
   if (num_cpus < 1) {
     std::cerr << "Unable to extract number of CPUs.  If your platform uses "
                  "/proc/cpuinfo, custom support may need to be added.\n";
+    /* There is at least one CPU which we run on. */
+    num_cpus = 1;
   }
   return num_cpus;
 }


### PR DESCRIPTION
The testcase fails on sparc64, because the parsing of /proc/cpuinfo fails and thus currently returns "0" CPUs which finally leads to division-by-zero faults in the tests.

Fix the issue by returning at least "1" CPU which allows the tests to run. A error message will be printed in any case.

Long-term the code should be fixed to parse the cpuinfo output on sparch which looks like this:
...
type            : sun4v
ncpus probed    : 48
ncpus active    : 48