### PR TITLE
Avoid repeated ASLR re-exec attempts

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -864,6 +864,11 @@ void MaybeReenterWithoutASLR(int /*argc*/, char** argv) {
   if ((internal::get_as_unsigned(new_personality) & ADDR_NO_RANDOMIZE) == 0)
     return;
 
+  // Some security profiles clear ADDR_NO_RANDOMIZE across exec even though the
+  // personality appears updated here. Avoid re-entering forever in that case.
+  constexpr const char* kAslrReexecEnv = "BENCHMARK_ASLR_NO_REEXEC";
+  if (std::getenv(kAslrReexecEnv) != nullptr) return;
+  if (setenv(kAslrReexecEnv, "1", 1) != 0) return;
   execv(argv[0], argv);
   // The exec() functions return only if an error has occurred,
   // in which case we want to just continue as-is.


### PR DESCRIPTION
## Summary
- add an environment sentinel before re-execing after ADDR_NO_RANDOMIZE is set
- skip the re-exec if the process already attempted the ASLR-disable path once
- avoid re-execing if the sentinel cannot be recorded

## Context
This addresses the AppArmor case from #2184 where `personality()` reports `ADDR_NO_RANDOMIZE` as set before `execv()`, but the new process image loses that flag and re-enters the same code path forever.

## Testing
- `git diff --check`

I did not add a direct unit test because the behavior depends on Linux exec/personality interaction under an AppArmor-constrained process tree.