### PR TITLE
ThreadRunner: always create new threads

### DIFF
--- a/test/manual_threading_test.cc
+++ b/test/manual_threading_test.cc
@@ -35,14 +35,12 @@ int numRunThreadsCalled_ = 0;
 class ManualThreadRunner : public benchmark::ThreadRunnerBase {
  public:
   explicit ManualThreadRunner(int num_threads)
-      : pool(static_cast<size_t>(num_threads - 1)) {}
+      : pool(static_cast<size_t>(num_threads)) {}
 
   void RunThreads(const std::function<void(int)>& fn) final {
     for (std::size_t ti = 0; ti < pool.size(); ++ti) {
-      pool[ti] = std::thread(fn, static_cast<int>(ti + 1));
+      pool[ti] = std::thread(fn, static_cast<int>(ti));
     }
-
-    fn(0);
 
     for (std::thread& thread : pool) {
       thread.join();


### PR DESCRIPTION
As noted in https://github.com/google/benchmark/issues/461, Address Space Layout Randomization would be different per-thread, and that naturally may affect the measurements.

But if we always measure single-thread benchmarks from the exact same thread, we won't get different ASLR unless the whole benchmark executable is rerun,
which seems suboptimal.

I'm not 100% sure why we weren't spawning a new thread in the single-thread case, i mean, is it just
a perf optimization, or are there deeper reasons for it?

Closes https://github.com/google/benchmark/issues/461