### PR TITLE
Enable Google Benchmark to run in WebAssembly with filesystem disabled

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -435,7 +435,7 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizes() {
   return GetCacheSizesWindows();
 #elif defined(BENCHMARK_OS_QNX)
   return GetCacheSizesQNX();
-#elif defined(BENCHMARK_OS_QURT)
+#elif defined(BENCHMARK_OS_QURT) || defined(__EMSCRIPTEN__)
   return std::vector<CPUInfo::CacheInfo>();
 #else
   return GetCacheSizesFromKVFS();


### PR DESCRIPTION


## Problem Description
When Google Benchmark runs in a WebAssembly environment, especially when compiled with Emscripten's -s FILESYSTEM=0 flag (which disables filesystem support), the program aborts when trying to access /sys/devices/system/cpu/cpu0/cache/ to retrieve CPU cache information.

This happens because the current implementation defaults to calling GetCacheSizesFromKVFS() on non-Windows/macOS/QNX/QURT platforms, a function that relies on filesystem access, which is not available in WebAssembly when the filesystem is disabled.

## Solution
This PR modifies the GetCacheSizes() function in src/sysinfo.cc to detect Emscripten environments and return an empty cache info vector when running in WebAssembly, avoiding access to a non-existent filesystem.

The change is minimal, simply adding detection for the __EMSCRIPTEN__ macro and merging it with the QURT OS handling, as both return empty cache information.


## Related Issue
Fixes #1952