### PR TITLE
Handle missing locale in test on more platforms

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@
 
 Albert Pretorius <pretoalb@gmail.com>
 Alex Steele <steeleal123@gmail.com>
+Alyssa Ross <hi@alyssa.is>
 Andriy Berestovskyy <berestovskyy@gmail.com>
 Arne Beer <arne@twobeer.de>
 Benjamin King <kingbenja5@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,6 +25,7 @@
 Abhina Sreeskantharajan <abhina.sreeskantharajan@ibm.com>
 Albert Pretorius <pretoalb@gmail.com>
 Alex Steele <steelal123@gmail.com>
+Alyssa Ross <hi@alyssa.is>
 Andriy Berestovskyy <berestovskyy@gmail.com>
 Arne Beer <arne@twobeer.de>
 Bátor Tallér <bator.taller@shapr3d.com>

--- a/test/locale_impermeability_test.cc
+++ b/test/locale_impermeability_test.cc
@@ -10,9 +10,10 @@
 
 namespace {
 void BM_ostream(benchmark::State& state) {
-#if !defined(__MINGW64__) || defined(__clang__)
-  // GCC-based versions of MINGW64 do not support locale manipulations,
-  // don't run the test under them.
+#if !defined(__GLIBCXX__) || defined(__GLIBC__) || defined(__DragonFly__)
+  // libstdc++ only supports locale manipulations on GNU and
+  // DragonflyBSD platforms at the time of writing, don't run the test
+  // on other platforms when using libstdc++.
   std::locale::global(std::locale("en_US.UTF-8"));
 #endif
   while (state.KeepRunning()) {


### PR DESCRIPTION
My musl installation has no en_US.UTF-8 locale.  Rather than trying to hardcode a complete list of platforms where this might happen, just accept the situation where we don't have that locale available to test with, with the same behavior as the test had before on GCC MINGW64.