### PR TITLE
Fix .gitignore to unignore .cmake files recursively under cmake/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.exe
 *.dylib
 *.cmake
-!/cmake/*.cmake
+!/cmake/**/*.cmake
 !/test/AssemblyTests.cmake
 *~
 *.swp

--- a/AUTHORS
+++ b/AUTHORS
@@ -77,3 +77,4 @@ Tobias Schmidt <tobias.schmidt@in.tum.de>
 Yixuan Qiu <yixuanq@gmail.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Zbigniew Skowron <zbychs@gmail.com>
+XiaoWei Lu <shaway77606@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -104,3 +104,4 @@ Tom Madams <tom.ej.madams@gmail.com> <tmadams@google.com>
 Yixuan Qiu <yixuanq@gmail.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Zbigniew Skowron <zbychs@gmail.com>
+XiaoWei Lu <shaway77606@gmail.com>


### PR DESCRIPTION
Fix #2190 

The rule `!/cmake/*.cmake` only unignores .cmake files at one level
under cmake/. Files in subdirectories like cmake/Modules/ remain
ignored because `*` does not match `/` in gitignore patterns.

Changed to `!/cmake/**/*.cmake` so `**` matches across all directory
levels.

This also prevents a future issue: if a new .cmake file is added under
cmake/Modules/, it would be silently ignored and not committed.