### PR TITLE
change pacboy compiler target for windows builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,7 +128,6 @@ jobs:
 
       # NOTE: we can't use cmake actions here as we need to do everything in msys2 shell.
       - name: configure cmake
-        shell: msys2 {0}
         env:
           CXX: ${{ matrix.msys2.compiler }}
         run: >
@@ -138,10 +137,8 @@ jobs:
           -DBUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
 
       - name: build
-        shell: msys2 {0}
         run: cmake --build _build/ --config ${{ matrix.build_type }}
 
       - name: test
-        shell: msys2 {0}
         working-directory: _build
         run: ctest -C ${{ matrix.build_type }} -VV

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -143,5 +143,5 @@ jobs:
 
       - name: test
         shell: msys2 {0}
-        working-directory: ${{ runner.workspace }}/_build
+        working-directory: _build
         run: ctest -C ${{ matrix.build_type }} -VV

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -121,6 +121,7 @@ jobs:
           pacboy: >-
             gcc:p
             clang:p
+            cmake:p
             ninja:p
 
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,9 +99,7 @@ jobs:
         os: [ windows-latest ]
         msys2:
           - { msystem: MINGW64,    arch: x86_64,  family: GNU,  compiler: g++ }
-          - { msystem: MINGW32,    arch: i686,    family: GNU,  compiler: g++ }
           - { msystem: CLANG64,    arch: x86_64,  family: LLVM, compiler: clang++ }
-          - { msystem: CLANG32,    arch: i686,    family: LLVM, compiler: clang++ }
           - { msystem: UCRT64,     arch: x86_64,  family: GNU,  compiler: g++ }
         build_type:
           - Debug

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -80,6 +80,7 @@ jobs:
           options: |
             BENCHMARK_DOWNLOAD_DEPENDENCIES=ON
             BUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
+            CMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
       - name: test
         working-directory: ${{ runner.workspace }}/_build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -72,19 +72,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: lukka/get-cmake@latest
+
+      - name: configure cmake
+        run: >
+          cmake -S . -B _build/
+          -G "${{ matrix.generator }}"
+          -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+          -DBUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
+
       - name: build
-        uses: threeal/cmake-action@v2.1.0
-        with:
-          build-dir: ${{ runner.workspace }}/_build
-          generator: ${{ matrix.generator }}
-          options: |
-            BENCHMARK_DOWNLOAD_DEPENDENCIES=ON
-            BUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
-            CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake --build ${{ runner.workspace }}/_build --config ${{ matrix.build_type }}
 
       - name: test
