### PR TITLE
Support per-benchmark custom context in JSON output

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -306,7 +306,9 @@ results commonly include fields such as `name`, `run_name`, `run_type`,
 `iterations`, `real_time`, `cpu_time`, `time_unit`, and `threads`. Depending on
 benchmark configuration, result objects can also include aggregate fields,
 asymptotic complexity fields, skip/error fields, memory metrics, labels, user
-counters, and user-requested performance counters.
+counters, and user-requested performance counters. Per-benchmark context added
+with `Benchmark::AddCustomContext` is emitted as a `custom_context` object with
+string fields.
 
 User counters, including rates such as `bytes_per_second` and
 `items_per_second`, are emitted as additional numeric fields on the benchmark
@@ -480,6 +482,24 @@ You can get the same effect with the API:
 
 Note that attempts to add a second value with the same key will fail with an
 error message.
+
+Context can also be attached to an individual benchmark instead of the whole
+run. It is reported with every result of that benchmark, currently only in
+the JSON output, as a `custom_context` object:
+
+```c++
+BENCHMARK(BM_memcpy)->AddCustomContext("variant", "sse2");
+```
+
+```json
+{
+  "name": "BM_memcpy",
+  ...
+  "custom_context": {
+    "variant": "sse2"
+  }
+}
+```
 
 <a name="runtime-and-reporting-considerations" />
 

