### PR TITLE
Fix error handling of getloadavg

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -850,11 +850,11 @@ std::vector<double> GetLoadAvg() {
     !(defined(__ANDROID__) && __ANDROID_API__ < 29)
   static constexpr int kMaxSamples = 3;
   std::vector<double> res(kMaxSamples, 0.0);
-  const size_t nelem = static_cast<size_t>(getloadavg(res.data(), kMaxSamples));
+  const auto nelem = getloadavg(res.data(), kMaxSamples);
   if (nelem < 1) {
     res.clear();
   } else {
-    res.resize(nelem);
+    res.resize(static_cast<size_t>(nelem));
   }
   return res;
 #else


### PR DESCRIPTION
getloadavg returns with -1 if cannot obtain load average, but the current source casts the return value to size_t right away. The cast result for such a case is probably maximum unsigned long int, so the resizing of the res vector is certainly going to fail.

This change keeps the original return type of getloadavg and casts it just before the resizing of the res vector.