### PR TITLE
Fix DoNotOptimize compilation error with partially const structs (Fixes #1997)

### DIFF
--- a/include/benchmark/utils.h
+++ b/include/benchmark/utils.h
@@ -53,18 +53,18 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
 #if defined(__clang__)
-  asm volatile("" : "+r,m"(value) : : "memory");
+  asm volatile("" : "+r,m"(reinterpret_cast<char(&)[sizeof(Tp)]>(value)) : : "memory");
 #else
-  asm volatile("" : "+m,r"(value) : : "memory");
+  asm volatile("" : "+m,r"(reinterpret_cast<char(&)[sizeof(Tp)]>(value)) : : "memory");
 #endif
 }
 
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp&& value) {
 #if defined(__clang__)
-  asm volatile("" : "+r,m"(value) : : "memory");
+  asm volatile("" : "+r,m"(reinterpret_cast<char(&)[sizeof(Tp)]>(value)) : : "memory");
 #else
-  asm volatile("" : "+m,r"(value) : : "memory");
+  asm volatile("" : "+m,r"(reinterpret_cast<char(&)[sizeof(Tp)]>(value)) : : "memory");
 #endif
 }
 #elif (__GNUC__ >= 5)
@@ -91,7 +91,7 @@ inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<std::is_trivially_copyable<Tp>::value &&
                             (sizeof(Tp) <= sizeof(Tp*))>::type
     DoNotOptimize(Tp& value) {
-  asm volatile("" : "+m,r"(value) : : "memory");
+  asm volatile("" : "+m,r"(reinterpret_cast<char(&)[sizeof(Tp)]>(value)) : : "memory");
 }
 
 template <class Tp>
@@ -99,7 +99,7 @@ inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<!std::is_trivially_copyable<Tp>::value ||
                             (sizeof(Tp) > sizeof(Tp*))>::type
     DoNotOptimize(Tp& value) {
-  asm volatile("" : "+m"(value) : : "memory");
+  asm volatile("" : "+m"(reinterpret_cast<char(&)[sizeof(Tp)]>(value)) : : "memory");
 }
 
 template <class Tp>
@@ -107,7 +107,7 @@ inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<std::is_trivially_copyable<Tp>::value &&
                             (sizeof(Tp) <= sizeof(Tp*))>::type
     DoNotOptimize(Tp&& value) {
-  asm volatile("" : "+m,r"(value) : : "memory");
+  asm volatile("" : "+m,r"(reinterpret_cast<char(&)[sizeof(Tp)]>(value)) : : "memory");
 }
 
 template <class Tp>
@@ -115,7 +115,7 @@ inline BENCHMARK_ALWAYS_INLINE
     typename std::enable_if<!std::is_trivially_copyable<Tp>::value ||
                             (sizeof(Tp) > sizeof(Tp*))>::type
     DoNotOptimize(Tp&& value) {
-  asm volatile("" : "+m"(value) : : "memory");
+  asm volatile("" : "+m"(reinterpret_cast<char(&)[sizeof(Tp)]>(value)) : : "memory");
 }
 #endif
 


### PR DESCRIPTION
Fixes #1997.

### What's wrong?
Passing structs with `const` members to `DoNotOptimize` causes compilation errors because the `asm` constraints (`+m`, `+r`) request write access to memory that the compiler considers `const`.

### Fix
Cast the input value to a raw byte array (`char(&)[sizeof(Tp)]`) to strip `const` qualifiers for the optimizer. This safely allows write access in the assembly block.

### Notes
- `const_cast` is not removing 'const' from internal struct members.
- `std::bit_cast` was considered but avoided to maintain compatibility with older C++ standards.
- This approach aligns with the existing workaround used for MSVC, which was missing from the GCC/Clang implementations.