### PR TITLE
Prevent repeated ASLR reexec attempts

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -149,6 +149,11 @@ BM_DEFINE_string(benchmark_perf_counters, "");
 // pairs. Kept internal as it's only used for parsing from env/command line.
 BM_DEFINE_kvpairs(benchmark_context, {});
 
+#ifdef BENCHMARK_OS_LINUX
+constexpr const char* kAslrReexecAttemptedEnv =
+    "BENCHMARK_ASLR_REEXEC_ATTEMPTED";
+#endif
+
 // Set the default time unit to use for reports
 // Valid values are 'ns', 'us', 'ms' or 's'
 BM_DEFINE_string(benchmark_time_unit, "");
@@ -836,6 +841,9 @@ void MaybeReenterWithoutASLR(int /*argc*/, char** argv) {
   if (!argv) return;
 
 #ifdef BENCHMARK_OS_LINUX
+  // The no-ASLR personality can be reset across exec by security policies.
+  if (getenv(kAslrReexecAttemptedEnv) != nullptr) return;
+
   const auto curr_personality = personality(0xffffffff);
 
   // We should never fail to read-only query the current personality,
@@ -853,14 +861,16 @@ void MaybeReenterWithoutASLR(int /*argc*/, char** argv) {
   // Have we failed to change the personality? That may happen.
   if (prev_personality == -1) return;
 
-  // Make sure the parsona has been updated with the no-ASLR flag,
+  // Make sure the persona has been updated with the no-ASLR flag,
   // otherwise we will try to reenter infinitely.
   // This seems impossible, but can happen in some docker configurations.
   const auto new_personality = personality(0xffffffff);
   if ((internal::get_as_unsigned(new_personality) & ADDR_NO_RANDOMIZE) == 0)
     return;
 
+  if (setenv(kAslrReexecAttemptedEnv, "1", 1) != 0) return;
   execv(argv[0], argv);
+  unsetenv(kAslrReexecAttemptedEnv);
   // The exec() functions return only if an error has occurred,
   // in which case we want to just continue as-is.
 #else

--- a/test/benchmark_gtest.cc
+++ b/test/benchmark_gtest.cc
@@ -1,8 +1,10 @@
+#include <cstdlib>
 #include <map>
 #include <string>
 #include <vector>
 
 #include "../src/benchmark_register.h"
+#include "../src/internal_macros.h"
 #include "benchmark/benchmark_api.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -163,6 +165,21 @@ TEST(AddCustomContext, DuplicateKey) {
   delete global_context;
   global_context = nullptr;
 }
+
+#ifndef BENCHMARK_OS_WINDOWS
+TEST(MaybeReenterWithoutASLRTest, ReexecSentinelPreventsAnotherExec) {
+  constexpr const char* kAslrReexecAttemptedEnv =
+      "BENCHMARK_ASLR_REEXEC_ATTEMPTED";
+  ASSERT_EQ(setenv(kAslrReexecAttemptedEnv, "1", 1), 0);
+
+  char program[] = "benchmark_gtest";
+  char* argv[] = {program, nullptr};
+  benchmark::MaybeReenterWithoutASLR(1, argv);
+
+  EXPECT_STREQ(getenv(kAslrReexecAttemptedEnv), "1");
+  ASSERT_EQ(unsetenv(kAslrReexecAttemptedEnv), 0);
+}
+#endif
 
 }  // namespace
 }  // namespace internal


### PR DESCRIPTION
## What changed

- Add an internal `BENCHMARK_ASLR_REEXEC_ATTEMPTED` sentinel before `MaybeReenterWithoutASLR()` calls `execv()`.
- If the benchmark process is re-entered but the no-ASLR personality was reset by a security policy, the next process sees the sentinel and skips another re-exec attempt.
- Add a gtest covering the sentinel short-circuit path.

## Why

This prevents an infinite re-exec loop when `personality()` appears to set `ADDR_NO_RANDOMIZE` in the current process, but AppArmor resets that personality across `execv()`.

Fixes #2184.

## Validation

- `git diff --check`
- `bazel test //test:benchmark_gtest --cxxopt=-isystem --cxxopt=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1`

Note: the explicit `--cxxopt` is needed on my macOS local environment because the default Command Line Tools compiler is not finding libc++ headers without the SDK include path.
