### PR TITLE
core(perf): use string move constructor for AddCustomContext

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -486,7 +486,7 @@ void RegisterProfilerManager(ProfilerManager* profiler_manager);
 
 // Add a key-value pair to output as part of the context stanza in the report.
 BENCHMARK_EXPORT
-void AddCustomContext(const std::string& key, const std::string& value);
+void AddCustomContext(std::string key, std::string value);
 
 namespace internal {
 class Benchmark;

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -708,11 +708,12 @@ void RegisterProfilerManager(ProfilerManager* manager) {
   internal::profiler_manager = manager;
 }
 
-void AddCustomContext(const std::string& key, const std::string& value) {
+void AddCustomContext(std::string key, std::string value) {
   if (internal::global_context == nullptr) {
     internal::global_context = new std::map<std::string, std::string>();
   }
-  if (!internal::global_context->emplace(key, value).second) {
+  if (!internal::global_context->emplace(std::move(key), std::move(value))
+           .second) {
     std::cerr << "Failed to add custom context \"" << key << "\" as it already "
               << "exists with value \"" << value << "\"\n";
   }


### PR DESCRIPTION
Avoid unnecessary string copies.