### PR TITLE
Install FindPFM.cmake for bencmarkConfig.cmake

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -5,6 +5,7 @@ include (CMakeFindDependencyMacro)
 find_dependency (Threads)
 
 if (@BENCHMARK_ENABLE_LIBPFM@)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
     find_dependency (PFM)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,9 @@ set_property(
 if (PFM_FOUND)
   target_link_libraries(benchmark PRIVATE PFM::libpfm)
   target_compile_definitions(benchmark PRIVATE -DHAVE_LIBPFM)
+  install(
+      FILES "${PROJECT_SOURCE_DIR}/cmake/Modules/FindPFM.cmake"
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 endif()
 
 # pthread affinity, if available


### PR DESCRIPTION
There is no upstream PFM cmake package config file to use, so this has to be installed for the benchmark cmake package config file to work.

Bug: https://bugs.gentoo.org/950573
See-Also: c2146397ac69e6589a50f6b4fc6a7355669caed5

```
$ bash cmake_check.sh /usr/lib64/cmake/benchmark
Temporary directory: /tmp/cmake-test.8nbt
/usr/lib64/cmake/benchmark/benchmarkConfig.cmake
CMake Error at /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:76 (find_package):
  By not providing "FindPFM.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "PFM", but
  CMake did not find one.

  Could not find a package configuration file provided by "PFM" with any of
  the following names:

    PFMConfig.cmake
    pfm-config.cmake

  Add the installation prefix of "PFM" to CMAKE_PREFIX_PATH or set "PFM_DIR"
  to a directory containing one of the above files.  If "PFM" provides a
  separate development package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  /usr/lib64/cmake/benchmark/benchmarkConfig.cmake:26 (find_dependency)
  CMakeLists.txt:3 (find_package)


Failed with:
cmake_minimum_required(VERSION 3.10)
project(test)
find_package(benchmark REQUIRED CONFIG)

```