### PR TITLE
Skip errored runs when computing repetition statistics

### DIFF
--- a/src/statistics.cc
+++ b/src/statistics.cc
@@ -117,8 +117,8 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
   };
   auto successful_run =
       std::find_if(reports.begin(), reports.end(), is_successful);
-  const auto successful_count =
-      std::count_if(reports.begin(), reports.end(), is_successful);
+  const auto successful_count = static_cast<std::vector<Run>::size_type>(
+      std::count_if(reports.begin(), reports.end(), is_successful));
 
   if (successful_count < 2) {
     // We don't report aggregated data if there was a single run.
@@ -129,8 +129,8 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
   std::vector<double> real_accumulated_time_stat;
   std::vector<double> cpu_accumulated_time_stat;
 
-  real_accumulated_time_stat.reserve(reports.size());
-  cpu_accumulated_time_stat.reserve(reports.size());
+  real_accumulated_time_stat.reserve(successful_count);
+  cpu_accumulated_time_stat.reserve(successful_count);
 
   // All repetitions should be run with the same number of iterations so we
   // can take this information from the first benchmark.
@@ -152,7 +152,7 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
                  .emplace(cnt.first,
                           CounterStat{cnt.second, std::vector<double>{}})
                  .first;
-        it->second.s.reserve(reports.size());
+        it->second.s.reserve(successful_count);
       } else {
         BM_CHECK_EQ(it->second.c.flags, cnt.second.flags);
       }

--- a/src/statistics.cc
+++ b/src/statistics.cc
@@ -117,7 +117,7 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
   };
   auto successful_run =
       std::find_if(reports.begin(), reports.end(), is_successful);
