### PR TITLE
fix(pyproject): Update license to SPDX identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "google_benchmark"
 description = "A library to benchmark code snippets."
 requires-python = ">=3.10"
-license = { file = "LICENSE" }
+license = "Apache-2.0"
 keywords = ["benchmark"]
 
 authors = [{ name = "Google", email = "benchmark-discuss@googlegroups.com" }]
@@ -15,7 +15,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Silences a warning in newer setuptools. The changes are as per the recommendation in Python's packaging guide, see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files.