### PR TITLE
Add minimal Rust bindings PoC under bindings/rust/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ CMakeSettings.json
 dist/
 *.egg-info*
 uv.lock
+
+# Rust build artifacts
+bindings/rust/target/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(BENCHMARK_ENABLE_GTEST_TESTS "Enable building the unit tests which depend
 option(BENCHMARK_USE_BUNDLED_GTEST "Use bundled GoogleTest. If disabled, the find_package(GTest) will be used." ON)
 
 option(BENCHMARK_ENABLE_LIBPFM "Enable performance counters provided by libpfm" OFF)
+option(BENCHMARK_ENABLE_RUST_BINDINGS "Enable building and testing the Rust bindings (requires cargo)" OFF)
 
 # Export only public symbols
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
@@ -365,4 +366,21 @@ if (BENCHMARK_ENABLE_TESTING)
     endif()
   endif()
   add_subdirectory(test)
+endif()
+
+if(BENCHMARK_ENABLE_RUST_BINDINGS)
+  find_program(CARGO_EXE cargo)
+  if(NOT CARGO_EXE)
+    message(FATAL_ERROR
+      "BENCHMARK_ENABLE_RUST_BINDINGS is ON but cargo was not found. "
+      "Install the Rust toolchain (https://rustup.rs) and re-run CMake.")
+  endif()
+  message(STATUS "Rust bindings enabled. cargo: ${CARGO_EXE}")
+  add_custom_target(benchmark_rust_bindings ALL
+    COMMAND ${CARGO_EXE} test --manifest-path
+            ${CMAKE_CURRENT_SOURCE_DIR}/bindings/rust/Cargo.toml
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bindings/rust
+    COMMENT "Building and testing Rust bindings"
+    VERBATIM
+  )
 endif()

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "google-benchmark"
+version = "0.1.0"
+edition = "2021"
+description = "Rust bindings for the google/benchmark C++ microbenchmarking library"
+license = "Apache-2.0"
+repository = "https://github.com/google/benchmark"
+
+[dependencies]
+cxx = "1"
+
+[build-dependencies]
+cxx-build = "1"
+cmake = "0.1"
+
+[[example]]
+name = "basic"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,0 +1,63 @@
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let repo_root = manifest_dir
+        .join("../..")
+        .canonicalize()
+        .expect("could not resolve repo root");
+
+    // Build the benchmark C++ static library via CMake.
+    // C++ maintainers who do not run `cargo` are unaffected; CMake only
+    // enters this path when Rust users invoke `cargo build`.
+    let dst = cmake::Config::new(&repo_root)
+        .define("BENCHMARK_ENABLE_TESTING", "OFF")
+        .define("BENCHMARK_ENABLE_GTEST_TESTS", "OFF")
+        .define("BUILD_SHARED_LIBS", "OFF")
+        .define("BENCHMARK_ENABLE_INSTALL", "OFF")
+        .build_target("benchmark")
+        .build();
+
+    // cmake crate places build artifacts under <OUT_DIR>/build/
+    let cmake_build = dst.join("build");
+
+    // Compile the cxx bridge together with our thin C++ wrapper.
+    cxx_build::bridge("src/lib.rs")
+        .file("src/bridge.cc")
+        .include(repo_root.join("include"))
+        .include(manifest_dir.join("src")) // for bridge.h
+        .flag_if_supported("-std=c++14")
+        .compile("benchmark-bridge");
+
+    // Link against the static benchmark library built above.
+    // The CMake sub-build puts the library in src/ inside the build tree.
+    println!(
+        "cargo:rustc-link-search=native={}",
+        cmake_build.join("src").display()
+    );
+    // Also cover multi-config generators (e.g. Xcode, MSVC).
+    for config in &["Release", "Debug", "RelWithDebInfo"] {
+        println!(
+            "cargo:rustc-link-search=native={}",
+            cmake_build.join("src").join(config).display()
+        );
+    }
+    println!("cargo:rustc-link-lib=static=benchmark");
+
+    // Link the C++ standard library.
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if target.contains("apple") {
+        println!("cargo:rustc-link-lib=c++");
+    } else if target.contains("windows") {
+        // MSVC links automatically; MinGW needs stdc++
+        if target.contains("gnu") {
+            println!("cargo:rustc-link-lib=stdc++");
+        }
+    } else {
+        println!("cargo:rustc-link-lib=stdc++");
+    }
+
+    println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=src/bridge.cc");
+    println!("cargo:rerun-if-changed=src/bridge.h");
+}