-        working-directory: ${{ runner.workspace }}/_build
-        run: ctest -C ${{ matrix.build_type }} -VV
+        run: ctest --test-dir ${{ runner.workspace }}/_build -C ${{ matrix.build_type }} -VV
 
   msys2:
     name: ${{ matrix.os }}.${{ matrix.build_type }}.${{ matrix.lib }}.${{ matrix.msys2.msystem }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,16 +76,16 @@ jobs:
 
       - name: configure cmake
         run: >
-          cmake -S . -B _build/
+          cmake -S . -B ${{ runner.workspace }}/_build/
           -G "${{ matrix.generator }}"
           -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
           -DBUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
 
       - name: build
-        run: cmake --build ${{ runner.workspace }}/_build --config ${{ matrix.build_type }}
+        run: cmake --build ${{ runner.workspace }}/_build/ --config ${{ matrix.build_type }}
 
       - name: test
-        run: ctest --test-dir ${{ runner.workspace }}/_build -C ${{ matrix.build_type }} -VV
+        run: ctest --test-dir ${{ runner.workspace }}/_build/ -C ${{ matrix.build_type }} -VV
 
   msys2:
     name: ${{ matrix.os }}.${{ matrix.build_type }}.${{ matrix.lib }}.${{ matrix.msys2.msystem }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -141,7 +141,8 @@ jobs:
             git
             base-devel
           pacboy: >-
-            cc:p
+            gcc:p
+            clang:p
             cmake:p
             ninja:p
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,7 +34,7 @@ jobs:
             BENCHMARK_DOWNLOAD_DEPENDENCIES=ON
             BUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
             CMAKE_BUILD_TYPE=${{ matrix.build_type }}
-            CMAKE_CXX_COMPILER=${{ env.CXX }}
+            CMAKE_CXX_COMPILER=${{ matrix.compiler }}
             CMAKE_CXX_VISIBILITY_PRESET=hidden
             CMAKE_VISIBILITY_INLINES_HIDDEN=ON
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -109,9 +109,7 @@ jobs:
           - static
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Base Dependencies
+      - name: setup msys2
         uses: msys2/setup-msys2@v2
         with:
           cache: false
@@ -125,16 +123,24 @@ jobs:
             clang:p
             ninja:p
 
+      - uses: actions/checkout@v4
+
+      # NOTE: we can't use cmake actions here as we need to do everything in msys2 shell.
+      - name: configure cmake
+        shell: msys2 {0}
+        env:
+          CXX: ${{ matrix.msys2.compiler }}
+        run: >
+          cmake -S . -B _build/
+          -GNinja
+          -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+          -DBUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
+
       - name: build
-        uses: threeal/cmake-action@v2.1.0
-        with:
-          build-dir: ${{ runner.workspace }}/_build
-          generator: Ninja
-          cxx-compiler: ${{ matrix.msys2.msystem.compiler }}
-          options: |
-            BENCHMARK_DOWNLOAD_DEPENDENCIES=ON
-            BUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
+        shell: msys2 {0}
+        run: cmake --build _build/ --config ${{ matrix.build_type }}
 
       - name: test
+        shell: msys2 {0}
         working-directory: ${{ runner.workspace }}/_build
         run: ctest -C ${{ matrix.build_type }} -VV

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,33 +25,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: lukka/get-cmake@latest
-
-      - name: create build environment
-        run: cmake -E make_directory ${{ runner.workspace }}/_build
-
-      - name: setup cmake initial cache
-        run: touch compiler-cache.cmake
-
-      - name: configure cmake
-        env:
-          CXX: ${{ matrix.compiler }}
-        shell: bash
-        working-directory: ${{ runner.workspace }}/_build
-        run: >
-          cmake -C ${{ github.workspace }}/compiler-cache.cmake
-          $GITHUB_WORKSPACE
-          -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
-          -DBUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
-          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-          -DCMAKE_CXX_COMPILER=${{ env.CXX }}
-          -DCMAKE_CXX_VISIBILITY_PRESET=hidden
-          -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON
-
       - name: build
-        shell: bash
-        working-directory: ${{ runner.workspace }}/_build
-        run: cmake --build . --config ${{ matrix.build_type }}
+        uses: threeal/cmake-action@v2.1.0
+        with:
+          build-dir: ${{ runner.workspace }}/_build
+          cxx-compiler: ${{ matrix.compiler }}
+          options: |
+            BENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+            BUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
+            CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+            CMAKE_CXX_COMPILER=${{ env.CXX }}
+            CMAKE_CXX_VISIBILITY_PRESET=hidden
+            CMAKE_VISIBILITY_INLINES_HIDDEN=ON
 
       - name: test
         shell: bash
@@ -70,8 +55,6 @@ jobs:
         msvc:
           - VS-16-2019
           - VS-17-2022
-        arch:
-          - x64
         build_type:
           - Debug
           - Release
@@ -89,21 +72,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: lukka/get-cmake@latest
-
-      - name: configure cmake
-        run: >
-          cmake -S . -B _build/
-          -A ${{ matrix.arch }}
-          -G "${{ matrix.generator }}"
-          -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
-          -DBUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
-
       - name: build
-        run: cmake --build _build/ --config ${{ matrix.build_type }}
+        uses: threeal/cmake-action@v2.1.0
+        with:
+          build-dir: ${{ runner.workspace }}/_build
+          generator: ${{ matrix.generator }}
+          options: |
+            BENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+            BUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
 
       - name: test
-        run: ctest --test-dir _build/ -C ${{ matrix.build_type }} -VV
+        working-directory: ${{ runner.workspace }}/_build
+        run: ctest -C ${{ matrix.build_type }} -VV
 
   msys2:
     name: ${{ matrix.os }}.${{ matrix.build_type }}.${{ matrix.lib }}.${{ matrix.msys2.msystem }}
@@ -143,20 +123,18 @@ jobs:
           pacboy: >-
             gcc:p
             clang:p
-            cmake:p
             ninja:p
 
-      - name: configure cmake
-        env:
-          CXX: ${{ matrix.msys2.compiler }}
-        run: >
-          cmake -S . -B _build/
-          -GNinja
-          -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
-          -DBUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
-
       - name: build
-        run: cmake --build _build/ --config ${{ matrix.build_type }}
+        uses: threeal/cmake-action@v2.1.0
+        with:
+          build-dir: ${{ runner.workspace }}/_build
+          generator: Ninja
+          cxx-compiler: ${{ matrix.msys2.msystem.compiler }}
+          options: |
+            BENCHMARK_DOWNLOAD_DEPENDENCIES=ON
+            BUILD_SHARED_LIBS=${{ matrix.lib == 'shared' }}
 
       - name: test
-        run: ctest --test-dir _build/ -C ${{ matrix.build_type }} -VV
+        working-directory: ${{ runner.workspace }}/_build
+        run: ctest -C ${{ matrix.build_type }} -VV


### PR DESCRIPTION
Also note that CLANG32 and MINGW32 are now "legacy environments" and do not get support from msys2: https://www.msys2.org/docs/environments/#__tabbed_1_2.  As such, removing those (clang32 was also the failing environment so perhaps that's an explanation of sorts).