### PR TITLE
Fix up windows tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         msvc:
-          - VS-17-2025
+          - VS-18-2025
           - VS-17-2022
         build_type:
           - Debug
@@ -69,9 +69,9 @@ jobs:
           - shared
           - static
         include:
-          - msvc: VS-17-2025
+          - msvc: VS-18-2025
             os: windows-2025
-            generator: 'Visual Studio 17 2022'
+            generator: 'Visual Studio 18 2026'
           - msvc: VS-17-2022
             os: windows-2022
             generator: 'Visual Studio 17 2022'

--- a/test/BUILD
+++ b/test/BUILD
@@ -36,11 +36,13 @@ PER_SRC_COPTS = {
 TEST_ARGS = ["--benchmark_min_time=0.01s"]
 
 PER_SRC_TEST_ARGS = {
-    "user_counters_tabular_test.cc": ["--benchmark_counters_tabular=true"],
+    "user_counters_tabular_test.cc": ["--benchmark_counters_tabular=true", "--benchmark_min_time=0.2s"],
     "repetitions_test.cc": [" --benchmark_repetitions=3"],
     "spec_arg_test.cc": ["--benchmark_filter=BM_NotChosen"],
     "spec_arg_verbosity_test.cc": ["--v=42"],
     "complexity_test.cc": ["--benchmark_min_time=1000000x"],
+    "user_counters_test.cc": ["--benchmark_min_time=0.2s"],
+    "user_counters_threads_test.cc": ["--benchmark_min_time=0.2s"],
 }
 
 cc_library(

--- a/test/BUILD
+++ b/test/BUILD
@@ -36,7 +36,10 @@ PER_SRC_COPTS = {
 TEST_ARGS = ["--benchmark_min_time=0.01s"]
 
 PER_SRC_TEST_ARGS = {
-    "user_counters_tabular_test.cc": ["--benchmark_counters_tabular=true", "--benchmark_min_time=0.2s"],
+    "user_counters_tabular_test.cc": [
+        "--benchmark_counters_tabular=true",
+        "--benchmark_min_time=0.2s",
+    ],
     "repetitions_test.cc": [" --benchmark_repetitions=3"],
     "spec_arg_test.cc": ["--benchmark_filter=BM_NotChosen"],
     "spec_arg_verbosity_test.cc": ["--v=42"],


### PR DESCRIPTION
It seems VS 2022 (17) has been removed from the 2025 image in favour of VS 2026 (18).
Also, while we previously updated cmake to pass in a more generous minimum time for user counter tests, we failed to do the same for bazel.

Hopefully fixes https://github.com/google/benchmark/issues/2027