### PR TITLE
Replace deprecated _ReadWriteBarrier with std::atomic_signal_fence in MSVC path

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,6 +61,7 @@ Olga Fadeeva <olga.kiselik@gmail.com>
 Ori Livneh <ori.livneh@gmail.com>
 Paul Redmond <paul.redmond@gmail.com>
 Prithvi Rao <ee22b024@smail.iitm.ac.in>
+qorexdev <sanenkosana600@gmail.com>
 Radoslav Yovchev <radoslav.tm@gmail.com>
 Raghu Raja <raghu@enfabrica.net>
 Rainer Orth <ro@cebitec.uni-bielefeld.de>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -85,6 +85,7 @@ Pascal Leroy <phl@google.com>
 Paul Redmond <paul.redmond@gmail.com>
 Pierre Phaneuf <pphaneuf@google.com>
 Prithvi Rao <ee22b024@smail.iitm.ac.in>
+qorexdev <sanenkosana600@gmail.com>
 Radoslav Yovchev <radoslav.tm@gmail.com>
 Raghu Raja <raghu@enfabrica.net>
 Rainer Orth <ro@cebitec.uni-bielefeld.de>

--- a/include/benchmark/utils.h
+++ b/include/benchmark/utils.h
@@ -127,19 +127,19 @@ BENCHMARK_DEPRECATED_MSG(
     "undesired compiler optimizations in benchmarks")
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
-  _ReadWriteBarrier();
+  std::atomic_signal_fence(std::memory_order_acq_rel);
 }
 
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
-  _ReadWriteBarrier();
+  std::atomic_signal_fence(std::memory_order_acq_rel);
 }
 
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp&& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
-  _ReadWriteBarrier();
+  std::atomic_signal_fence(std::memory_order_acq_rel);
 }
 #else
 template <class Tp>

--- a/include/benchmark/utils.h
+++ b/include/benchmark/utils.h
@@ -127,19 +127,19 @@ BENCHMARK_DEPRECATED_MSG(
     "undesired compiler optimizations in benchmarks")
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
-  std::atomic_signal_fence(std::memory_order_acq_rel);
+  ClobberMemory();
 }
 
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
-  std::atomic_signal_fence(std::memory_order_acq_rel);
+  ClobberMemory();
 }
 
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp&& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
-  std::atomic_signal_fence(std::memory_order_acq_rel);
+  ClobberMemory();
 }
 #else
 template <class Tp>


### PR DESCRIPTION
_ReadWriteBarrier() has been deprecated since MSVC 2015. This replaces
the three calls in the MSVC DoNotOptimize overloads with
std::atomic_signal_fence(std::memory_order_acq_rel), which is the
standard C++11 equivalent (compiler-only barrier, no hardware fence).

Same function is already used for ClobberMemory() in this file, and
<atomic> is already included.

Fixes #747