### PR TITLE
Make the Benchmark class public

### DIFF
--- a/bindings/python/google_benchmark/benchmark.cc
+++ b/bindings/python/google_benchmark/benchmark.cc
@@ -36,8 +36,8 @@ std::vector<std::string> Initialize(const std::vector<std::string>& argv) {
   return remaining_argv;
 }
 
-benchmark::internal::Benchmark* RegisterBenchmark(const std::string& name,
-                                                  nb::callable f) {
+benchmark::Benchmark* RegisterBenchmark(const std::string& name,
+                                        nb::callable f) {
   return benchmark::RegisterBenchmark(
       name, [f](benchmark::State& state) { f(&state); });
 }
@@ -64,7 +64,7 @@ NB_MODULE(_benchmark, m) {
       .value("oLambda", BigO::oLambda)
       .export_values();
 
-  using benchmark::internal::Benchmark;
+  using benchmark::Benchmark;
   nb::class_<Benchmark>(m, "Benchmark")
       // For methods returning a pointer to the current object, reference
       // return policy is used to ask nanobind not to take ownership of the

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -452,7 +452,7 @@ benchmark. The following example enumerates a dense range on one parameter,
 and a sparse range on the second.
 
 ```c++
-static void CustomArguments(benchmark::internal::Benchmark* b) {
+static void CustomArguments(benchmark::Benchmark* b) {
   for (int i = 0; i <= 10; ++i)
     for (int j = 32; j <= 1024*1024; j *= 8)
       b->Args({i, j});

--- a/src/benchmark_api_internal.cc
+++ b/src/benchmark_api_internal.cc
@@ -7,7 +7,8 @@
 namespace benchmark {
 namespace internal {
 
-BenchmarkInstance::BenchmarkInstance(Benchmark* benchmark, int family_idx,
+BenchmarkInstance::BenchmarkInstance(benchmark::Benchmark* benchmark,
+                                     int family_idx,
                                      int per_family_instance_idx,
                                      const std::vector<int64_t>& args,
                                      int thread_count)

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -17,7 +17,7 @@ namespace internal {
 // Information kept per benchmark we may want to run
 class BenchmarkInstance {
  public:
-  BenchmarkInstance(Benchmark* benchmark, int family_idx,
+  BenchmarkInstance(benchmark::Benchmark* benchmark, int family_idx,
                     int per_family_instance_idx,
                     const std::vector<int64_t>& args, int thread_count);
 
@@ -52,7 +52,7 @@ class BenchmarkInstance {
 
  private:
   BenchmarkName name_;
-  Benchmark& benchmark_;
+  benchmark::Benchmark& benchmark_;
   const int family_index_;
   const int per_family_instance_index_;
   AggregationReportMode aggregation_report_mode_;

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -217,7 +217,8 @@ class ThreadRunnerDefault : public ThreadRunnerBase {
 };
 
 std::unique_ptr<ThreadRunnerBase> GetThreadRunner(
-    const threadrunner_factory& userThreadRunnerFactory, int num_threads) {
+    const benchmark::threadrunner_factory& userThreadRunnerFactory,
+    int num_threads) {
   return userThreadRunnerFactory
              ? userThreadRunnerFactory(num_threads)
              : std::make_unique<ThreadRunnerDefault>(num_threads);

--- a/test/benchmark_setup_teardown_cb_types_gtest.cc
+++ b/test/benchmark_setup_teardown_cb_types_gtest.cc
@@ -1,13 +1,13 @@
 #include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 
+using benchmark::Benchmark;
 using benchmark::BenchmarkReporter;
 using benchmark::callback_function;
 using benchmark::ClearRegisteredBenchmarks;
 using benchmark::RegisterBenchmark;
 using benchmark::RunSpecifiedBenchmarks;
 using benchmark::State;
-using benchmark::internal::Benchmark;
 
 static int functor_called = 0;
 struct Functor {

--- a/test/memory_results_gtest.cc
+++ b/test/memory_results_gtest.cc
@@ -5,13 +5,13 @@
 
 namespace {
 
+using benchmark::Benchmark;
 using benchmark::ClearRegisteredBenchmarks;
 using benchmark::ConsoleReporter;
 using benchmark::MemoryManager;
 using benchmark::RegisterBenchmark;
 using benchmark::RunSpecifiedBenchmarks;
 using benchmark::State;
-using benchmark::internal::Benchmark;
 
 constexpr int N_REPETITIONS = 100;
 constexpr int N_ITERATIONS = 1;

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -51,7 +51,7 @@ BENCHMARK(BM_basic)->RangeMultiplier(4)->Range(-8, 8);
 BENCHMARK(BM_basic)->DenseRange(-2, 2, 1);
 BENCHMARK(BM_basic)->Ranges({{-64, 1}, {-8, -1}});
 
-void CustomArgs(benchmark::internal::Benchmark* b) {
+void CustomArgs(benchmark::Benchmark* b) {
   for (int i = 0; i < 10; ++i) {
     b->Arg(i);
   }

--- a/test/register_benchmark_test.cc
+++ b/test/register_benchmark_test.cc
@@ -56,7 +56,7 @@ int AddCases(std::initializer_list<TestCase> const& v) {
 #define ADD_CASES(...) \
   const int CONCAT(dummy, __LINE__) = AddCases({__VA_ARGS__})
 
-using ReturnVal = benchmark::internal::Benchmark const* const;
+using ReturnVal = benchmark::Benchmark const* const;
 
 //----------------------------------------------------------------------------//
 // Test RegisterBenchmark with no additional arguments

--- a/test/time_unit_gtest.cc
+++ b/test/time_unit_gtest.cc
@@ -6,7 +6,7 @@ namespace internal {
 
 namespace {
 
-class DummyBenchmark : public Benchmark {
+class DummyBenchmark : public benchmark::Benchmark {
  public:
   DummyBenchmark() : Benchmark("dummy") {}
   void Run(State& /*state*/) override {}


### PR DESCRIPTION
Move ::benchmark::internal::Benchmark to ::benchmark::Benchmark.

It's a bit odd that the documented way to pass arguments to a benchmark is with `benchmark::internal::Benchmark`.  Make this public instead.

https://github.com/google/benchmark/blob/v1.9.4/docs/user_guide.md#passing-arguments

https://raw.githubusercontent.com/google/benchmark/refs/tags/v1.9.4/docs/user_guide.md#:~:text=void%20CustomArguments(benchmark%3A%3A-,internal%3A%3ABenchmark,-*%20b)%20%7B%0A%20%20for%20(int

Keep ::benchmark::internal::Benchmark as a deprecated forwarding alias. Uses of Benchmark in the internal namespace need to explicitly use ::benchmark::Benchmark to avoid the deprecation warning.