### PR TITLE
Detect and report ASLR status

### DIFF
--- a/docs/reducing_variance.md
+++ b/docs/reducing_variance.md
@@ -50,15 +50,18 @@ If you see this error:
 you might want to disable the ASLR security hardening feature while running the
 benchmark.
 
-To globally disable ASLR, run
+To globally disable ASLR on Linux, run
 ```
 echo 0 > /proc/sys/kernel/randomize_va_space
 ```
 
-To run a single benchmark with ASLR disabled, do:
+To run a single benchmark with ASLR disabled on Linux, do:
 ```
 setarch `uname -m` -R ./a_benchmark
 ```
+
+Note that for the information on how to disable ASLR on other operating systems,
+please refer to their documentation.
 
 ## Reducing Variance in Benchmarks
 

--- a/docs/reducing_variance.md
+++ b/docs/reducing_variance.md
@@ -39,6 +39,27 @@ The benchmarks you subsequently run will have less variance.
 
 <a name="reducing-variance" />
 
+## Disabling ASLR
+
+If you see this error:
+
+```
+***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
+```
+
+you might want to disable the ASLR security hardening feature while running the
+benchmark.
+
+To globally disable ASLR, run
+```
+echo 0 > /proc/sys/kernel/randomize_va_space
+```
+
+To run a single benchmark with ASLR disabled, do:
+```
+setarch `uname -m` -R ./a_benchmark
+```
+
 ## Reducing Variance in Benchmarks
 
 The Linux CPU frequency governor [discussed

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1731,7 +1731,10 @@ struct BENCHMARK_EXPORT CPUInfo {
 
 // Adding Struct for System Information
 struct BENCHMARK_EXPORT SystemInfo {
+  enum class ASLR { UNKNOWN, ENABLED, DISABLED };
+
   std::string name;
+  ASLR ASLRStatus;
   static const SystemInfo& Get();
 
  private:

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -144,6 +144,14 @@ bool JSONReporter::ReportContext(const Context& context) {
         << ",\n";
   }
 
+  const SystemInfo& sysinfo = context.sys_info;
+  if (SystemInfo::ASLR::UNKNOWN != sysinfo.ASLRStatus) {
+    out << indent
+        << FormatKV("aslr_enabled",
+                    sysinfo.ASLRStatus == SystemInfo::ASLR::ENABLED)
+        << ",\n";
+  }
+
   out << indent << "\"caches\": [\n";
   indent = std::string(6, ' ');
   std::string cache_indent(8, ' ');

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -88,6 +88,12 @@ void BenchmarkReporter::PrintBasicContext(std::ostream *out,
            "overhead.\n";
   }
 
+  const SystemInfo &sysinfo = context.sys_info;
+  if (SystemInfo::ASLR::ENABLED == sysinfo.ASLRStatus) {
+    Out << "***WARNING*** ASLR is enabled, the results may have unreproducible "
+           "noise in them.\n";
+  }
+
 #ifndef NDEBUG
   Out << "***WARNING*** Library was built as DEBUG. Timings may be "
          "affected.\n";

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -54,6 +54,10 @@
 #include <pthread.h>
 #endif
 
+#if defined(BENCHMARK_OS_LINUX)
+#include <sys/personality.h>
+#endif
+
 #include <algorithm>
 #include <array>
 #include <bitset>
@@ -493,6 +497,16 @@ std::string GetSystemName() {
 #endif  // Catch-all POSIX block.
 }
 
+SystemInfo::ASLR GetASLR() {
+#ifdef BENCHMARK_OS_LINUX
+  const auto curr_personality = personality(0xffffffff);
+  return (curr_personality & ADDR_NO_RANDOMIZE) ? SystemInfo::ASLR::DISABLED
+                                                : SystemInfo::ASLR::ENABLED;
+#else
+  return SystemInfo::ASLR::UNKNOWN;
+#endif
+}
+
 int GetNumCPUsImpl() {
 #ifdef BENCHMARK_OS_WINDOWS
   SYSTEM_INFO sysinfo;
@@ -881,5 +895,5 @@ const SystemInfo& SystemInfo::Get() {
   return *info;
 }
 
-SystemInfo::SystemInfo() : name(GetSystemName()) {}
+SystemInfo::SystemInfo() : name(GetSystemName()), ASLRStatus(GetASLR()) {}
 }  // end namespace benchmark

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -503,6 +503,7 @@ SystemInfo::ASLR GetASLR() {
   return (curr_personality & ADDR_NO_RANDOMIZE) ? SystemInfo::ASLR::DISABLED
                                                 : SystemInfo::ASLR::ENABLED;
 #else
+  // FIXME: support detecting ASLR on other OS.
   return SystemInfo::ASLR::UNKNOWN;
 #endif
 }


### PR DESCRIPTION
Theoretically, we could just disable ASLR in `main()`, but that seems to be disallowed by default
by some other security features.

Refs. https://github.com/google/benchmark/issues/461