### PR TITLE
Sort entry in AUTHORS and CONTRIBUTORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,7 +74,7 @@ Staffan Tjernstrom <staffantj@gmail.com>
 Steinar H. Gunderson <sgunderson@bigfoot.com>
 Stripe, Inc.
 Tobias Schmidt <tobias.schmidt@in.tum.de>
+XiaoWei Lu <shaway77606@gmail.com>
 Yixuan Qiu <yixuanq@gmail.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Zbigniew Skowron <zbychs@gmail.com>
-XiaoWei Lu <shaway77606@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -101,7 +101,7 @@ Steven Wan <wan.yu@ibm.com>
 Tobias Schmidt <tobias.schmidt@in.tum.de>
 Tobias Ulvgård <tobias.ulvgard@dirac.se>
 Tom Madams <tom.ej.madams@gmail.com> <tmadams@google.com>
+XiaoWei Lu <shaway77606@gmail.com>
 Yixuan Qiu <yixuanq@gmail.com>
 Yusuke Suzuki <utatane.tea@gmail.com>
 Zbigniew Skowron <zbychs@gmail.com>
-XiaoWei Lu <shaway77606@gmail.com>


### PR DESCRIPTION
Follow-up to #2191 : Fix ordering for my entry in AUTHORS and CONTRIBUTORS.

These files are maintained in alphabetical order; this change moves my name to the correct position without altering content.