### PR TITLE
Automatic ASLR disablement

### DIFF
--- a/bindings/python/google_benchmark/__init__.py
+++ b/bindings/python/google_benchmark/__init__.py
@@ -137,6 +137,8 @@ def main(argv=None):
     return app.run(_run_benchmarks, argv=argv, flags_parser=_flags_parser)
 
 
+# FIXME: can we rerun with disabled ASLR?
+
 # Methods for use with custom main function.
 initialize = _benchmark.Initialize
 run_benchmarks = _benchmark.RunSpecifiedBenchmarks

--- a/docs/reducing_variance.md
+++ b/docs/reducing_variance.md
@@ -50,6 +50,17 @@ If you see this error:
 you might want to disable the ASLR security hardening feature while running the
 benchmark.
 
+The simplest way is to add
+```
+benchmark::MaybeReenterWithoutASLR(argc, argv);
+```
+as the first line of your `main()` function. It will try to disable ASLR
+for the current processor, and, if successful, re-execute the binary.
+Note that `personality(2)` may be forbidden by e.g. seccomp (which happens
+by default if you are running in a Docker container).
+
+Note that if you link to `benchmark_main` already does that for you.
+
 To globally disable ASLR on Linux, run
 ```
 echo 0 > /proc/sys/kernel/randomize_va_space

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1268,6 +1268,7 @@ For Example:
 auto BM_test = [](benchmark::State& st, auto Inputs) { /* ... */ };
 
 int main(int argc, char** argv) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
   for (auto& test_input : { /* ... */ })
       benchmark::RegisterBenchmark(test_input.name(), BM_test, test_input);
   benchmark::Initialize(&argc, argv);

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -40,6 +40,7 @@ BENCHMARK(BM_StringCopy);
 //       my_unittest --benchmark_filter=String
 //       my_unittest --benchmark_filter='Copy|Creation'
 int main(int argc, char** argv) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
   benchmark::Initialize(&argc, argv);
   benchmark::RunSpecifiedBenchmarks();
   benchmark::Shutdown();
@@ -333,6 +334,8 @@ using callback_function = std::function<void(const benchmark::State&)>;
 
 // Default number of minimum benchmark running time in seconds.
 const char kDefaultMinTimeStr[] = "0.5s";
+
+BENCHMARK_EXPORT void MaybeReenterWithoutASLR(int, char**);
 
 // Returns the version of the library.
 BENCHMARK_EXPORT std::string GetBenchmarkVersion();
@@ -1687,6 +1690,7 @@ class Fixture : public internal::Benchmark {
 // Note the workaround for Hexagon simulator passing argc != 0, argv = NULL.
 #define BENCHMARK_MAIN()                                                \
   int main(int argc, char** argv) {                                     \
+    benchmark::MaybeReenterWithoutASLR(argc, argv);                     \
     char arg0_default[] = "benchmark";                                  \
     char* args_default = reinterpret_cast<char*>(arg0_default);         \
     if (!argv) {                                                        \

--- a/test/benchmark_min_time_flag_iters_test.cc
+++ b/test/benchmark_min_time_flag_iters_test.cc
@@ -44,6 +44,8 @@ static void BM_MyBench(benchmark::State& state) {
 BENCHMARK(BM_MyBench);
 
 int main(int argc, char** argv) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+
   // Make a fake argv and append the new --benchmark_min_time=<foo> to it.
   int fake_argc = argc + 1;
   std::vector<const char*> fake_argv(static_cast<size_t>(fake_argc));

--- a/test/benchmark_min_time_flag_time_test.cc
+++ b/test/benchmark_min_time_flag_time_test.cc
@@ -69,6 +69,8 @@ static void BM_MyBench(benchmark::State& state) {
 BENCHMARK(BM_MyBench);
 
 int main(int argc, char** argv) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+
   // Make a fake argv and append the new --benchmark_min_time=<foo> to it.
   int fake_argc = argc + 1;
   std::vector<const char*> fake_argv(static_cast<size_t>(fake_argc));

--- a/test/benchmark_setup_teardown_test.cc
+++ b/test/benchmark_setup_teardown_test.cc
@@ -134,6 +134,8 @@ BENCHMARK(BM_WithRep)
     ->Repetitions(4);
 
 int main(int argc, char** argv) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+
   benchmark::Initialize(&argc, argv);
 
   size_t ret = benchmark::RunSpecifiedBenchmarks(".");

--- a/test/complexity_test.cc
+++ b/test/complexity_test.cc
@@ -269,4 +269,7 @@ ADD_COMPLEXITY_CASES(complexity_capture_name, complexity_capture_name + "_BigO",
 // --------------------------- TEST CASES END ------------------------------ //
 // ========================================================================= //
 
-int main(int argc, char *argv[]) { RunOutputTests(argc, argv); }
+int main(int argc, char *argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+  RunOutputTests(argc, argv);
+}

--- a/test/diagnostics_test.cc
+++ b/test/diagnostics_test.cc
@@ -94,6 +94,7 @@ int main(int argc, char* argv[]) {
   (void)argc;
   (void)argv;
 #else
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
   benchmark::internal::GetAbortHandler() = &TestHandler;
   benchmark::Initialize(&argc, argv);
   benchmark::RunSpecifiedBenchmarks();

--- a/test/display_aggregates_only_test.cc
+++ b/test/display_aggregates_only_test.cc
@@ -17,6 +17,8 @@ void BM_SummaryRepeat(benchmark::State& state) {
 BENCHMARK(BM_SummaryRepeat)->Repetitions(3)->DisplayAggregatesOnly();
 
 int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+
   const std::string output = GetFileReporterOutput(argc, argv);
 
   if (SubstrCnt(output, "\"name\": \"BM_SummaryRepeat/repeats:3") != 7 ||

--- a/test/donotoptimize_test.cc
+++ b/test/donotoptimize_test.cc
@@ -26,7 +26,9 @@ struct BitRef {
   BitRef(int i, unsigned char& b) : index(i), byte(b) {}
 };
 
-int main(int /*unused*/, char* /*unused*/[]) {
+int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+
   // this test verifies compilation of DoNotOptimize() for some types
 
   char buffer1[1] = "";

--- a/test/filter_test.cc
+++ b/test/filter_test.cc
@@ -70,6 +70,8 @@ static void BM_FooBa(benchmark::State& state) {
 BENCHMARK(BM_FooBa);
 
 int main(int argc, char** argv) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+
   bool list_only = false;
   for (int i = 0; i < argc; ++i) {
     list_only |= std::string(argv[i]).find("--benchmark_list_tests") !=

--- a/test/internal_threading_test.cc
+++ b/test/internal_threading_test.cc
@@ -183,4 +183,8 @@ BENCHMARK(BM_MainThreadAndWorkerThread)
 // ---------------------------- TEST CASES END ----------------------------- //
 // ========================================================================= //
 
-int main(int argc, char* argv[]) { RunOutputTests(argc, argv); }
+int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+
+  RunOutputTests(argc, argv);
+}

--- a/test/manual_threading_test.cc
+++ b/test/manual_threading_test.cc
@@ -167,6 +167,7 @@ BENCHMARK(BM_ManualThreading)
 // ========================================================================= //
 
 int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
   benchmark::Initialize(&argc, argv);
   benchmark::RunSpecifiedBenchmarks();
   benchmark::Shutdown();

--- a/test/memory_manager_test.cc
+++ b/test/memory_manager_test.cc
@@ -40,6 +40,7 @@ ADD_CASES(TC_JSONOut, {{"\"name\": \"BM_empty\",$"},
 ADD_CASES(TC_CSVOut, {{"^\"BM_empty\",%csv_report$"}});
 
 int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
   std::unique_ptr<benchmark::MemoryManager> mm(new TestMemoryManager());
 
   benchmark::RegisterMemoryManager(mm.get());

--- a/test/perf_counters_test.cc
+++ b/test/perf_counters_test.cc
@@ -79,6 +79,7 @@ CHECK_BENCHMARK_RESULTS("BM_WithoutPauseResume", &SaveInstrCountWithoutResume);
 CHECK_BENCHMARK_RESULTS("BM_WithPauseResume", &SaveInstrCountWithResume);
 
 int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
   if (!benchmark::internal::PerfCounters::kSupported) {
     return 0;
   }

--- a/test/profiler_manager_iterations_test.cc
+++ b/test/profiler_manager_iterations_test.cc
@@ -35,6 +35,7 @@ static void BM_MyBench(benchmark::State& state) {
 BENCHMARK(BM_MyBench);
 
 int main(int argc, char** argv) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
   // Make a fake argv and append the new --benchmark_profiler_iterations=<foo>
   // to it.
   int fake_argc = argc + 1;

--- a/test/profiler_manager_test.cc
+++ b/test/profiler_manager_test.cc
@@ -40,6 +40,7 @@ ADD_CASES(TC_JSONOut, {{"\"name\": \"BM_empty\",$"},
 ADD_CASES(TC_CSVOut, {{"^\"BM_empty\",%csv_report$"}});
 
 int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
   std::unique_ptr<TestProfilerManager> pm(new TestProfilerManager());
 
   benchmark::RegisterProfilerManager(pm.get());

--- a/test/register_benchmark_test.cc
+++ b/test/register_benchmark_test.cc
@@ -184,6 +184,7 @@ void RunTestTwo() {
 }
 
 int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
   benchmark::Initialize(&argc, argv);
 
   RunTestOne();

--- a/test/repetitions_test.cc
+++ b/test/repetitions_test.cc
@@ -211,4 +211,7 @@ ADD_CASES(TC_CSVOut, {{"^\"BM_ImplicitRepetitions_stddev\",%csv_report$"}});
 // --------------------------- TEST CASES END ------------------------------ //
 // ========================================================================= //
 
-int main(int argc, char* argv[]) { RunOutputTests(argc, argv); }
+int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+  RunOutputTests(argc, argv);
+}

--- a/test/report_aggregates_only_test.cc
+++ b/test/report_aggregates_only_test.cc
@@ -17,6 +17,7 @@ void BM_SummaryRepeat(benchmark::State& state) {
 BENCHMARK(BM_SummaryRepeat)->Repetitions(3)->ReportAggregatesOnly();
 
 int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
   const std::string output = GetFileReporterOutput(argc, argv);
 
   if (SubstrCnt(output, "\"name\": \"BM_SummaryRepeat/repeats:3") != 4 ||

--- a/test/reporter_output_test.cc
+++ b/test/reporter_output_test.cc
@@ -1133,4 +1133,7 @@ ADD_CASES(TC_CSVOut, {{"^\"BM_CSV_Format\",,,,,,,,true,\"\"\"freedom\"\"\"$"}});
 // --------------------------- TEST CASES END ------------------------------ //
 // ========================================================================= //
 
-int main(int argc, char* argv[]) { RunOutputTests(argc, argv); }
+int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+  RunOutputTests(argc, argv);
+}

--- a/test/skip_with_error_test.cc
+++ b/test/skip_with_error_test.cc
@@ -183,6 +183,7 @@ ADD_CASES("BM_error_while_paused", {{"/1/threads:1", true, "error message"},
                                     {"/2/threads:8", false, ""}});
 
 int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
   benchmark::Initialize(&argc, argv);
 
   TestReporter test_reporter;

--- a/test/spec_arg_test.cc
+++ b/test/spec_arg_test.cc
@@ -55,6 +55,8 @@ static void BM_Chosen(benchmark::State& state) {
 BENCHMARK(BM_Chosen);
 
 int main(int argc, char** argv) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+
   const std::string flag = "BM_NotChosen";
 
   // Verify that argv specify --benchmark_filter=BM_NotChosen.

--- a/test/spec_arg_verbosity_test.cc
+++ b/test/spec_arg_verbosity_test.cc
@@ -12,6 +12,8 @@ static void BM_Verbosity(benchmark::State& state) {
 BENCHMARK(BM_Verbosity);
 
 int main(int argc, char** argv) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+
   const int32_t flagv = 42;
 
   // Verify that argv specify --v=42.

--- a/test/user_counters_tabular_test.cc
+++ b/test/user_counters_tabular_test.cc
@@ -560,4 +560,7 @@ CHECK_BENCHMARK_RESULTS("BM_CounterSet2_Tabular", &CheckSet2);
 // --------------------------- TEST CASES END ------------------------------ //
 // ========================================================================= //
 
-int main(int argc, char* argv[]) { RunOutputTests(argc, argv); }
+int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+  RunOutputTests(argc, argv);
+}

--- a/test/user_counters_test.cc
+++ b/test/user_counters_test.cc
@@ -565,4 +565,7 @@ CHECK_BENCHMARK_RESULTS("BM_Counters_kAvgIterationsRate",
 // --------------------------- TEST CASES END ------------------------------ //
 // ========================================================================= //
 
-int main(int argc, char* argv[]) { RunOutputTests(argc, argv); }
+int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+  RunOutputTests(argc, argv);
+}

--- a/test/user_counters_thousands_test.cc
+++ b/test/user_counters_thousands_test.cc
@@ -184,4 +184,7 @@ CHECK_BENCHMARK_RESULTS("BM_Counters_Thousands", &CheckThousands);
 // --------------------------- TEST CASES END ------------------------------ //
 // ========================================================================= //
 
-int main(int argc, char* argv[]) { RunOutputTests(argc, argv); }
+int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+  RunOutputTests(argc, argv);
+}


### PR DESCRIPTION
While ASLR is a useful security hardening feature, it introduces unreproducible noise into benchmarks, and we really really really don't want any noise,
especially easily avoidable one.

Unless prevented by some other security hardening, we can disable ASLR for the current process,
and restart it, thus eliminating this noise.

Fixes https://github.com/google/benchmark/issues/461