### PR TITLE
wheels: Build Linux ARM wheels natively on ARM runners

### DIFF
--- a/.github/install_bazel.sh
+++ b/.github/install_bazel.sh
@@ -4,7 +4,7 @@ if ! bazel version; then
     arch="arm64"
   fi
   echo "Downloading $arch Bazel binary from GitHub releases."
-  curl -L -o $HOME/bin/bazel --create-dirs "https://github.com/bazelbuild/bazel/releases/download/7.1.1/bazel-7.1.1-linux-$arch"
+  curl -L -o $HOME/bin/bazel --create-dirs "https://github.com/bazelbuild/bazel/releases/download/8.2.0/bazel-8.2.0-linux-$arch"
   chmod +x $HOME/bin/bazel
 else
   # Bazel is installed for the correct architecture

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,8 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
-
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
     steps:
       - name: Check out Google Benchmark
         uses: actions/checkout@v4
@@ -49,20 +48,13 @@ jobs:
           python-version: "3.12"
       - run: pip install --upgrade pip uv
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
       - name: Build wheels on ${{ matrix.os }} using cibuildwheel
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v2.23.2
         env:
           CIBW_BUILD: "cp310-* cp311-* cp312-*"
           CIBW_BUILD_FRONTEND: "build[uv]"
           CIBW_SKIP: "*-musllinux_*"
-          CIBW_ARCHS_LINUX: auto64 aarch64
-          CIBW_ARCHS_WINDOWS: auto64
+          CIBW_ARCHS: auto64
           CIBW_BEFORE_ALL_LINUX: bash .github/install_bazel.sh
           # Grab the rootless Bazel installation inside the container.
           CIBW_ENVIRONMENT_LINUX: PATH=$PATH:$HOME/bin


### PR DESCRIPTION
Updates the Linux Docker Bazel installation to version 8.2.0, which was released on April 14, earlier this week.

Since Ubuntu on ARM  runners are now available, we can build wheels directly on the host machines instead of going the slow way of QEMU virtualization.

--------------------

A successful build job: https://github.com/nicholasjng/benchmark/actions/runs/14489652405

This takes about 7 minutes instead of the 21-23 minutes we see for previous releases, so we get a neat 3x speedup together with the deleted lines of GitHub Actions code.

No Windows ARM yet, since there are no Bazel Python toolchains available for it at the moment.