### PR TITLE
Update error message now that /proc/cpuinfo is no longer in use

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -515,8 +515,7 @@ int GetNumCPUsImpl() {
 int GetNumCPUs() {
   int num_cpus = GetNumCPUsImpl();
   if (num_cpus < 1) {
-    std::cerr << "Unable to extract number of CPUs.  If your platform uses "
-                 "/proc/cpuinfo, custom support may need to be added.\n";
+    std::cerr << "Unable to extract number of CPUs.\n";
     /* There is at least one CPU which we run on. */
     num_cpus = 1;
   }


### PR DESCRIPTION
c24774dc4f4402c3ad150363321cc972ed2669e7 removed using /proc/cpuinfo
so no longer mention it in the error message.