### PR TITLE
Add initializer for statistics field

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1821,6 +1821,7 @@ class BENCHMARK_EXPORT BenchmarkReporter {
           complexity(oNone),
           complexity_lambda(),
           complexity_n(0),
+          statistics(),
           report_big_o(false),
           report_rms(false),
           allocs_per_iter(0.0) {}


### PR DESCRIPTION
Copying uninitialized pointers is undefined behavior, and security mitigations such as structure protection [1] take advantage of this. Previously benchmarks would crash when copying the uninitialized statistics field; fix the crash by initializing it.

[1] https://discourse.llvm.org/t/rfc-structure-protection-a-family-of-uaf-mitigation-techniques/85555