### PR TITLE
Revert "Remove redundant feature checks on re-run of CMake config ste…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,17 +315,10 @@ if (BENCHMARK_USE_LIBCXX)
 endif(BENCHMARK_USE_LIBCXX)
 
 # C++ feature checks
-# Determine the correct regular expression engine to use. First compatible engine found is used.
+# Determine the correct regular expression engine to use
 cxx_feature_check(STD_REGEX)
-
-if(NOT HAVE_STD_REGEX)
-  cxx_feature_check(GNU_POSIX_REGEX)
-endif()
-
-if(NOT HAVE_STD_REGEX AND NOT HAVE_GNU_POSIX_REGEX)
-  cxx_feature_check(POSIX_REGEX)
-endif()
-
+cxx_feature_check(GNU_POSIX_REGEX)
+cxx_feature_check(POSIX_REGEX)
 if(NOT HAVE_STD_REGEX AND NOT HAVE_GNU_POSIX_REGEX AND NOT HAVE_POSIX_REGEX)
   message(FATAL_ERROR "Failed to determine the source files for the regular expression backend")
 endif()

--- a/cmake/CXXFeatureCheck.cmake
+++ b/cmake/CXXFeatureCheck.cmake
@@ -10,35 +10,22 @@
 #
 # include(CXXFeatureCheck)
 # cxx_feature_check(STD_REGEX)
-# Requires CMake 3.13+
+# Requires CMake 2.8.12+
 
 if(__cxx_feature_check)
   return()
 endif()
 set(__cxx_feature_check INCLUDED)
 
-option(CXXFEATURECHECK_DEBUG OFF "Enable debug messages for CXX feature checks")
+option(CXXFEATURECHECK_DEBUG OFF)
 
-function(cxx_feature_check_print log)
-  if(CXXFEATURECHECK_DEBUG)
-    message(STATUS "${log}")
-  endif()
-endfunction()
-
-function(cxx_feature_check FEATURE)
-  string(TOLOWER ${FEATURE} FILE)
-  string(TOUPPER HAVE_${FEATURE} VAR)
-
-  # Check if the variable is already defined to a true or false for a quick return.
-  # This allows users to predefine the variable to skip the check.
-  # Or, if the variable is already defined by a previous check, we skip the costly check.
-  if (DEFINED ${VAR})
-    if (${VAR})
-      cxx_feature_check_print("Feature ${FEATURE} already enabled.")
-      add_compile_definitions(${VAR})
-    else()
-      cxx_feature_check_print("Feature ${FEATURE} already disabled.")
-    endif()
+function(cxx_feature_check FILE)
+  string(TOLOWER ${FILE} FILE)
+  string(TOUPPER ${FILE} VAR)
+  string(TOUPPER "HAVE_${VAR}" FEATURE)
+  if (DEFINED HAVE_${VAR})
+    set(HAVE_${VAR} 1 PARENT_SCOPE)
+    add_definitions(-DHAVE_${VAR})
     return()
   endif()
 
@@ -48,53 +35,48 @@ function(cxx_feature_check FEATURE)
     list(APPEND FEATURE_CHECK_CMAKE_FLAGS ${ARGV1})
   endif()
 
-  if(CMAKE_CROSSCOMPILING)
-    cxx_feature_check_print("Cross-compiling to test ${FEATURE}")
-    try_compile(
-      COMPILE_STATUS
-      ${CMAKE_BINARY_DIR} 
-      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${FILE}.cpp
-      CXX_STANDARD 17
-      CXX_STANDARD_REQUIRED ON
-      CMAKE_FLAGS "${FEATURE_CHECK_CMAKE_FLAGS}"
-      LINK_LIBRARIES "${BENCHMARK_CXX_LIBRARIES}"
-      OUTPUT_VARIABLE COMPILE_OUTPUT_VAR
-    )
-    if(COMPILE_STATUS)
-      set(RUN_STATUS 0)
-      message(WARNING
-              "If you see build failures due to cross compilation, try setting ${VAR} to 0")
+  if (NOT DEFINED COMPILE_${FEATURE})
+    if(CMAKE_CROSSCOMPILING)
+      message(STATUS "Cross-compiling to test ${FEATURE}")
+      try_compile(COMPILE_${FEATURE}
+              ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${FILE}.cpp
+              CXX_STANDARD 17
+              CXX_STANDARD_REQUIRED ON
+              CMAKE_FLAGS ${FEATURE_CHECK_CMAKE_FLAGS}
+              LINK_LIBRARIES ${BENCHMARK_CXX_LIBRARIES}
+              OUTPUT_VARIABLE COMPILE_OUTPUT_VAR)
+      if(COMPILE_${FEATURE})
+        message(WARNING
+              "If you see build failures due to cross compilation, try setting HAVE_${VAR} to 0")
+        set(RUN_${FEATURE} 0 CACHE INTERNAL "")
+      else()
+        set(RUN_${FEATURE} 1 CACHE INTERNAL "")
+      endif()
+    else()
+      message(STATUS "Compiling and running to test ${FEATURE}")
+      try_run(RUN_${FEATURE} COMPILE_${FEATURE}
+              ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${FILE}.cpp
+              CXX_STANDARD 17
+              CXX_STANDARD_REQUIRED ON
+              CMAKE_FLAGS ${FEATURE_CHECK_CMAKE_FLAGS}
+              LINK_LIBRARIES ${BENCHMARK_CXX_LIBRARIES}
+              COMPILE_OUTPUT_VARIABLE COMPILE_OUTPUT_VAR)
+    endif()
+  endif()
+
+  if(COMPILE_${FEATURE})
+    if(DEFINED RUN_${FEATURE} AND RUN_${FEATURE} EQUAL 0)
+      message(STATUS "Performing Test ${FEATURE} -- success")
+      set(HAVE_${VAR} 1 PARENT_SCOPE)
+      add_definitions(-DHAVE_${VAR})
+    else()
+      message(STATUS "Performing Test ${FEATURE} -- compiled but failed to run")
     endif()
   else()
