### PR TITLE
Guard adding intel compiler flag behind check for intel compiler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,9 @@ else()
     # See #631 for rationale.
     add_cxx_compiler_flag(-wd1786)
     add_cxx_compiler_flag(-fno-finite-math-only)
+    # ICC17u2: overloaded virtual function "benchmark::Fixture::SetUp" is only partially
+    # overridden (because of deprecated overload)
+    add_cxx_compiler_flag(-wd654)
   endif()
   # Disable deprecation warnings for release builds (when -Werror is enabled).
   if(BENCHMARK_ENABLE_WERROR)
@@ -229,12 +232,6 @@ else()
     if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Intel" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM") #ICC17u2: Many false positives for Wstrict-aliasing
       add_cxx_compiler_flag(-Wstrict-aliasing)
     endif()
-  endif()
-  if  (CMAKE_CXX_COMPILER_ID STREQUAL "Intel" OR
-       CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
-      # ICC17u2: overloaded virtual function "benchmark::Fixture::SetUp" is only partially overridden
-      # (because of deprecated overload)
-      add_cxx_compiler_flag(-wd654)
   endif()
 
   add_cxx_compiler_flag(-Wthread-safety)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,9 +230,13 @@ else()
       add_cxx_compiler_flag(-Wstrict-aliasing)
     endif()
   endif()
-  # ICC17u2: overloaded virtual function "benchmark::Fixture::SetUp" is only partially overridden
-  # (because of deprecated overload)
-  add_cxx_compiler_flag(-wd654)
+  if  (CMAKE_CXX_COMPILER_ID STREQUAL "Intel" OR
+       CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+      # ICC17u2: overloaded virtual function "benchmark::Fixture::SetUp" is only partially overridden
+      # (because of deprecated overload)
+      add_cxx_compiler_flag(-wd654)
+  endif()
+
   add_cxx_compiler_flag(-Wthread-safety)
   if (HAVE_CXX_FLAG_WTHREAD_SAFETY)
     cxx_feature_check(THREAD_SAFETY_ATTRIBUTES "-DINCLUDE_DIRECTORIES=${PROJECT_SOURCE_DIR}/include")


### PR DESCRIPTION
For reasons I don't yet fully understand, failing to guard the check for flag -wd654 will cause it to be added to certain clang configurations, and then cause compilation to fail.

While exactly why this happens needs investigation, the fix proposed in this patch seems direct and simple enough to apply regardless.