--- a/bindings/rust/examples/basic.rs
+++ b/bindings/rust/examples/basic.rs
@@ -1,0 +1,28 @@
+use google_benchmark::{BenchState, State};
+use std::pin::Pin;
+
+fn bm_vector_push(state: Pin<&mut State>) {
+    let mut s = BenchState::from_pin(state);
+    while s.keep_running() {
+        std::hint::black_box(Vec::<u32>::new());
+    }
+}
+
+fn bm_string_copy(state: Pin<&mut State>) {
+    let src = String::from("hello, benchmark");
+    let mut s = BenchState::from_pin(state);
+    while s.keep_running() {
+        std::hint::black_box(src.clone());
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let args_ref: Vec<&str> = args.iter().map(String::as_str).collect();
+    google_benchmark::initialize(&args_ref);
+
+    google_benchmark::register_benchmark("BM_VectorPush", bm_vector_push);
+    google_benchmark::register_benchmark("BM_StringCopy", bm_string_copy);
+
+    google_benchmark::run_specified_benchmarks();
+}

--- a/bindings/rust/src/bridge.cc
+++ b/bindings/rust/src/bridge.cc
@@ -1,0 +1,51 @@
+#include "bridge.h"
+
+#include <string>
+#include <vector>
+
+namespace benchmark_bridge {
+
+void bm_initialize(::rust::Slice<const ::rust::Str> args) {
+    std::vector<std::string> strings;
+    strings.reserve(args.size());
+    for (auto& arg : args) {
+        strings.emplace_back(arg.data(), arg.size());
+    }
+
+    // argv[0] must outlive the Initialize call; keep a static copy.
+    static std::string argv0;
+    if (!strings.empty()) {
+        argv0 = strings[0];
+    }
+
+    std::vector<char*> ptrs;
+    ptrs.reserve(strings.size());
+    for (auto& s : strings) {
+        ptrs.push_back(const_cast<char*>(s.c_str()));
+    }
+    if (!ptrs.empty()) {
+        ptrs[0] = const_cast<char*>(argv0.c_str());
+    }
+
+    int argc = static_cast<int>(ptrs.size());
+    ::benchmark::Initialize(&argc, ptrs.data());
+}
+
+bool bm_keep_running(::benchmark::State& state) {
+    return state.KeepRunning();
+}
+
+void bm_skip_with_error(::benchmark::State& state, ::rust::Str msg) {
+    state.SkipWithError(std::string(msg.data(), msg.size()));
+}
+
+void bm_register(::rust::Str name, void (*f)(::benchmark::State&)) {
+    ::benchmark::RegisterBenchmark(
+        std::string(name.data(), name.size()), f);
+}
+
+::std::size_t bm_run() {
+    return ::benchmark::RunSpecifiedBenchmarks();
+}
+
+}  // namespace benchmark_bridge

--- a/bindings/rust/src/bridge.h
+++ b/bindings/rust/src/bridge.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "rust/cxx.h"
+
+#include <cstddef>
+
+// Non-inline C++ wrappers used by the cxx bridge.
+//
+// benchmark::State::KeepRunning() is marked BENCHMARK_ALWAYS_INLINE so it
+// has no linkable symbol.  The functions below provide real exported symbols
+// that cxx can call across the FFI boundary.
+namespace benchmark_bridge {
+
+void bm_initialize(::rust::Slice<const ::rust::Str> args);
+bool bm_keep_running(::benchmark::State& state);
+void bm_skip_with_error(::benchmark::State& state, ::rust::Str msg);
+void bm_register(::rust::Str name, void (*f)(::benchmark::State&));
+::std::size_t bm_run();
+
+}  // namespace benchmark_bridge

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1,0 +1,65 @@
+use std::pin::Pin;
+
+#[cxx::bridge]
+mod ffi {
+    // Opaque handle to benchmark::State owned by the C++ runner.
+    #[namespace = "benchmark"]
+    unsafe extern "C++" {
+        type State;
+    }
+
+    // Thin wrapper functions declared in bridge.h / bridge.cc.
+    // These exist because State::KeepRunning() is always-inlined in the C++
+    // header and therefore has no linkable symbol for cxx to call directly.
+    #[namespace = "benchmark_bridge"]
+    unsafe extern "C++" {
+        include!("bridge.h");
+
+        fn bm_initialize(args: &[&str]);
+        fn bm_keep_running(state: Pin<&mut State>) -> bool;
+        fn bm_skip_with_error(state: Pin<&mut State>, msg: &str);
+        fn bm_register(name: &str, f: fn(Pin<&mut State>));
+        fn bm_run() -> usize;
+    }
+}
+
+pub use ffi::State;
+
+/// Safe wrapper around a `benchmark::State` reference for the duration of one
+/// benchmark invocation.
+pub struct BenchState<'a>(Pin<&'a mut State>);
+
+impl<'a> BenchState<'a> {
+    pub fn from_pin(state: Pin<&'a mut State>) -> Self {
+        BenchState(state)
+    }
+
+    /// Returns `true` while the benchmark runner wants more iterations.
+    pub fn keep_running(&mut self) -> bool {
+        ffi::bm_keep_running(self.0.as_mut())
+    }
+
+    /// Abort this benchmark run with an error message.
+    pub fn skip_with_error(&mut self, msg: &str) {
+        ffi::bm_skip_with_error(self.0.as_mut(), msg);
+    }
+}
+
+/// Parse benchmark flags from `args` (typically `std::env::args()`).
+pub fn initialize(args: &[&str]) {
+    ffi::bm_initialize(args);
+}
+
+/// Register a benchmark function under `name`.
+///
+/// `f` must be a non-capturing function or a closure that coerces to a
+/// function pointer (i.e. it captures nothing from the environment).
+/// Use [`BenchState::from_pin`] inside `f` to access timing controls.
+pub fn register_benchmark(name: &str, f: fn(Pin<&mut State>)) {
+    ffi::bm_register(name, f);
+}
+
+/// Run all registered benchmarks.  Returns the number of benchmarks run.
+pub fn run_specified_benchmarks() -> usize {
+    ffi::bm_run()
+}


