### PR TITLE
python: Assert that libdir is a Path in all branches

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,8 @@ class BuildBazelExtension(build_ext.build_ext):
             libdir = Path(self.build_lib) / pkgname
         else:
             build_py = self.get_finalized_command("build_py")
-            libdir = build_py.get_package_dir(pkgname)
+            libdir = Path(build_py.get_package_dir(pkgname))
+
         for root, dirs, files in os.walk(srcdir, topdown=True):
             # exclude runfiles directories and children.
             dirs[:] = [d for d in dirs if "runfiles" not in d]


### PR DESCRIPTION
The `inplace=True` branch previously relied on some non-trivial interactions between `str` and `pathlib.Path` objects, which produces unexpected values in cases of `s / p`, where `s` is a string and `p` is an absolute path.

To fix, just create a `pathlib.Path` of the return value of `build_py.get_package_dir()`.