### PR TITLE
Take a closure for benchmark configuration

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1229,7 +1229,7 @@ class BENCHMARK_EXPORT Benchmark {
   // Pass this benchmark object to *func, which can customize
   // the benchmark by calling various methods like Arg, Args,
   // Threads, etc.
-  Benchmark* Apply(void (*custom_arguments)(Benchmark* benchmark));
+  Benchmark* Apply(const std::function<void(Benchmark* benchmark)>&);
 
   // Set the range multiplier for non-dense range. If not called, the range
   // multiplier kRangeMultiplier will be used.

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -330,7 +330,8 @@ Benchmark* Benchmark::Args(const std::vector<int64_t>& args) {
   return this;
 }
 
-Benchmark* Benchmark::Apply(void (*custom_arguments)(Benchmark* benchmark)) {
+Benchmark* Benchmark::Apply(
+    const std::function<void(Benchmark* benchmark)>& custom_arguments) {
   custom_arguments(this);
   return this;
 }


### PR DESCRIPTION
It turns out it is useful when a benchmark is generated on the fly before the enumeration on benchmark registration.

There is a use case in which benchmarks shall be built from configuration flags, before the benchmark init. Without captures, it is actually hard to pass additional data.