### PR TITLE
Clarify DoNotOptimize const-ref warning

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1462,10 +1462,10 @@ known. For example:
   // while (...) DoNotOptimize(__result__);
 ```
 
-Since that is not the behavior the user intended, such problematic cases
-produce a compile-time diagnostic. Pass a non-const lvalue instead. For an
-expression result, store the result in a local variable before calling
-`DoNotOptimize`:
+Since that is not the behaviour the user intended,
+such problematic cases will result in a diagnostic
+at compile time. The correct approach, for an expression result,
+is to use an intermediate local variable:
 
 ```c++
   // Avoid: may call the deprecated const-reference overload.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1462,12 +1462,12 @@ known. For example:
   // while (...) DoNotOptimize(__result__);
 ```
 
-Passing a temporary or `const` value may call the deprecated const-reference
-overload. Store the value in a local non-const variable and pass that lvalue to
-make the result observable:
+If `DoNotOptimize` warns about the deprecated const-reference overload, pass it
+a non-const lvalue instead. For an expression result, store the result in a
+local variable before calling `DoNotOptimize`:
 
 ```c++
-  // Avoid: calls the deprecated const-reference overload for the temporary.
+  // Avoid: may call the deprecated const-reference overload.
   while (...) DoNotOptimize(foo(0));
 
   // Prefer: materialize the result, then pass the local lvalue.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1462,9 +1462,10 @@ known. For example:
   // while (...) DoNotOptimize(__result__);
 ```
 
-If `DoNotOptimize` warns about the deprecated const-reference overload, pass it
-a non-const lvalue instead. For an expression result, store the result in a
-local variable before calling `DoNotOptimize`:
+Since that is not the behavior the user intended, such problematic cases
+produce a compile-time diagnostic. Pass a non-const lvalue instead. For an
+expression result, store the result in a local variable before calling
+`DoNotOptimize`:
 
 ```c++
   // Avoid: may call the deprecated const-reference overload.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1462,6 +1462,21 @@ known. For example:
   // while (...) DoNotOptimize(__result__);
 ```
 
+Passing a temporary or `const` value may call the deprecated const-reference
+overload. Store the value in a local non-const variable and pass that lvalue to
+make the result observable:
+
+```c++
+  // Avoid: calls the deprecated const-reference overload for the temporary.
+  while (...) DoNotOptimize(foo(0));
+
+  // Prefer: materialize the result, then pass the local lvalue.
+  while (...) {
+    auto result = foo(0);
+    DoNotOptimize(result);
+  }
+```
+
 The second tool for preventing optimizations is `ClobberMemory()`. In essence
 `ClobberMemory()` forces the compiler to perform all pending writes to global
 memory. Memory managed by block scope objects must be "escaped" using

--- a/include/benchmark/utils.h
+++ b/include/benchmark/utils.h
@@ -37,12 +37,15 @@ inline BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
   std::atomic_signal_fence(std::memory_order_acq_rel);
 }
 
+#define BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG                     \
+  "DoNotOptimize(T const&) can permit undesired compiler optimizations. "    \
+  "Store the expression result in a local non-const variable and pass that " \
+  "lvalue instead."
+
 #ifndef BENCHMARK_HAS_NO_INLINE_ASSEMBLY
 #if !defined(__GNUC__) || defined(__llvm__) || defined(__INTEL_COMPILER)
 template <class Tp>
-BENCHMARK_DEPRECATED_MSG(
-    "The const-ref version of this method can permit "
-    "undesired compiler optimizations in benchmarks")
+BENCHMARK_DEPRECATED_MSG(BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG)
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   asm volatile("" : : "r,m"(value) : "memory");
 }
@@ -66,9 +69,7 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp&& value) {
 }
 #elif (__GNUC__ >= 5)
 template <class Tp>
-BENCHMARK_DEPRECATED_MSG(
-    "The const-ref version of this method can permit "
-    "undesired compiler optimizations in benchmarks")
+BENCHMARK_DEPRECATED_MSG(BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG)
 inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<std::is_trivially_copyable<Tp>::value &&
                             (sizeof(Tp) <= sizeof(Tp*))>::type
@@ -77,9 +78,7 @@ inline BENCHMARK_ALWAYS_INLINE
 }
 
 template <class Tp>
-BENCHMARK_DEPRECATED_MSG(
-    "The const-ref version of this method can permit "
-    "undesired compiler optimizations in benchmarks")
+BENCHMARK_DEPRECATED_MSG(BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG)
 inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<!std::is_trivially_copyable<Tp>::value ||
                             (sizeof(Tp) > sizeof(Tp*))>::type
@@ -122,9 +121,7 @@ inline BENCHMARK_ALWAYS_INLINE
 
 #elif defined(_MSC_VER)
 template <class Tp>
-BENCHMARK_DEPRECATED_MSG(
-    "The const-ref version of this method can permit "
-    "undesired compiler optimizations in benchmarks")
+BENCHMARK_DEPRECATED_MSG(BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG)
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
   ClobberMemory();
@@ -147,6 +144,8 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp&& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
 }
 #endif
+
+#undef BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG
 
 }  // end namespace benchmark
 

--- a/include/benchmark/utils.h
+++ b/include/benchmark/utils.h
@@ -37,8 +37,8 @@ inline BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
   std::atomic_signal_fence(std::memory_order_acq_rel);
 }
 
-#define BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG                     \
-  "DoNotOptimize(T const&) can permit undesired compiler optimizations. "    \
+#define BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG                       \
+  "DoNotOptimize(T const&) can permit undesired compiler optimizations. "      \
   "Pass a non-const lvalue instead; if the argument is an expression result, " \
   "store it in a local variable first."
 

--- a/include/benchmark/utils.h
+++ b/include/benchmark/utils.h
@@ -39,8 +39,8 @@ inline BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
 
 #define BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG                     \
   "DoNotOptimize(T const&) can permit undesired compiler optimizations. "    \
-  "Store the expression result in a local non-const variable and pass that " \
-  "lvalue instead."
+  "Pass a non-const lvalue instead; if the argument is an expression result, " \
+  "store it in a local variable first."
 
 #ifndef BENCHMARK_HAS_NO_INLINE_ASSEMBLY
 #if !defined(__GNUC__) || defined(__llvm__) || defined(__INTEL_COMPILER)


### PR DESCRIPTION
## Summary
- make the deprecated `DoNotOptimize(T const&)` diagnostic tell users what to do next
- point users to storing expression results in a local non-const variable and passing that lvalue
- add the same before/after guidance to the user guide

Fixes #1580.

## Testing
- `cmake --build build --target donotoptimize_test`
- `./build/test/donotoptimize_test`
- `cmake --build build --target benchmark_gtest`
- `./build/test/benchmark_gtest`
- `git diff --check`
- compiled a local snippet with `-Wdeprecated-declarations` to verify the new warning text

`bazel test //test:donotoptimize_test` could not run in this local environment because the Bazel C++ toolchain cannot find the standard library header `<cmath>` while compiling `src/check.cc`.