### PR TITLE
Replace usage of deprecated sysctl on macOS

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -483,7 +483,9 @@ int GetNumCPUsImpl() {
 #ifdef BENCHMARK_HAS_SYSCTL
   int num_cpu = -1;
   constexpr auto* hwncpu =
-#ifdef HW_NCPUONLINE
+#if defined BENCHMARK_OS_MACOSX
+      "hw.logicalcpu";
+#elif defined(HW_NCPUONLINE)
       "hw.ncpuonline";
 #else
       "hw.ncpu";


### PR DESCRIPTION
The use of the sysctl hw.ncpu has long been deprecated and should be replaced by hw.logicalcpu.