--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -21,6 +21,7 @@
 #endif
 
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
@@ -141,6 +142,12 @@ class BENCHMARK_EXPORT Benchmark {
   Benchmark* DenseThreadRange(int min_threads, int max_threads, int stride = 1);
   Benchmark* ThreadPerCpu();
   Benchmark* ThreadRunner(threadrunner_factory&& factory);
+  // Adds a key-value pair that is reported alongside every result of this
+  // benchmark, currently only in the JSON output. Unlike
+  // benchmark::AddCustomContext(), which applies to the whole run, this
+  // context is per-benchmark. Attempts to add a second value with the same
+  // key fail with an error message.
+  Benchmark* AddCustomContext(const std::string& key, const std::string& value);
 
   virtual void Run(State& state) = 0;
 
@@ -184,6 +191,8 @@ class BENCHMARK_EXPORT Benchmark {
   callback_function teardown_;
 
   threadrunner_factory threadrunner_;
+
+  std::map<std::string, std::string> custom_context_;
 
   BENCHMARK_DISALLOW_COPY_AND_ASSIGN(Benchmark);
 };

--- a/include/benchmark/reporter.h
+++ b/include/benchmark/reporter.h
@@ -23,6 +23,7 @@
 
 #include <cassert>
 #include <iostream>
+#include <map>
 #include <set>
 #include <string>
 #include <vector>
@@ -115,6 +116,7 @@ class BENCHMARK_EXPORT BenchmarkReporter {
     UserCounters counters;
     MemoryManager::Result memory_result;
     double allocs_per_iter;
+    std::map<std::string, std::string> custom_context;
   };
 
   struct PerFamilyRunReports {

--- a/src/benchmark_api_internal.h
+++ b/src/benchmark_api_internal.h
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <iosfwd>
 #include <limits>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -36,6 +37,9 @@ class BenchmarkInstance {
   BigO complexity() const { return complexity_; }
   BigOFunc* complexity_lambda() const { return complexity_lambda_; }
   const std::vector<Statistics>& statistics() const { return statistics_; }
+  const std::map<std::string, std::string>& custom_context() const {
+    return benchmark_.custom_context_;
+  }
   int repetitions() const { return repetitions_; }
   double min_time() const { return min_time_; }
   double min_warmup_time() const { return min_warmup_time_; }

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -464,6 +464,15 @@ Benchmark* Benchmark::ComputeStatistics(const std::string& name,
   return this;
 }
 
+Benchmark* Benchmark::AddCustomContext(const std::string& key,
+                                       const std::string& value) {
+  if (!custom_context_.emplace(key, value).second) {
+    std::cerr << "Failed to add custom context \"" << key << "\" as it already "
+              << "exists with value \"" << custom_context_.at(key) << "\"\n";
+  }
+  return this;
+}
+
 Benchmark* Benchmark::Threads(int t) {
   BM_CHECK_GT(t, 0);
   thread_counts_.push_back(t);

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -104,6 +104,7 @@ BenchmarkReporter::Run CreateRunReport(
   report.threads = b.threads();
   report.repetition_index = repetition_index;
   report.repetitions = repeats;
+  report.custom_context = b.custom_context();
 
   if (report.skipped == 0u) {
     if (b.use_manual_time()) {

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -337,6 +337,18 @@ void JSONReporter::PrintRunData(Run const& run) {
     report_if_present("net_heap_growth", memory_result.net_heap_growth);
   }
 
+  if (!run.custom_context.empty()) {
+    out << ",\n" << indent << "\"custom_context\": {\n";
+    std::string inner_indent(8, ' ');
+    for (auto it = run.custom_context.begin();
+         it != run.custom_context.end();) {
+      out << inner_indent << FormatKV(it->first, it->second);
+      ++it;
+      out << (it != run.custom_context.end() ? ",\n" : "\n");
+    }
+    out << indent << '}';
+  }
+
   if (!run.report_label.empty()) {
     out << ",\n" << indent << FormatKV("label", run.report_label);
   }

--- a/src/statistics.cc
+++ b/src/statistics.cc
@@ -205,6 +205,7 @@ std::vector<BenchmarkReporter::Run> ComputeStats(
     data.aggregate_name = Stat.name_;
     data.aggregate_unit = Stat.unit_;
     data.report_label = report_label;
+    data.custom_context = successful_run->custom_context;
 
     // It is incorrect to say that an aggregate is computed over
     // run's iterations, because those iterations already got averaged.

--- a/test/reporter_output_test.cc
+++ b/test/reporter_output_test.cc
@@ -1132,6 +1132,37 @@ void BM_CSV_Format(benchmark::State& state) {
 }
 BENCHMARK(BM_CSV_Format);
 ADD_CASES(TC_CSVOut, {{"^\"BM_CSV_Format\",,,,,,,,true,\"\"\"freedom\"\"\"$"}});
+
+// ========================================================================= //
+// -------------------- Testing Custom Context Output ---------------------- //
+// ========================================================================= //
+
+void BM_CustomContext(benchmark::State& state) {
+  for (auto _ : state) {
+  }
+}
+BENCHMARK(BM_CustomContext)
+    ->AddCustomContext("run_group", "alpha")
+    ->AddCustomContext("variant", "sse2");
+ADD_CASES(TC_ConsoleOut, {{"^BM_CustomContext %console_report$"}});
+ADD_CASES(TC_JSONOut, {{"\"name\": \"BM_CustomContext\",$"},
+                       {"\"family_index\": %int,$", MR_Next},
+                       {"\"per_family_instance_index\": 0,$", MR_Next},
+                       {"\"run_name\": \"BM_CustomContext\",$", MR_Next},
+                       {"\"run_type\": \"iteration\",$", MR_Next},
+                       {"\"repetitions\": 1,$", MR_Next},
+                       {"\"repetition_index\": 0,$", MR_Next},
+                       {"\"threads\": 1,$", MR_Next},
+                       {"\"iterations\": %int,$", MR_Next},
+                       {"\"real_time\": %float,$", MR_Next},
+                       {"\"cpu_time\": %float,$", MR_Next},
+                       {"\"time_unit\": \"ns\",$", MR_Next},
+                       {"\"custom_context\": \\{$", MR_Next},
+                       {"\"run_group\": \"alpha\",$", MR_Next},
+                       {"\"variant\": \"sse2\"$", MR_Next},
+                       {"}", MR_Next},
+                       {"}", MR_Next}});
+ADD_CASES(TC_CSVOut, {{"^\"BM_CustomContext\",%csv_report$"}});
 }  // end namespace
 
 // ========================================================================= //


### PR DESCRIPTION
Add Benchmark::AddCustomContext(key, value) to attach string key-value pairs to a benchmark at registration time. The pairs are reported with every result of that benchmark (including aggregates) as a custom_context object in the JSON output, complementing the existing run-wide benchmark::AddCustomContext() which only goes into the top-level context. This allows tagging generated benchmark variants with structured metadata instead of encoding it into the benchmark name and parsing it back out of reports.

Fixes google/benchmark#1890