### PR TITLE
Update build instructions for Visual Studio

### DIFF
--- a/docs/platform_specific_build_instructions.md
+++ b/docs/platform_specific_build_instructions.md
@@ -15,21 +15,25 @@ On QNX, the pthread library is part of libc and usually included automatically
 [`pthread_create()`](https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.lib_ref/topic/p/pthread_create.html)).
 There's no separate pthread library to link.
 
-## Building with Visual Studio 2015 or 2017
+## Building with Visual Studio 2015, 2017 or 2022
 
 The `shlwapi` library (`-lshlwapi`) is required to support a call to `CPUInfo` which reads the registry. Either add `shlwapi.lib` under `[ Configuration Properties > Linker > Input ]`, or use the following:
 
 ```
 // Alternatively, can add libraries using linker options.
+
+// First, Add the path to the generated library files (directory containing the `benchmark.lib`) in `[Configuration Properties > Linker > General > Additional Library Directories]`. Then do the following:
 #ifdef _WIN32
 #pragma comment ( lib, "Shlwapi.lib" )
 #ifdef _DEBUG
-#pragma comment ( lib, "benchmarkd.lib" )
+#pragma comment ( lib, "benchmark.lib" )
 #else
 #pragma comment ( lib, "benchmark.lib" )
 #endif
 #endif
 ```
+
+When using the static library, make sure to add `BENCHMARK_STATIC_DEFINE` under `[Configuration Properties > C/C++ > Preprocessor > Preprocessor Definitions]`
 
 Can also use the graphical version of CMake:
 * Open `CMake GUI`.


### PR DESCRIPTION
Try to set up benchmark environment on Windows and spend quite a bit time to figure out what happened when building with debug mode in Visual Studio.

After this change #947, no 'd' postfix will be generated for debug builds. The library file is consistently named `benchmark.lib` for all configurations.

btw, I have successfully tested this configuration on two independent machines with Visual Studio 2022. Hopefully it demonstrates the reliability for this setup approach.