-  const auto successful_count = static_cast<std::vector<Run>::size_type>(
+  const auto successful_count = static_cast<size_t>(
       std::count_if(reports.begin(), reports.end(), is_successful));
 
   if (successful_count < 2) {

--- a/src/statistics.cc
+++ b/src/statistics.cc
@@ -112,13 +112,13 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
   typedef BenchmarkReporter::Run Run;
   std::vector<Run> results;
 
-  auto successful_run = std::find_if(reports.begin(), reports.end(),
-                                     [](Run const& run) {
-                                       return run.skipped == 0u;
-                                     });
-  const auto successful_count = std::count_if(
-      reports.begin(), reports.end(),
-      [](Run const& run) { return run.skipped == 0u; });
+  const auto is_successful = [](Run const& run) {
+    return run.skipped == internal::NotSkipped;
+  };
+  auto successful_run =
+      std::find_if(reports.begin(), reports.end(), is_successful);
+  const auto successful_count =
+      std::count_if(reports.begin(), reports.end(), is_successful);
 
   if (successful_count < 2) {
     // We don't report aggregated data if there was a single run.
@@ -142,7 +142,7 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
   };
   std::map<std::string, CounterStat> counter_stats;
   for (Run const& r : reports) {
-    if (r.skipped != 0u) {
+    if (!is_successful(r)) {
       continue;
     }
     for (auto const& cnt : r.counters) {
@@ -162,7 +162,7 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
   // Populate the accumulators.
   for (Run const& run : reports) {
     BM_CHECK_EQ(successful_run->benchmark_name(), run.benchmark_name());
-    if (run.skipped != 0u) {
+    if (!is_successful(run)) {
       continue;
     }
     BM_CHECK_EQ(run_iterations, run.iterations);
@@ -179,7 +179,7 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
   // Only add label if it is same for all runs
   std::string report_label = successful_run->report_label;
   for (const Run& run : reports) {
-    if (run.skipped != 0u) {
+    if (!is_successful(run)) {
       continue;
     }
     if (run.report_label != report_label) {

--- a/src/statistics.cc
+++ b/src/statistics.cc
@@ -112,10 +112,15 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
   typedef BenchmarkReporter::Run Run;
   std::vector<Run> results;
 
-  auto error_count = std::count_if(reports.begin(), reports.end(),
-                                   [](Run const& run) { return run.skipped; });
+  auto successful_run = std::find_if(reports.begin(), reports.end(),
+                                     [](Run const& run) {
+                                       return run.skipped == 0u;
+                                     });
+  const auto successful_count = std::count_if(
+      reports.begin(), reports.end(),
+      [](Run const& run) { return run.skipped == 0u; });
 
-  if (reports.size() - static_cast<size_t>(error_count) < 2) {
+  if (successful_count < 2) {
     // We don't report aggregated data if there was a single run.
     return results;
   }
@@ -129,7 +134,7 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
 
   // All repetitions should be run with the same number of iterations so we
   // can take this information from the first benchmark.
-  const IterationCount run_iterations = reports.front().iterations;
+  const IterationCount run_iterations = successful_run->iterations;
   // create stats for user counters
   struct CounterStat {
     Counter c;
@@ -137,6 +142,9 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
   };
   std::map<std::string, CounterStat> counter_stats;
   for (Run const& r : reports) {
+    if (r.skipped != 0u) {
+      continue;
+    }
     for (auto const& cnt : r.counters) {
       auto it = counter_stats.find(cnt.first);
       if (it == counter_stats.end()) {
@@ -153,11 +161,11 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
 
   // Populate the accumulators.
   for (Run const& run : reports) {
-    BM_CHECK_EQ(reports[0].benchmark_name(), run.benchmark_name());
-    BM_CHECK_EQ(run_iterations, run.iterations);
+    BM_CHECK_EQ(successful_run->benchmark_name(), run.benchmark_name());
     if (run.skipped != 0u) {
       continue;
     }
+    BM_CHECK_EQ(run_iterations, run.iterations);
     real_accumulated_time_stat.emplace_back(run.real_accumulated_time);
     cpu_accumulated_time_stat.emplace_back(run.cpu_accumulated_time);
     // user counters
@@ -169,26 +177,30 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
   }
 
   // Only add label if it is same for all runs
-  std::string report_label = reports[0].report_label;
-  for (std::size_t i = 1; i < reports.size(); i++) {
-    if (reports[i].report_label != report_label) {
+  std::string report_label = successful_run->report_label;
+  for (const Run& run : reports) {
+    if (run.skipped != 0u) {
+      continue;
+    }
+    if (run.report_label != report_label) {
       report_label = "";
       break;
     }
   }
 
   const double iteration_rescale_factor =
-      static_cast<double>(reports.size()) / static_cast<double>(run_iterations);
+      static_cast<double>(successful_count) /
+      static_cast<double>(run_iterations);
 
-  for (const auto& Stat : *reports[0].statistics) {
+  for (const auto& Stat : *successful_run->statistics) {
     // Get the data from the accumulator to BenchmarkReporter::Run's.
     Run data;
-    data.run_name = reports[0].run_name;
-    data.family_index = reports[0].family_index;
-    data.per_family_instance_index = reports[0].per_family_instance_index;
+    data.run_name = successful_run->run_name;
+    data.family_index = successful_run->family_index;
+    data.per_family_instance_index = successful_run->per_family_instance_index;
     data.run_type = BenchmarkReporter::Run::RT_Aggregate;
-    data.threads = reports[0].threads;
-    data.repetitions = reports[0].repetitions;
+    data.threads = successful_run->threads;
+    data.repetitions = successful_run->repetitions;
     data.repetition_index = Run::no_repetition_index;
     data.aggregate_name = Stat.name_;
     data.aggregate_unit = Stat.unit_;
@@ -199,7 +211,7 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
     // Similarly, if there are N repetitions with 1 iterations each,
     // an aggregate will be computed over N measurements, not 1.
     // Thus it is best to simply use the count of separate reports.
-    data.iterations = static_cast<IterationCount>(reports.size());
+    data.iterations = static_cast<IterationCount>(successful_count);
 
     data.real_accumulated_time = Stat.compute_(real_accumulated_time_stat);
     data.cpu_accumulated_time = Stat.compute_(cpu_accumulated_time_stat);
@@ -214,7 +226,7 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
       data.cpu_accumulated_time *= iteration_rescale_factor;
     }
 
-    data.time_unit = reports[0].time_unit;
+    data.time_unit = successful_run->time_unit;
 
     // user counters
     for (auto const& kv : counter_stats) {

--- a/test/repetitions_test.cc
+++ b/test/repetitions_test.cc
@@ -209,6 +209,44 @@ ADD_CASES(TC_CSVOut, {{"^\"BM_ImplicitRepetitions\",%csv_report$"}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_ImplicitRepetitions_mean\",%csv_report$"}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_ImplicitRepetitions_median\",%csv_report$"}});
 ADD_CASES(TC_CSVOut, {{"^\"BM_ImplicitRepetitions_stddev\",%csv_report$"}});
+
+// ========================================================================= //
+// --------------------- Testing Skipped Repetitions ------------------------ //
+// ========================================================================= //
+
+void BM_SkippedFirstRepetition(benchmark::State& state) {
+  static int repetition_index = 0;
+  if (repetition_index++ == 0) {
+    state.SkipWithError("skipped first repetition");
+    return;
+  }
+  for (auto _ : state) {
+  }
+}
+BENCHMARK(BM_SkippedFirstRepetition)->Repetitions(3);
+
+ADD_CASES(TC_ConsoleOut,
+          {{"^BM_SkippedFirstRepetition/repeats:3[ ]+ERROR OCCURRED: "
+            "'skipped first repetition'$"},
+           {"^BM_SkippedFirstRepetition/repeats:3 %console_report$", MR_Next},
+           {"^BM_SkippedFirstRepetition/repeats:3 %console_report$", MR_Next},
+           {"^BM_SkippedFirstRepetition/repeats:3_mean %console_report$",
+            MR_Next},
+           {"^BM_SkippedFirstRepetition/repeats:3_median %console_report$",
+            MR_Next},
+           {"^BM_SkippedFirstRepetition/repeats:3_stddev %console_report$",
+            MR_Next}});
+ADD_CASES(TC_JSONOut,
+          {{"\"name\": \"BM_SkippedFirstRepetition/repeats:3_mean\",$"},
+           {"\"run_type\": \"aggregate\",$"},
+           {"\"repetitions\": 3,$", MR_Next},
+           {"\"threads\": 1,$", MR_Next},
+           {"\"aggregate_name\": \"mean\",$", MR_Next},
+           {"\"aggregate_unit\": \"time\",$", MR_Next},
+           {"\"iterations\": 2,$", MR_Next}});
+ADD_CASES(TC_CSVOut,
+          {{"^\"BM_SkippedFirstRepetition/repeats:3_mean\",2,%float,%float,"
+            "ns,,,,,$"}});
 }  // end namespace
 
 // ========================================================================= //

--- a/test/repetitions_test.cc
+++ b/test/repetitions_test.cc
@@ -225,17 +225,16 @@ void BM_SkippedFirstRepetition(benchmark::State& state) {
 }
 BENCHMARK(BM_SkippedFirstRepetition)->Repetitions(3);
 
-ADD_CASES(TC_ConsoleOut,
-          {{"^BM_SkippedFirstRepetition/repeats:3[ ]+ERROR OCCURRED: "
-            "'skipped first repetition'$"},
-           {"^BM_SkippedFirstRepetition/repeats:3 %console_report$", MR_Next},
-           {"^BM_SkippedFirstRepetition/repeats:3 %console_report$", MR_Next},
-           {"^BM_SkippedFirstRepetition/repeats:3_mean %console_report$",
-            MR_Next},
-           {"^BM_SkippedFirstRepetition/repeats:3_median %console_report$",
-            MR_Next},
-           {"^BM_SkippedFirstRepetition/repeats:3_stddev %console_report$",
-            MR_Next}});
+ADD_CASES(
+    TC_ConsoleOut,
+    {{"^BM_SkippedFirstRepetition/repeats:3[ ]+ERROR OCCURRED: "
+      "'skipped first repetition'$"},
+     {"^BM_SkippedFirstRepetition/repeats:3 %console_report$", MR_Next},
+     {"^BM_SkippedFirstRepetition/repeats:3 %console_report$", MR_Next},
+     {"^BM_SkippedFirstRepetition/repeats:3_mean %console_report$", MR_Next},
+     {"^BM_SkippedFirstRepetition/repeats:3_median %console_report$", MR_Next},
+     {"^BM_SkippedFirstRepetition/repeats:3_stddev %console_report$",
+      MR_Next}});
 ADD_CASES(TC_JSONOut,
           {{"\"name\": \"BM_SkippedFirstRepetition/repeats:3_mean\",$"},
            {"\"run_type\": \"aggregate\",$"},

--- a/test/statistics_gtest.cc
+++ b/test/statistics_gtest.cc
@@ -6,25 +6,6 @@
 #include "gtest/gtest.h"
 
 namespace {
-using BenchmarkRun = benchmark::BenchmarkReporter::Run;
-
-BenchmarkRun MakeRun(
-    const std::vector<benchmark::internal::Statistics>* statistics,
-    int64_t repetition_index, double real_time, double cpu_time) {
-  BenchmarkRun run;
-  run.run_name.function_name = "BM_Flaky";
-  run.family_index = 1;
-  run.per_family_instance_index = 2;
-  run.iterations = 10;
-  run.repetition_index = repetition_index;
-  run.repetitions = 3;
-  run.time_unit = benchmark::kSecond;
-  run.real_accumulated_time = real_time;
-  run.cpu_accumulated_time = cpu_time;
-  run.statistics = statistics;
-  return run;
-}
-
 TEST(StatisticsTest, Mean) {
   EXPECT_DOUBLE_EQ(benchmark::StatisticsMean({42, 42, 42, 42}), 42.0);
   EXPECT_DOUBLE_EQ(benchmark::StatisticsMean({1, 2, 3, 4}), 2.5);
@@ -49,28 +30,6 @@ TEST(StatisticsTest, CV) {
   EXPECT_DOUBLE_EQ(benchmark::StatisticsCV({1, 2, 3}), 1. / 2.);
   ASSERT_NEAR(benchmark::StatisticsCV({2.5, 2.4, 3.3, 4.2, 5.1}),
               0.32888184094918121, 1e-15);
-}
-
-TEST(StatisticsTest, ComputeStatsSkipsErroredFirstRun) {
-  const std::vector<benchmark::internal::Statistics> statistics = {
-      {"mean", benchmark::StatisticsMean}};
-
-  BenchmarkRun skipped = MakeRun(nullptr, 0, 0.0, 0.0);
-  skipped.skipped = benchmark::internal::SkippedWithError;
-
-  const std::vector<BenchmarkRun> reports = {
-      skipped,
-      MakeRun(&statistics, 1, 20.0, 30.0),
-      MakeRun(&statistics, 2, 40.0, 50.0),
-  };
-
-  const std::vector<BenchmarkRun> results = benchmark::ComputeStats(reports);
-
-  ASSERT_EQ(results.size(), 1u);
-  EXPECT_EQ(results[0].benchmark_name(), "BM_Flaky_mean");
-  EXPECT_EQ(results[0].iterations, 2);
-  EXPECT_DOUBLE_EQ(results[0].GetAdjustedRealTime(), 3.0);
-  EXPECT_DOUBLE_EQ(results[0].GetAdjustedCPUTime(), 4.0);
 }
 
 }  // end namespace

--- a/test/statistics_gtest.cc
+++ b/test/statistics_gtest.cc
@@ -6,6 +6,25 @@
 #include "gtest/gtest.h"
 
 namespace {
+using BenchmarkRun = benchmark::BenchmarkReporter::Run;
+
+BenchmarkRun MakeRun(
+    const std::vector<benchmark::internal::Statistics>* statistics,
+    int64_t repetition_index, double real_time, double cpu_time) {
+  BenchmarkRun run;
+  run.run_name.function_name = "BM_Flaky";
+  run.family_index = 1;
+  run.per_family_instance_index = 2;
+  run.iterations = 10;
+  run.repetition_index = repetition_index;
+  run.repetitions = 3;
+  run.time_unit = benchmark::kSecond;
+  run.real_accumulated_time = real_time;
+  run.cpu_accumulated_time = cpu_time;
+  run.statistics = statistics;
+  return run;
+}
+
 TEST(StatisticsTest, Mean) {
   EXPECT_DOUBLE_EQ(benchmark::StatisticsMean({42, 42, 42, 42}), 42.0);
   EXPECT_DOUBLE_EQ(benchmark::StatisticsMean({1, 2, 3, 4}), 2.5);
@@ -30,6 +49,28 @@ TEST(StatisticsTest, CV) {
   EXPECT_DOUBLE_EQ(benchmark::StatisticsCV({1, 2, 3}), 1. / 2.);
   ASSERT_NEAR(benchmark::StatisticsCV({2.5, 2.4, 3.3, 4.2, 5.1}),
               0.32888184094918121, 1e-15);
+}
+
+TEST(StatisticsTest, ComputeStatsSkipsErroredFirstRun) {
+  const std::vector<benchmark::internal::Statistics> statistics = {
+      {"mean", benchmark::StatisticsMean}};
+
+  BenchmarkRun skipped = MakeRun(nullptr, 0, 0.0, 0.0);
+  skipped.skipped = benchmark::internal::SkippedWithError;
+
+  const std::vector<BenchmarkRun> reports = {
+      skipped,
+      MakeRun(&statistics, 1, 20.0, 30.0),
+      MakeRun(&statistics, 2, 40.0, 50.0),
+  };
+
+  const std::vector<BenchmarkRun> results = benchmark::ComputeStats(reports);
+
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].benchmark_name(), "BM_Flaky_mean");
+  EXPECT_EQ(results[0].iterations, 2);
+  EXPECT_DOUBLE_EQ(results[0].GetAdjustedRealTime(), 3.0);
+  EXPECT_DOUBLE_EQ(results[0].GetAdjustedCPUTime(), 4.0);
 }
 
 }  // end namespace


### PR DESCRIPTION
Fixes #1406.

## Summary
- compute repetition aggregates from non-errored runs only
- use the first successful run as the metadata/statistics reference instead of `reports[0]`
- ignore skipped runs when building aggregate counter inputs and labels
- add a regression test for a skipped first run followed by successful repetitions

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBENCHMARK_ENABLE_TESTING=ON -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON -DCMAKE_CXX_FLAGS="-isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1"
- cmake --build build --target statistics_gtest skip_with_error_test -- -j4
- ctest --test-dir build -R `statistics_gtest|skip_with_error_test` --output-on-failure

Note: the explicit CMAKE_CXX_FLAGS include path is only needed on my local macOS CommandLineTools install because its default C++ header search path does not find SDK libc++ headers.