### PR TITLE
Fix thread safety attribute detection failing to link in CMake check

### DIFF
--- a/cmake/thread_safety_attributes.cpp
+++ b/cmake/thread_safety_attributes.cpp
@@ -1,4 +1,25 @@
-#define HAVE_THREAD_SAFETY_ATTRIBUTES
-#include "../src/mutex.h"
+#if defined(__clang__)
+#define THREAD_ANNOTATION_ATTRIBUTE_(x) __attribute__((x))
+#else
+#define THREAD_ANNOTATION_ATTRIBUTE_(x)
+#endif
 
-int main() {}
+#define CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE_(capability(x))
+#define ACQUIRE() THREAD_ANNOTATION_ATTRIBUTE_(acquire_capability())
+#define RELEASE() THREAD_ANNOTATION_ATTRIBUTE_(release_capability())
+
+class CAPABILITY("mutex") Mutex {
+ public:
+  void lock() ACQUIRE();
+  void unlock() RELEASE();
+};
+
+void Mutex::lock() ACQUIRE() {}
+void Mutex::unlock() RELEASE() {}
+
+int main() {
+  Mutex m;
+  m.lock();
+  m.unlock();
+  return 0;
+}


### PR DESCRIPTION
The `cmake/thread_safety_attributes.cpp` check was including `../src/mutex.h`, which transitively pulls in `check.h`. That header declares `benchmark::internal::GetAbortHandler()` with `BENCHMARK_EXPORT`, which requires linking against the benchmark library. Since `try_run` in `CXXFeatureCheck.cmake` only links against `BENCHMARK_CXX_LIBRARIES` (which doesn't include the full library at check time), the check failed to link, leaving `HAVE_THREAD_SAFETY_ATTRIBUTES` undefined.

Without `HAVE_THREAD_SAFETY_ATTRIBUTES`, the `ACQUIRE()`/`RELEASE()` annotations on the benchmark `Mutex` wrapper expand to nothing. When users compile with `-D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS`, libc++'s `std::mutex` already carries thread safety attributes, and the unannotated benchmark wrapper causes false-positive `-Wthread-safety` warnings (mutex still held at end of function / releasing mutex not held).

The fix replaces the check file with a self-contained test that directly exercises the thread safety attributes without including any benchmark headers, so the feature check compiles and links successfully on its own. With `HAVE_THREAD_SAFETY_ATTRIBUTES` now properly defined, the mutex wrapper annotations work correctly alongside libc++'s own annotations.

Fixes #943
