### PR TITLE
fix: resolve editable installation issue for python package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,11 @@ class BuildBazelExtension(build_ext.build_ext):
         pkgname = "google_benchmark"
         pythonroot = Path("bindings") / "python" / "google_benchmark"
         srcdir = temp_path / "bazel-bin" / pythonroot
-        libdir = Path(self.build_lib) / pkgname
+        if not self.inplace:
+            libdir = Path(self.build_lib) / pkgname
+        else:
+            build_py = self.get_finalized_command("build_py")
+            libdir = build_py.get_package_dir(pkgname)
         for root, dirs, files in os.walk(srcdir, topdown=True):
             # exclude runfiles directories and children.
             dirs[:] = [d for d in dirs if "runfiles" not in d]


### PR DESCRIPTION
Before this `pip install -e .` produced ` error: [Errno 2] No such file or directory: '/tmp/tmpi02jtn4q.build-lib/google_benchmark/_benchmark.pyi'`

Second try of #1987. I hope code makes more sense now. Yes, `_benchmark.pyi`, `_benchmark.so` and `py.typed` go to the source tree, but this is how it is supposed to work.