### PR TITLE
Clarify DoNotOptimize const-ref diagnostics

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1462,6 +1462,21 @@ known. For example:
   // while (...) DoNotOptimize(__result__);
 ```
 
+When `DoNotOptimize` diagnoses one of these cases, pass a non-const lvalue
+instead. For an expression result, store the result in a local variable before
+calling `DoNotOptimize`:
+
+```c++
+  // Avoid: may trigger the const-reference diagnostic.
+  while (...) DoNotOptimize(foo(0));
+
+  // Prefer: materialize the result, then pass the local lvalue.
+  while (...) {
+    auto result = foo(0);
+    DoNotOptimize(result);
+  }
+```
+
 The second tool for preventing optimizations is `ClobberMemory()`. In essence
 `ClobberMemory()` forces the compiler to perform all pending writes to global
 memory. Memory managed by block scope objects must be "escaped" using

--- a/include/benchmark/utils.h
+++ b/include/benchmark/utils.h
@@ -37,12 +37,15 @@ inline BENCHMARK_ALWAYS_INLINE void ClobberMemory() {
   std::atomic_signal_fence(std::memory_order_acq_rel);
 }
 
+#define BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG                     \
+  "DoNotOptimize(T const&) can permit undesired compiler optimizations. "    \
+  "Pass a non-const lvalue instead; if the argument is an expression result, " \
+  "store it in a local variable first."
+
 #ifndef BENCHMARK_HAS_NO_INLINE_ASSEMBLY
 #if !defined(__GNUC__) || defined(__llvm__) || defined(__INTEL_COMPILER)
 template <class Tp>
-BENCHMARK_DEPRECATED_MSG(
-    "The const-ref version of this method can permit "
-    "undesired compiler optimizations in benchmarks")
+BENCHMARK_DEPRECATED_MSG(BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG)
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   asm volatile("" : : "r,m"(value) : "memory");
 }
@@ -66,9 +69,7 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp&& value) {
 }
 #elif (__GNUC__ >= 5)
 template <class Tp>
-BENCHMARK_DEPRECATED_MSG(
-    "The const-ref version of this method can permit "
-    "undesired compiler optimizations in benchmarks")
+BENCHMARK_DEPRECATED_MSG(BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG)
 inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<std::is_trivially_copyable<Tp>::value &&
                             (sizeof(Tp) <= sizeof(Tp*))>::type
@@ -77,9 +78,7 @@ inline BENCHMARK_ALWAYS_INLINE
 }
 
 template <class Tp>
-BENCHMARK_DEPRECATED_MSG(
-    "The const-ref version of this method can permit "
-    "undesired compiler optimizations in benchmarks")
+BENCHMARK_DEPRECATED_MSG(BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG)
 inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<!std::is_trivially_copyable<Tp>::value ||
                             (sizeof(Tp) > sizeof(Tp*))>::type
@@ -122,9 +121,7 @@ inline BENCHMARK_ALWAYS_INLINE
 
 #elif defined(_MSC_VER)
 template <class Tp>
-BENCHMARK_DEPRECATED_MSG(
-    "The const-ref version of this method can permit "
-    "undesired compiler optimizations in benchmarks")
+BENCHMARK_DEPRECATED_MSG(BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG)
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
   ClobberMemory();
@@ -147,6 +144,8 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp&& value) {
   internal::UseCharPointer(&reinterpret_cast<char const volatile&>(value));
 }
 #endif
+
+#undef BENCHMARK_DONOTOPTIMIZE_CONST_REF_DEPRECATED_MSG
 
 }  // end namespace benchmark
 


### PR DESCRIPTION
Summary:
- make the deprecated const-reference DoNotOptimize diagnostic point to the actionable workaround
- add the same expression-result guidance to the user guide

Context: #1675 called out that the current failure mode can be hard to act on. This does not change DoNotOptimize semantics; it just makes the intended usage clearer.

Test:
- cmake --build build --target donotoptimize_test
- ctest --test-dir build -R '^donotoptimize_test$' --output-on-failure
- git diff --check
