### PR TITLE
python: Update to cibuildwheel 3.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,10 +46,11 @@ jobs:
         name: Install Python 3.12
         with:
           python-version: "3.12"
-      - run: pip install --upgrade pip uv
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
 
       - name: Build wheels on ${{ matrix.os }} using cibuildwheel
-        uses: pypa/cibuildwheel@v2.23.2
+        uses: pypa/cibuildwheel@v3.0.0
         env:
           CIBW_BUILD: "cp310-* cp311-* cp312-*"
           CIBW_BUILD_FRONTEND: "build[uv]"
@@ -60,7 +61,7 @@ jobs:
           CIBW_ENVIRONMENT_LINUX: PATH=$PATH:$HOME/bin
           CIBW_TEST_COMMAND: python {project}/bindings/python/google_benchmark/example.py
           # unused by Bazel, but needed explicitly by delocate on MacOS.
-          MACOSX_DEPLOYMENT_TARGET: "10.14"
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-13' && 10.14 || 11.0 }}
 
       - name: Upload Google Benchmark ${{ matrix.os }} wheels
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Includes an implicit update to manylinux_2_28 (i.e., the wheels work on Linux systems with a glibc version >=2.28).

We now set the MacOS deployment target dynamically based on the runner image to avoid a warning on the MacOS Intel runner.

-------------------

Notes:

* cibuildwheel v3.0.0 was released yesterday, users are encouraged to upgrade.
* [Here](https://github.com/nicholasjng/benchmark/actions/runs/15612060966) is a successful wheel build with this PR. Note also that the macOS deployment target-related warnings are gone from the action summary.