### PR TITLE
Fix ComputeStats crash when first repetition is skipped

### DIFF
--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -105,6 +105,10 @@ BenchmarkReporter::Run CreateRunReport(
   report.repetition_index = repetition_index;
   report.repetitions = repeats;
 
+  // Set `statistics` for every report, skipped or not, so the pointer is
+  // always valid in aggregation paths.
+  report.statistics = &b.statistics();
+
   if (report.skipped == 0u) {
     if (b.use_manual_time()) {
       report.real_accumulated_time = results.manual_time_used;
@@ -116,7 +120,6 @@ BenchmarkReporter::Run CreateRunReport(
     report.complexity_n = results.complexity_n;
     report.complexity = b.complexity();
     report.complexity_lambda = b.complexity_lambda();
-    report.statistics = &b.statistics();
     report.counters = results.counters;
 
     if (memory_iterations > 0) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -143,6 +143,9 @@ benchmark_add_test(NAME diagnostics_test COMMAND diagnostics_test --benchmark_mi
 compile_benchmark_test(skip_with_error_test)
 benchmark_add_test(NAME skip_with_error_test COMMAND skip_with_error_test --benchmark_min_time=0.01s)
 
+compile_benchmark_test(skipped_repetition_test)
+benchmark_add_test(NAME skipped_repetition_test COMMAND skipped_repetition_test --benchmark_min_time=0.01s --benchmark_repetitions=3)
+
 compile_benchmark_test(donotoptimize_test)
 # Enable errors for deprecated deprecations (DoNotOptimize(Tp const& value)).
 check_cxx_compiler_flag(-Werror=deprecated-declarations BENCHMARK_HAS_DEPRECATED_DECLARATIONS_FLAG)

--- a/test/skipped_repetition_test.cc
+++ b/test/skipped_repetition_test.cc
@@ -1,0 +1,79 @@
+
+#undef NDEBUG
+#include <cassert>
+#include <vector>
+
+#include "../src/check.h"  // NOTE: check.h is for internal use only!
+#include "benchmark/benchmark_api.h"
+#include "benchmark/registration.h"
+#include "benchmark/reporter.h"
+#include "benchmark/state.h"
+#include "benchmark/utils.h"
+
+namespace {
+
+class TestReporter : public benchmark::ConsoleReporter {
+ public:
+  bool ReportContext(const Context& context) override {
+    return ConsoleReporter::ReportContext(context);
+  };
+
+  void ReportRuns(const std::vector<Run>& report) override {
+    all_runs_.insert(all_runs_.end(), begin(report), end(report));
+    ConsoleReporter::ReportRuns(report);
+  }
+
+  TestReporter() {}
+  ~TestReporter() override {}
+
+  mutable std::vector<Run> all_runs_;
+};
+
+// Regression test for a crash in ComputeStats() when aggregating across
+// repetitions where the first repetition is skipped.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+int invocation_count = 0;
+
+void BM_skip_first_rep(benchmark::State& state) {
+  if (invocation_count++ == 0) {
+    state.SkipWithError("first repetition skipped");
+    return;
+  }
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(invocation_count);
+  }
+}
+BENCHMARK(BM_skip_first_rep)->Repetitions(3);
+
+}  // end namespace
+
+int main(int argc, char* argv[]) {
+  benchmark::MaybeReenterWithoutASLR(argc, argv);
+  benchmark::Initialize(&argc, argv);
+
+  TestReporter test_reporter;
+  benchmark::RunSpecifiedBenchmarks(&test_reporter);
+
+  typedef benchmark::BenchmarkReporter::Run Run;
+
+  int iteration_runs = 0;
+  int skipped_iteration_runs = 0;
+  int aggregate_runs = 0;
+  for (Run const& run : test_reporter.all_runs_) {
+    if (run.run_type == Run::RT_Aggregate) {
+      ++aggregate_runs;
+    } else {
+      ++iteration_runs;
+      if (run.skipped == benchmark::internal::SkippedWithError) {
+        ++skipped_iteration_runs;
+      }
+    }
+  }
+
+  BM_CHECK(iteration_runs == 3);
+  BM_CHECK(skipped_iteration_runs == 1);
+  // Default statistics: mean, median, stddev, cv.
+  BM_CHECK(aggregate_runs == 4);
+
+  return 0;
+}


### PR DESCRIPTION
Fixes #2206

When  --benchmark_repetitions > 1  and the first repetition is skipped (via  SkipWithError / SkipWithMessage ), ComputeStats()  crashes due to:

1. Dereferencing null  reports[0].statistics  (only set for non-skipped runs).                                                                                                   
2. Expecting  reports.front().iterations  to match every non-skipped run's iteration count.

Fixed by:

- Picking the first non-skipped report as the baseline for  run_iterations ,  report_label , and statistics.
- Ensuring  report.statistics  is always initialized in  CreateRunReport() , even for skipped runs.                                                                              
- Skipping skipped runs in aggregation and consistency loops.                                                                                                                    

Also adds a regression test reproducing the crash.


AI-Assisted-by: Gemini (Google DeepMind Antigravity)
