### PR TITLE
Compilation example was wrong. Fixed standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ be under the build directory you created.
 ```bash
 # Example on linux after running the build steps above. Assumes the
 # `benchmark` and `build` directories are under the current directory.
-$ g++ mybenchmark.cc -std=c++11 -isystem benchmark/include \
+$ g++ mybenchmark.cc -std=c++14 -isystem benchmark/include \
   -Lbenchmark/build/src -lbenchmark -lpthread -o mybenchmark
 ```
 


### PR DESCRIPTION
The README.md file put a compile example with the flag `-std=c++11`, and because of the use of new standard library functions, the flag in the compile example had to be changed to `-std=c++14`, this solving issue: #1943