### PR TITLE
#2125: Fix error: format string is not a string literal (#2126)

### DIFF
--- a/src/string_util.h
+++ b/src/string_util.h
@@ -16,13 +16,7 @@ BENCHMARK_EXPORT
 std::string HumanReadableNumber(double n, Counter::OneK one_k);
 
 BENCHMARK_EXPORT
-#if defined(__MINGW32__)
-__attribute__((format(__MINGW_PRINTF_FORMAT, 1, 2)))
-#elif defined(__GNUC__)
-__attribute__((format(printf, 1, 2)))
-#endif
-std::string
-StrFormat(const char* format, ...);
+std::string StrFormat(const char* format, ...) PRINTF_FORMAT_STRING_FUNC(1, 2);
 
 inline std::ostream& StrCatImp(std::ostream& out) BENCHMARK_NOEXCEPT {
   return out;


### PR DESCRIPTION
For some reasons, `std::string StrFormat(const char* format, ...)` was declared with custom format attributes in conditions. The project wide macro `PRINTF_FORMAT_STRING_FUNC` must be used.