### PR TITLE
Bump the version of python used for pip.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,7 +31,7 @@ python.toolchain(python_version = "3.13")
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_dependency = True)
 pip.parse(
     hub_name = "tools_pip_deps",
-    python_version = "3.9",
+    python_version = "3.12",
     requirements_lock = "//tools:requirements.txt",
 )
 use_repo(pip, "tools_pip_deps")


### PR DESCRIPTION
The default python is already 3.12 (widely available) and we should use the same default for the pip calls too.  It's tricky to get older python versions sometimes so this should simplify things.