-    cxx_feature_check_print("Compiling and running to test ${FEATURE}")
-    try_run(
-      RUN_STATUS 
-      COMPILE_STATUS
-      ${CMAKE_BINARY_DIR} 
-      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${FILE}.cpp
-      CXX_STANDARD 17
-      CXX_STANDARD_REQUIRED ON
-      CMAKE_FLAGS "${FEATURE_CHECK_CMAKE_FLAGS}"
-      LINK_LIBRARIES "${BENCHMARK_CXX_LIBRARIES}"
-      COMPILE_OUTPUT_VARIABLE COMPILE_OUTPUT
-      RUN_OUTPUT_VARIABLE RUN_OUTPUT
-    )
+    if(CXXFEATURECHECK_DEBUG)
+      message(STATUS "Performing Test ${FEATURE} -- failed to compile: ${COMPILE_OUTPUT_VAR}")
+    else()
+      message(STATUS "Performing Test ${FEATURE} -- failed to compile")
+    endif()
   endif()
-
-  if(COMPILE_STATUS AND RUN_STATUS EQUAL 0)
-    message(STATUS "Performing Test ${FEATURE} -- success")
-    set(${VAR} TRUE CACHE BOOL "" FORCE)
-    add_compile_definitions(${VAR})
-    return()
-  endif()
-
-  set(${VAR} FALSE CACHE BOOL "" FORCE)
-  message(STATUS "Performing Test ${FEATURE} -- failed")
-
-  if(NOT COMPILE_STATUS)
-    cxx_feature_check_print("Compile Output: ${COMPILE_OUTPUT}")
-  else()
-    cxx_feature_check_print("Run Output: ${RUN_OUTPUT}")
-  endif()
-
 endfunction()


### PR DESCRIPTION
…p (#2084)"

This reverts commit 6a8dee95ae1151142fe4be94482cdfd11b7111bd.

This commit has broken our build, e.g.: 
```
-- Compiling and running to test GNU_POSIX_REGEX
CMake Error at build/linux/armhf/googlebenchmark-source/CMakeLists.txt:330 (message):
  Failed to determine the source files for the regular expression backend


-- Performing Test GNU_POSIX_REGEX -- failed
-- Compile Output: Change Dir: '/__w/XNNPACK/XNNPACK/build/linux/armhf/CMakeFiles/CMakeTmp'

Run Build Command(s): /usr/bin/ninja -v cmTC_0f13b
[1/2] ccache /usr/bin/arm-linux-gnueabihf-g++   -Wall  -Wextra  -Wshadow  -Wfloat-equal  -Wold-style-cast  -Wconversion  -Wformat=2  -Werror  -Wsuggest-override  -pedantic  -pedantic-errors  -fstrict-aliasing  -Wno-deprecated-declarations  -Wno-deprecated  -Wstrict-aliasing  -std=c++17 -o CMakeFiles/cmTC_0f13b.dir/gnu_posix_regex.cpp.o -c /__w/XNNPACK/XNNPACK/build/linux/armhf/googlebenchmark-source/cmake/gnu_posix_regex.cpp
FAILED: CMakeFiles/cmTC_0f13b.dir/gnu_posix_regex.cpp.o 
ccache /usr/bin/arm-linux-gnueabihf-g++   -Wall  -Wextra  -Wshadow  -Wfloat-equal  -Wold-style-cast  -Wconversion  -Wformat=2  -Werror  -Wsuggest-override  -pedantic  -pedantic-errors  -fstrict-aliasing  -Wno-deprecated-declarations  -Wno-deprecated  -Wstrict-aliasing  -std=c++17 -o CMakeFiles/cmTC_0f13b.dir/gnu_posix_regex.cpp.o -c /__w/XNNPACK/XNNPACK/build/linux/armhf/googlebenchmark-source/cmake/gnu_posix_regex.cpp
/__w/XNNPACK/XNNPACK/build/linux/armhf/googlebenchmark-source/cmake/gnu_posix_regex.cpp:1:10: fatal error: gnuregex.h: No such file or directory
    1 | #include <gnuregex.h>
      |          ^~~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.


-- Feature POSIX_REGEX already disabled.
```
(https://github.com/google/XNNPACK/actions/runs/22084382825/job/63815804259)

This seems to affect most (maybe all) of our cross-compiled builds.

I've spent some time trying to fix this, and found some supsicious things (e.g. `COMPILE_OUTPUT_VAR` incompletely renamed) but unfortunately we don't have a good way to reproduce these cross-compile builds, so it is difficult to debug. 

Considering the original commit was only an optimization of the build, I hope it will be acceptable to just revert it. I've verified that reverting this commit repairs our builds when updating this dependency.

This should reopen #2078