### PR TITLE
Add deprecation warnings for MSVC

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -621,6 +621,17 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   _ReadWriteBarrier();
 }
 
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
+  internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
+  _ReadWriteBarrier();
+}
+
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp&& value) {
+  internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
+  _ReadWriteBarrier();
+}
 #else
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp&& value) {


### PR DESCRIPTION
It was discovered that the deprecation warnings were not emitted for MSVC when updating uses of Google Benchmark in the MSVC STL suite. I believe it's better to emit the warnings.

Extensions `__declspec(deprecated("msg"))` and `__pragma` are used. If we want to drop support for relatively old versions of MSVC, we can use `_Pragma` and `[[deprecated("msg")]]`.