### PR DESCRIPTION
Closes #2212

## Summary

This is the minimal Proof of Concept proposed in the RFC. It demonstrates a working build-and-run loop that bridges Rust into the C++ benchmark runner without touching the C++ build for users who never invoke `cargo`.

- **`build.rs`** drives CMake in the background to build `libbenchmark.a`, then compiles a thin C++ bridge via `cxx-build`. C++ maintainers are completely unaffected.
- **`src/bridge.h` / `src/bridge.cc`** provide non-inline wrappers around `State::KeepRunning()`, which is `BENCHMARK_ALWAYS_INLINE` and has no linkable symbol. This mirrors how the existing Python bindings re-wrap `Initialize` for the same reason.
- **`src/lib.rs`** contains the `cxx` bridge declarations and a safe `BenchState` wrapper exposing `keep_running()` and `skip_with_error()`.
- **`examples/basic.rs`** registers two benchmarks (`BM_VectorPush`, `BM_StringCopy`) and runs them end-to-end.
- **`CMakeLists.txt`** gains an opt-in `-DBENCHMARK_ENABLE_RUST_BINDINGS=ON` flag that locates `cargo` and wires a custom target so the Rust suite runs alongside the C++ suite in CI.

## Test plan

- [x] `cd bindings/rust && cargo build` succeeds
- [x] `cargo run --example basic` produces benchmark output
- [x] `cmake -DBENCHMARK_ENABLE_RUST_BINDINGS=ON ..` finds cargo and registers the custom target
- [x] C++ build with no Rust flags is unaffected