### PR TITLE
Add missing type_traits include to benchmark_register.h

### DIFF
--- a/src/benchmark_register.h
+++ b/src/benchmark_register.h
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <type_traits>
 #include <vector>
 
 #include "check.h"


### PR DESCRIPTION
The file uses std::is_signed, which is in <type_traits>.

Without this, this file won't build after https://llvm.org/PR168334