### PR TITLE
Document static library benchmark registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,16 +220,16 @@ target_link_libraries(MyTarget benchmark::benchmark)
 ```
 
 When benchmark sources are shared through an intermediate CMake target, prefer
-an object library:
+an object library instead of a static library:
 
 ```cmake
-add_library(my_benchmarks OBJECT bench.cc)
-target_link_libraries(my_benchmarks benchmark::benchmark_main)
-add_executable(my_benchmark)
-target_link_libraries(my_benchmark my_benchmarks)
+add_library(shared_benchmarks OBJECT bench.cc)
+target_link_libraries(shared_benchmarks benchmark::benchmark_main)
+add_executable(runnable_benchmarks)
+target_link_libraries(runnable_benchmarks shared_benchmarks)
 ```
 
 This links the object file that contains `BENCHMARK` registrations into the
 final executable. If those registrations are placed only in an intermediate
-static library, the linker may omit the otherwise-unused object file and the
+`STATIC` library, the linker may omit the otherwise-unused object file and the
 benchmarks will not be registered at runtime.

--- a/README.md
+++ b/README.md
@@ -218,3 +218,16 @@ Either way, link to the library as follows.
 ```cmake
 target_link_libraries(MyTarget benchmark::benchmark)
 ```
+
+If benchmark registrations live outside the final executable, make sure the
+benchmark object files are linked into it. The `BENCHMARK` macro registers
+benchmarks through static initialization, and many linkers do not pull
+otherwise-unused object files out of a static library. Prefer an object library
+so CMake links the registration objects directly:
+
+```cmake
+add_library(my_benchmarks OBJECT bench.cc)
+target_link_libraries(my_benchmarks benchmark::benchmark_main)
+add_executable(my_benchmark)
+target_link_libraries(my_benchmark my_benchmarks)
+```

--- a/README.md
+++ b/README.md
@@ -219,11 +219,8 @@ Either way, link to the library as follows.
 target_link_libraries(MyTarget benchmark::benchmark)
 ```
 
-If benchmark registrations live outside the final executable, make sure the
-benchmark object files are linked into it. The `BENCHMARK` macro registers
-benchmarks through static initialization, and many linkers do not pull
-otherwise-unused object files out of a static library. Prefer an object library
-so CMake links the registration objects directly:
+When benchmark sources are shared through an intermediate CMake target, prefer
+an object library:
 
 ```cmake
 add_library(my_benchmarks OBJECT bench.cc)
@@ -231,3 +228,8 @@ target_link_libraries(my_benchmarks benchmark::benchmark_main)
 add_executable(my_benchmark)
 target_link_libraries(my_benchmark my_benchmarks)
 ```
+
+This links the object file that contains `BENCHMARK` registrations into the
+final executable. If those registrations are placed only in an intermediate
+static library, the linker may omit the otherwise-unused object file and the
+benchmarks will not be registered at runtime.

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Either way, link to the library as follows.
 target_link_libraries(MyTarget benchmark::benchmark)
 ```
 
-When benchmark sources are shared through an intermediate CMake target, prefer
+When benchmark sources are shared through an intermediate CMake target, choose
 an object library instead of a static library:
 
 ```cmake
@@ -231,5 +231,5 @@ target_link_libraries(runnable_benchmarks shared_benchmarks)
 
 This links the object file that contains `BENCHMARK` registrations into the
 final executable. If those registrations are placed only in an intermediate
-`STATIC` library, the linker may omit the otherwise-unused object file and the
-benchmarks will not be registered at runtime.
+`STATIC` library, the linker may not copy static registration symbols, and thus
+benchmarks will not be part of the final executable.


### PR DESCRIPTION
Addresses #1498.

## Summary
- document why benchmarks registered from a separate static library may not appear at runtime
- explain that BENCHMARK uses static initialization and otherwise-unused object files may not be linked
- show an OBJECT library CMake pattern that forces benchmark registration objects into the final executable

## Validation
- git diff --check -- README.md

This is a documentation-only change.