### PR TITLE
ci: Update pre-commit hooks and GitHub Action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,4 +19,4 @@ jobs:
       with:
         python-version: 3.12
     - name: Run pre-commit checks
-      run: uv run --no-sync --extra dev pre-commit run --all-files --verbose --show-diff-on-failure
+      run: uv run --only-group=dev pre-commit run --all-files --verbose --show-diff-on-failure

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,36 +6,17 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  CMAKE_GENERATOR: Ninja
-
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
-    env:
-      MYPY_CACHE_DIR: "${{ github.workspace }}/.cache/mypy"
-      RUFF_CACHE_DIR: "${{ github.workspace }}/.cache/ruff"
-      PRE_COMMIT_HOME: "${{ github.workspace }}/.cache/pre-commit"
 
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v5
+        persist-credentials: false
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
       with:
-        python-version: 3.11
-        cache: pip
-        cache-dependency-path: pyproject.toml
-    - name: Install dependencies
-      run: python -m pip install ".[dev]"
-    - name: Cache pre-commit tools
-      uses: actions/cache@v4
-      with:
-        path: |
-          ${{ env.MYPY_CACHE_DIR }}
-          ${{ env.RUFF_CACHE_DIR }}
-          ${{ env.PRE_COMMIT_HOME }}
-        key: ${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}-linter-cache
+        python-version: 3.12
     - name: Run pre-commit checks
-      run: pre-commit run --all-files --verbose --show-diff-on-failure
+      run: uv run --no-sync --extra dev pre-commit run --all-files --verbose --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   -   repo: https://github.com/keith/pre-commit-buildifier
-      rev: 8.0.3
+      rev: 8.2.0
       hooks:
       -   id: buildifier
       -   id: buildifier-lint
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.16.0
     hooks:
       - id: mypy
         types_or: [ python, pyi ]
         args: [ "--ignore-missing-imports", "--scripts-are-modules" ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.11.13
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [ --fix, --exit-non-zero-on-fix ]
       - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Testing",
     "Topic :: System :: Benchmark",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dynamic = ["readme", "version"]
 
 dependencies = ["absl-py>=0.7.1"]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = ["pre-commit>=3.3.3"]
 
 [project.urls]


### PR DESCRIPTION
Using pre-commit together with uv gives a considerable speedup when running with `--no-sync`, and eliminates the need for our current elaborate caching setup in GitHub Actions.

Also adds the Python 3.13 trove classifier to `pyproject.toml`, since wheels for it have been published on PyPI.

---------------

Since uv is already used in cibuildwheel for Python virtual environment management, I figured it was a good idea to implement it here also. I've been running this setup (`uv run pre-commit run ...`) across multiple projects for a while now, including benchmark, so I consider it a well-tried approach.

As for the addition of `--no-sync`: This prevents the installation of google-benchmark into the virtual environment, which is good, since it is not necessary for pre-commit to begin with, and takes a good 20-30s on GitHub runners.