### PR TITLE
exclude linking to lib rt for QNX to avoid linking error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,12 @@ include(CheckCXXCompilerFlag)
 include(CheckLibraryExists)
 include(CXXFeatureCheck)
 
-check_library_exists(rt shm_open "" HAVE_LIB_RT)
+# Check for rt library, but explicitly disable for QNX
+if(QNXNTO)
+  set(HAVE_LIB_RT FALSE)
+else()
+  check_library_exists(rt shm_open "" HAVE_LIB_RT)
+endif()
 
 if (BENCHMARK_BUILD_32_BITS)
   add_required_cxx_compiler_flag(-m32)


### PR DESCRIPTION
solves [#issue-3865896474](https://github.com/google/benchmark/issues/2113#issue-3865896474)