### PR TITLE
Replicate generic hardware events on all CPU PMUs

### DIFF
--- a/src/perf_counters.h
+++ b/src/perf_counters.h
@@ -152,7 +152,7 @@ class BENCHMARK_EXPORT PerfCountersMeasurement final {
 
   size_t num_counters() const { return counters_.num_counters(); }
 
-  std::vector<std::string> names() const { return counters_.names(); }
+  const std::vector<std::string>& names() const { return counters_.names(); }
 
   BENCHMARK_ALWAYS_INLINE bool Start() {
     if (num_counters() == 0) return true;


### PR DESCRIPTION
On systems with more than one PMU for the CPUs (e.g. Apple M series SOCs), generic hardware events are only created for an arbitrary PMU. Usually this is the big cluster's PMU, which can cause inaccuracies when the process is scheduled onto a little core. To fix this, teach PerfCounters to register generic hardware events on all CPU PMUs.

CPU PMUs are identified using the same method as perf.