### PR TITLE
Clarify CPU frequency stability guidance

### DIFF
--- a/docs/reducing_variance.md
+++ b/docs/reducing_variance.md
@@ -35,7 +35,12 @@ by running this command:
 cpupower frequency-info -o proc
 ```
 
-The benchmarks you subsequently run will have less variance.
+The benchmarks you subsequently run will usually have less variance. Do not
+assume that the governor setting is the only frequency control that matters:
+boost settings, SMT/Hyperthreading, firmware, and kernel behavior can still
+change the observed CPU frequency. For sensitive measurements, monitor the
+actual per-CPU frequency during the benchmark run and keep the configuration
+that is stable on that machine.
 
 <a name="reducing-variance" />
 

--- a/docs/reducing_variance.md
+++ b/docs/reducing_variance.md
@@ -35,12 +35,8 @@ by running this command:
 cpupower frequency-info -o proc
 ```
 
-Do not assume that the governor setting is the only frequency control that
-matters:
-boost settings, SMT/Hyperthreading, firmware, and kernel behavior can still
-change the observed CPU frequency. For sensitive measurements, monitor the
-actual per-CPU frequency during the benchmark run and keep the configuration
-that is stable on that machine.
+For other CPU-frequency and system-noise sources that can still affect
+measurements, see the reducing variance section below.
 
 <a name="reducing-variance" />
 

--- a/docs/reducing_variance.md
+++ b/docs/reducing_variance.md
@@ -35,8 +35,8 @@ by running this command:
 cpupower frequency-info -o proc
 ```
 
-The benchmarks you subsequently run will usually have less variance. Do not
-assume that the governor setting is the only frequency control that matters:
+Do not assume that the governor setting is the only frequency control that
+matters:
 boost settings, SMT/Hyperthreading, firmware, and kernel behavior can still
 change the observed CPU frequency. For sensitive measurements, monitor the
 actual per-CPU frequency during the benchmark run and keep the configuration


### PR DESCRIPTION
Summary:
- soften the CPU governor guidance from a guarantee to a usual variance reduction
- call out that boost, SMT/Hyperthreading, firmware, and kernel behavior can still affect observed frequency
- suggest monitoring per-CPU frequency during sensitive benchmark runs

Fixes #1686.

Test:
- git diff --check
