### PR TITLE
deps: Update nanobind_bazel to v2.5.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,4 +38,4 @@ use_repo(pip, "tools_pip_deps")
 
 # -- bazel_dep definitions -- #
 
-bazel_dep(name = "nanobind_bazel", version = "2.4.0", dev_dependency = True)
+bazel_dep(name = "nanobind_bazel", version = "2.5.0", dev_dependency = True)


### PR DESCRIPTION
No new functionality, just an update to the newest nanobind.