### PR TITLE
Update nanobind-bazel to v2.4.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_foreign_cc", version = "0.10.1")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 
-bazel_dep(name = "rules_python", version = "0.37.0", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "1.0.0", dev_dependency = True)
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True, repo_name = "com_google_googletest")
 
 bazel_dep(name = "libpfm", version = "4.11.0")
@@ -39,4 +39,4 @@ use_repo(pip, "tools_pip_deps")
 
 # -- bazel_dep definitions -- #
 
-bazel_dep(name = "nanobind_bazel", version = "2.2.0", dev_dependency = True)
+bazel_dep(name = "nanobind_bazel", version = "2.4.0", dev_dependency = True)


### PR DESCRIPTION
Contains nanobind v2.4.0, which brings some more functionality, free-threading fixes, and performance improvements.