### PR TITLE
python binding: add range check

### DIFF
--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -167,7 +167,15 @@ NB_MODULE(_benchmark, m) {
       .def_prop_rw("items_processed", &State::items_processed,
                    &State::SetItemsProcessed)
       .def("set_label", &State::SetLabel)
-      .def("range", &State::range, nb::arg("pos") = 0)
+      .def(
+          "range",
+          [](const State& state, std::size_t pos = 0) -> int64_t {
+            if (pos < state.range_size()) {
+              return state.range(pos);
+            }
+            throw nb::index_error("pos is out of range");
+          },
+          nb::arg("pos") = 0)
       .def_prop_ro("iterations", &State::iterations)
       .def_prop_ro("name", &State::name)
       .def_rw("counters", &State::counters)

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -956,6 +956,8 @@ class BENCHMARK_EXPORT BENCHMARK_INTERNAL_CACHELINE_ALIGNED State {
   BENCHMARK_ALWAYS_INLINE
   std::string name() const { return name_; }
 
+  size_t range_size() const { return range_.size(); }
+
  private:
   // items we expect on the first cache line (ie 64 bytes of the struct)
   // When total_iterations_ is 0, KeepRunning() and friends will return false.


### PR DESCRIPTION
fixes segmentation fault in
```python
import google_benchmark as benchmark

@benchmark.register
def av_test(state):
    state.range(9)

benchmark.main()
```

closes #1965

@nicholasjng, what do you think about performance impact?