### PR TITLE
JSON reporter: make int dumping always happen in C locale

### DIFF
--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -81,7 +81,9 @@ std::string FormatKV(std::string const& key, bool value) {
 
 std::string FormatKV(std::string const& key, int64_t value) {
   std::stringstream ss;
-  ss << '"' << StrEscape(key) << "\": " << value;
+  // We really want to just dump the integer as-is,
+  // without the system locale interfering.
+  ss << '"' << StrEscape(key) << "\": " << std::to_string(value);
   return ss.str();
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -219,6 +219,9 @@ benchmark_add_test(NAME profiler_manager_iterations COMMAND profiler_manager_ite
 compile_output_test(complexity_test)
 benchmark_add_test(NAME complexity_benchmark COMMAND complexity_test --benchmark_min_time=1000000x)
 
+compile_output_test(locale_impermeability_test)
+benchmark_add_test(NAME locale_impermeability_test COMMAND locale_impermeability_test)
+
 ###############################################################################
 # GoogleTest Unit Tests
 ###############################################################################

--- a/test/locale_impermeability_test.cc
+++ b/test/locale_impermeability_test.cc
@@ -1,0 +1,47 @@
+#undef NDEBUG
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+#include "output_test.h"
+
+static void BM_ostream(benchmark::State &state) {
+#if !defined(__MINGW64__) || defined(__clang__)
+  // GCC-based versions of MINGW64 do not support locale manipulations,
+  // don't run the test under them.
+  std::locale::global(std::locale("en_US.UTF-8"));
+#endif
+  while (state.KeepRunning()) {
+    state.SetIterationTime(1e-6);
+  }
+}
+BENCHMARK(BM_ostream)->UseManualTime()->Iterations(1000000);
+
+ADD_CASES(TC_ConsoleOut, {{"^BM_ostream/iterations:1000000/manual_time"
+                           " %console_report$"}});
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_ostream/iterations:1000000/manual_time\",$"},
+           {"\"family_index\": 0,$", MR_Next},
+           {"\"per_family_instance_index\": 0,$", MR_Next},
+           {"\"run_name\": "
+            "\"BM_ostream/iterations:1000000/manual_time\",$",
+            MR_Next},
+           {"\"run_type\": \"iteration\",$", MR_Next},
+           {"\"repetitions\": 1,$", MR_Next},
+           {"\"repetition_index\": 0,$", MR_Next},
+           {"\"threads\": 1,$", MR_Next},
+           {"\"iterations\": 1000000,$", MR_Next},
+           {"\"real_time\": %float,$", MR_Next},
+           {"\"cpu_time\": %float,$", MR_Next},
+           {"\"time_unit\": \"ns\"$", MR_Next},
+           {"}", MR_Next}});
+ADD_CASES(TC_CSVOut, {{"^\"BM_ostream/iterations:1000000/"
+                       "manual_time\",1000000,%float,%float,ns,,,,,$"}});
+
+int main(int argc, char *argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+  RunOutputTests(argc, argv);
+}


### PR DESCRIPTION
The test fails without the fix.

Fixes https://github.com/google/benchmark/issues/2039