### PR TITLE
Fix a batch of clang-tidy findings in src/

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -290,7 +290,7 @@ void State::ResumeTiming() {
 void State::SkipWithMessage(const std::string& msg) {
   skipped_ = internal::SkippedWithMessage;
   {
-    MutexLock l(manager_->GetBenchmarkMutex());
+    MutexLock const l(manager_->GetBenchmarkMutex());
     if (internal::NotSkipped == manager_->results.skipped_) {
       manager_->results.skip_message_ = msg;
       manager_->results.skipped_ = skipped_;
@@ -305,7 +305,7 @@ void State::SkipWithMessage(const std::string& msg) {
 void State::SkipWithError(const std::string& msg) {
   skipped_ = internal::SkippedWithError;
   {
-    MutexLock l(manager_->GetBenchmarkMutex());
+    MutexLock const l(manager_->GetBenchmarkMutex());
     if (internal::NotSkipped == manager_->results.skipped_) {
       manager_->results.skip_message_ = msg;
       manager_->results.skipped_ = skipped_;
@@ -322,7 +322,7 @@ void State::SetIterationTime(double seconds) {
 }
 
 void State::SetLabel(const std::string& label) {
-  MutexLock l(manager_->GetBenchmarkMutex());
+  MutexLock const l(manager_->GetBenchmarkMutex());
   manager_->results.report_label_ = label;
 }
 
@@ -452,7 +452,7 @@ void RunBenchmarks(const std::vector<BenchmarkInstance>& benchmarks,
       }
       benchmarks_with_threads += static_cast<int>(benchmark.threads() > 1);
       runners.emplace_back(benchmark, &perfcounters, reports_for_family);
-      int num_repeats_of_this_instance = runners.back().GetNumRepeats();
+      int const num_repeats_of_this_instance = runners.back().GetNumRepeats();
       num_repetitions_total +=
           static_cast<size_t>(num_repeats_of_this_instance);
       if (reports_for_family != nullptr) {
@@ -489,7 +489,7 @@ void RunBenchmarks(const std::vector<BenchmarkInstance>& benchmarks,
       std::shuffle(repetition_indices.begin(), repetition_indices.end(), g);
     }
 
-    for (size_t repetition_index : repetition_indices) {
+    for (size_t const repetition_index : repetition_indices) {
       internal::BenchmarkRunner& runner = runners[repetition_index];
       runner.DoOneRepetition();
       if (runner.HasRepeatsRemaining()) {
@@ -823,7 +823,7 @@ void ParseCommandLineFlags(int* argc, char** argv) {
 }  // end namespace
 
 int InitializeStreams() {
-  static std::ios_base::Init init;
+  static std::ios_base::Init const init;
   return 0;
 }
 

--- a/src/benchmark_api_internal.cc
+++ b/src/benchmark_api_internal.cc
@@ -102,16 +102,16 @@ State BenchmarkInstance::Run(
 
 void BenchmarkInstance::Setup() const {
   if (setup_ != nullptr) {
-    State st(name_.function_name, /*iters*/ 1, args_, /*thread_id*/ 0, threads_,
-             nullptr, nullptr, nullptr, nullptr);
+    State const st(name_.function_name, /*iters*/ 1, args_, /*thread_id*/ 0,
+                   threads_, nullptr, nullptr, nullptr, nullptr);
     setup_(st);
   }
 }
 
 void BenchmarkInstance::Teardown() const {
   if (teardown_ != nullptr) {
-    State st(name_.function_name, /*iters*/ 1, args_, /*thread_id*/ 0, threads_,
-             nullptr, nullptr, nullptr, nullptr);
+    State const st(name_.function_name, /*iters*/ 1, args_, /*thread_id*/ 0,
+                   threads_, nullptr, nullptr, nullptr, nullptr);
     teardown_(st);
   }
 }

--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -105,14 +105,14 @@ BenchmarkFamilies* BenchmarkFamilies::GetInstance() {
 
 size_t BenchmarkFamilies::AddBenchmark(
     std::unique_ptr<benchmark::Benchmark> family) {
-  MutexLock l(mutex_);
-  size_t index = families_.size();
+  MutexLock const l(mutex_);
+  size_t const index = families_.size();
   families_.push_back(std::move(family));
   return index;
 }
 
 void BenchmarkFamilies::ClearBenchmarks() {
-  MutexLock l(mutex_);
+  MutexLock const l(mutex_);
   families_.clear();
   families_.shrink_to_fit();
 }
@@ -140,9 +140,9 @@ bool BenchmarkFamilies::FindBenchmarks(
 
   int next_family_index = 0;
 
-  MutexLock l(mutex_);
+  MutexLock const l(mutex_);
   for (std::unique_ptr<benchmark::Benchmark>& family : families_) {
-    int family_index = next_family_index;
+    int const family_index = next_family_index;
     int per_family_instance_index = 0;
 
     // Family was deleted or benchmark doesn't match
@@ -172,7 +172,7 @@ bool BenchmarkFamilies::FindBenchmarks(
     }
 
     for (auto const& args : family->args_) {
-      for (int num_threads : *thread_counts) {
+      for (int const num_threads : *thread_counts) {
         BenchmarkInstance instance(family.get(), family_index,
                                    per_family_instance_index, args,
                                    num_threads);
@@ -264,7 +264,7 @@ Benchmark* Benchmark::Range(int64_t start, int64_t limit) {
   std::vector<int64_t> arglist;
   internal::AddRange(&arglist, start, limit, range_multiplier_);
 
-  for (int64_t i : arglist) {
+  for (int64_t const i : arglist) {
     args_.push_back({i});
   }
   return this;
@@ -517,7 +517,7 @@ int Benchmark::ArgsCnt() const {
 
 const char* Benchmark::GetArgName(int arg) const {
   BM_CHECK_GE(arg, 0);
-  size_t uarg = static_cast<size_t>(arg);
+  size_t const uarg = static_cast<size_t>(arg);
   BM_CHECK_LT(uarg, arg_names_.size());
   return arg_names_[uarg].c_str();
 }

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -158,7 +158,7 @@ void RunInThread(const BenchmarkInstance* b, IterationCount iters,
         "'SkipWithXXX` in your benchmark as appropriate.");
   }
   {
-    MutexLock l(manager->GetBenchmarkMutex());
+    MutexLock const l(manager->GetBenchmarkMutex());
     internal::ThreadManager::Result& results = manager->results;
     results.iterations += st.iterations();
     results.cpu_time_used += timer.cpu_time_used();
@@ -244,7 +244,7 @@ BenchTimeType ParseBenchMinTime(const std::string& value) {
     char* p_end = nullptr;
     // Reset errno before it's changed by strtol.
     errno = 0;
-    IterationCount num_iters = std::strtol(value.c_str(), &p_end, 10);
+    IterationCount const num_iters = std::strtol(value.c_str(), &p_end, 10);
 
     // After a valid parse, p_end should have been set to
     // point to the 'x' suffix.
@@ -257,7 +257,7 @@ BenchTimeType ParseBenchMinTime(const std::string& value) {
     return ret;
   }
 
-  bool has_suffix = value.back() == 's';
+  bool const has_suffix = value.back() == 's';
   if (!has_suffix) {
     BM_VLOG(0) << "Value passed to --benchmark_min_time should have a suffix. "
                   "Eg., `30s` for 30-seconds.";
@@ -266,7 +266,7 @@ BenchTimeType ParseBenchMinTime(const std::string& value) {
   char* p_end = nullptr;
   // Reset errno before it's changed by strtod.
   errno = 0;
-  double min_time = std::strtod(value.c_str(), &p_end);
+  double const min_time = std::strtod(value.c_str(), &p_end);
 
   // After a successful parse, p_end should point to the suffix 's',
   // or the end of the string if the suffix was omitted.
@@ -345,7 +345,7 @@ BenchmarkRunner::IterationResults BenchmarkRunner::DoNIterations() {
   IterationResults i;
   // Acquire the measurements/counters from the manager, UNDER THE LOCK!
   {
-    MutexLock l(manager->GetBenchmarkMutex());
+    MutexLock const l(manager->GetBenchmarkMutex());
     i.results = manager->results;
   }
 
@@ -554,7 +554,7 @@ void BenchmarkRunner::DoOneRepetition() {
   }
 
   // Ok, now actually report.
-  BenchmarkReporter::Run report =
+  BenchmarkReporter::Run const report =
       CreateRunReport(b, i.results, memory_iterations, memory_result, i.seconds,
                       num_repetitions_done, repeats);
 

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -105,7 +105,7 @@ BenchmarkReporter::Run CreateRunReport(
   report.repetition_index = repetition_index;
   report.repetitions = repeats;
 
-  if (report.skipped == 0u) {
+  if (report.skipped == 0U) {
     if (b.use_manual_time()) {
       report.real_accumulated_time = results.manual_time_used;
     } else {
@@ -321,10 +321,10 @@ BenchmarkRunner::BenchmarkRunner(
   if (b.aggregation_report_mode() != internal::ARM_Unspecified) {
     run_results.display_report_aggregates_only =
         ((b.aggregation_report_mode() &
-          internal::ARM_DisplayReportAggregatesOnly) != 0u);
+          internal::ARM_DisplayReportAggregatesOnly) != 0U);
     run_results.file_report_aggregates_only =
         ((b.aggregation_report_mode() &
-          internal::ARM_FileReportAggregatesOnly) != 0u);
+          internal::ARM_FileReportAggregatesOnly) != 0U);
     BM_CHECK(FLAGS_benchmark_perf_counters.empty() ||
              (perf_counters_measurement_ptr->num_counters() == 0))
         << "Perf counters were requested but could not be set up.";
@@ -399,7 +399,7 @@ bool BenchmarkRunner::ShouldReportIterationResults(
   // Determine if this run should be reported;
   // Either it has run for a sufficient amount of time
   // or because an error was reported.
-  return (i.results.skipped_ != 0u) || FLAGS_benchmark_dry_run ||
+  return (i.results.skipped_ != 0U) || FLAGS_benchmark_dry_run ||
          i.iters >= kMaxIterations ||  // Too many iterations already.
          i.seconds >=
              GetMinTimeToApply() ||  // The elapsed time is large enough.
@@ -560,7 +560,7 @@ void BenchmarkRunner::DoOneRepetition() {
 
   if (reports_for_family != nullptr) {
     ++reports_for_family->num_runs_done;
-    if (report.skipped == 0u) {
+    if (report.skipped == 0U) {
       reports_for_family->Runs.push_back(report);
     }
   }

--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -152,7 +152,7 @@ void RunInThread(const BenchmarkInstance* b, IterationCount iters,
 
   State st = b->Run(iters, thread_id, &timer, manager,
                     perf_counters_measurement, profiler_manager_);
-  if (!(st.skipped() || st.iterations() >= st.max_iterations)) {
+  if (!st.skipped() && st.iterations() < st.max_iterations) {
     st.SkipWithError(
         "The benchmark didn't run, nor was it explicitly skipped. Please call "
         "'SkipWithXXX` in your benchmark as appropriate.");

--- a/src/colorprint.cc
+++ b/src/colorprint.cc
@@ -104,7 +104,7 @@ std::string FormatString(const char* msg, va_list args) {
   }
   // we did not provide a long enough buffer on our first attempt.
   size = static_cast<size_t>(ret) + 1;  // + 1 for the null byte
-  std::unique_ptr<char[]> buff(new char[size]);
+  std::unique_ptr<char[]> const buff(new char[size]);
   va_list args_cp2;
   va_copy(args_cp2, args);
   ret = vsnprintf(buff.get(), size, msg, args_cp2);

--- a/src/commandlineflags.cc
+++ b/src/commandlineflags.cc
@@ -308,7 +308,7 @@ bool IsFlag(const char* str, const char* flag) {
 BENCHMARK_EXPORT
 bool IsTruthyFlagValue(const std::string& value) {
   if (value.size() == 1) {
-    char v = value[0];
+    char const v = value[0];
     return isalnum(v) &&
            !(v == '0' || v == 'f' || v == 'F' || v == 'n' || v == 'N');
   }

--- a/src/commandlineflags.cc
+++ b/src/commandlineflags.cc
@@ -309,8 +309,8 @@ BENCHMARK_EXPORT
 bool IsTruthyFlagValue(const std::string& value) {
   if (value.size() == 1) {
     char const v = value[0];
-    return isalnum(v) &&
-           v != '0' && v != 'f' && v != 'F' && v != 'n' && v != 'N';
+    return isalnum(v) && v != '0' && v != 'f' && v != 'F' && v != 'n' &&
+           v != 'N';
   }
   if (!value.empty()) {
     std::string value_lower(value);

--- a/src/commandlineflags.cc
+++ b/src/commandlineflags.cc
@@ -310,7 +310,7 @@ bool IsTruthyFlagValue(const std::string& value) {
   if (value.size() == 1) {
     char const v = value[0];
     return isalnum(v) &&
-           !(v == '0' || v == 'f' || v == 'F' || v == 'n' || v == 'N');
+           v != '0' && v != 'f' && v != 'F' && v != 'n' && v != 'N';
   }
   if (!value.empty()) {
     std::string value_lower(value);

--- a/src/complexity.cc
+++ b/src/complexity.cc
@@ -94,7 +94,7 @@ LeastSq MinimalLeastSq(const std::vector<ComplexityN>& n,
 
   // Calculate least square fitting parameter
   for (size_t i = 0; i < n.size(); ++i) {
-    double gn_i = fitting_curve(n[i]);
+    double const gn_i = fitting_curve(n[i]);
     sigma_gn_squared += gn_i * gn_i;
     sigma_time += time[i];
     sigma_time_gn += time[i] * gn_i;
@@ -109,12 +109,12 @@ LeastSq MinimalLeastSq(const std::vector<ComplexityN>& n,
   // Calculate RMS
   double rms = 0.0;
   for (size_t i = 0; i < n.size(); ++i) {
-    double fit = result.coef * fitting_curve(n[i]);
+    double const fit = result.coef * fitting_curve(n[i]);
     rms += std::pow((time[i] - fit), 2);
   }
 
   // Normalized RMS by the mean of the observed values
-  double mean = sigma_time / static_cast<double>(n.size());
+  double const mean = sigma_time / static_cast<double>(n.size());
   result.rms = std::sqrt(rms / static_cast<double>(n.size())) / mean;
 
   return result;
@@ -137,7 +137,8 @@ LeastSq MinimalLeastSq(const std::vector<ComplexityN>& n,
   LeastSq best_fit;
 
   if (complexity == oAuto) {
-    std::vector<BigO> fit_curves = {oLogN, oN, oNLogN, oNSquared, oNCubed};
+    std::vector<BigO> const fit_curves = {oLogN, oN, oNLogN, oNSquared,
+                                          oNCubed};
 
     // Take o1 as default best fitting curve
     best_fit = MinimalLeastSq(n, time, FittingCurve(o1));
@@ -145,7 +146,7 @@ LeastSq MinimalLeastSq(const std::vector<ComplexityN>& n,
 
     // Compute all possible fitting curves and stick to the best one
     for (const auto& fit : fit_curves) {
-      LeastSq current_fit = MinimalLeastSq(n, time, FittingCurve(fit));
+      LeastSq const current_fit = MinimalLeastSq(n, time, FittingCurve(fit));
       if (current_fit.rms < best_fit.rms) {
         best_fit = current_fit;
         best_fit.complexity = fit;
@@ -235,7 +236,7 @@ std::vector<BenchmarkReporter::Run> ComputeBigO(
   // should not be multiplied at all. So, here, we _divide_ it by the
   // multiplier so that when it is multiplied later the result is the
   // correct one.
-  double multiplier = GetTimeUnitMultiplier(reports[0].time_unit);
+  double const multiplier = GetTimeUnitMultiplier(reports[0].time_unit);
 
   // Only add label to mean/stddev if it is same for all runs
   Run rms;

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -99,16 +99,18 @@ void ConsoleReporter::ReportRuns(const std::vector<Run>& reports) {
   }
 }
 
+namespace {
+
 PRINTF_FORMAT_STRING_FUNC(3, 4)
-static void IgnoreColorPrint(std::ostream& out, LogColor /*unused*/,
-                             const char* fmt, ...) {
+void IgnoreColorPrint(std::ostream& out, LogColor /*unused*/, const char* fmt,
+                      ...) {
   va_list args;
   va_start(args, fmt);
   out << FormatString(fmt, args);
   va_end(args);
 }
 
-static std::string FormatTime(double time) {
+std::string FormatTime(double time) {
   // For the time columns of the console printer 13 digits are reserved. One of
   // them is a space and max two of them are the time unit (e.g ns). That puts
   // us at 10 digits usable for the number.
@@ -129,6 +131,8 @@ static std::string FormatTime(double time) {
   }
   return FormatString("%10.0f", time);
 }
+
+}  // namespace
 
 BENCHMARK_EXPORT
 void ConsoleReporter::PrintRunData(const Run& result) {

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -73,7 +73,7 @@ void ConsoleReporter::PrintHeader(const Run& run) {
       str += " UserCounters...";
     }
   }
-  std::string line = std::string(str.length(), '-');
+  std::string const line = std::string(str.length(), '-');
   GetOutputStream() << line << "\n" << str << "\n" << line << "\n";
 }
 
@@ -160,7 +160,7 @@ void ConsoleReporter::PrintRunData(const Run& result) {
   const std::string cpu_time_str = FormatTime(cpu_time);
 
   if (result.report_big_o) {
-    std::string big_o = GetBigOString(result.complexity);
+    std::string const big_o = GetBigOString(result.complexity);
     printer(Out, COLOR_YELLOW, "%10.2f %-4s %10.2f %-4s ", real_time,
             big_o.c_str(), cpu_time, big_o.c_str());
   } else if (result.report_rms) {

--- a/src/counter.cc
+++ b/src/counter.cc
@@ -14,6 +14,8 @@
 
 #include "counter.h"
 
+#include <algorithm>
+
 namespace benchmark {
 namespace internal {
 
@@ -74,12 +76,10 @@ bool SameNames(UserCounters const& l, UserCounters const& r) {
   if (l.size() != r.size()) {
     return false;
   }
-  for (auto const& c : l) {
-    if (r.find(c.first) == r.end()) {
-      return false;
-    }
-  }
-  return true;
+  return std::all_of(l.begin(), l.end(),
+                     [&r](const UserCounters::value_type& c) {
+                       return r.find(c.first) != r.end();
+                     });
 }
 
 }  // end namespace internal

--- a/src/csv_reporter.cc
+++ b/src/csv_reporter.cc
@@ -35,7 +35,7 @@ const std::vector<const char*> elements = {
 std::string CsvEscape(const std::string& s) {
   std::string tmp;
   tmp.reserve(s.size() + 2);
-  for (char c : s) {
+  for (char const c : s) {
     switch (c) {
       case '"':
         tmp += "\"\"";

--- a/src/csv_reporter.cc
+++ b/src/csv_reporter.cc
@@ -112,7 +112,7 @@ BENCHMARK_EXPORT
 void CSVReporter::PrintRunData(const Run& run) {
   std::ostream& Out = GetOutputStream();
   Out << CsvEscape(run.benchmark_name()) << ",";
-  if (run.skipped != 0u) {
+  if (run.skipped != 0U) {
     Out << std::string(elements.size() - 3, ',');
     Out << std::boolalpha << (internal::SkippedWithError == run.skipped) << ",";
     Out << CsvEscape(run.skip_message) << "\n";

--- a/src/json_reporter.cc
+++ b/src/json_reporter.cc
@@ -37,7 +37,7 @@ namespace {
 std::string StrEscape(const std::string& s) {
   std::string tmp;
   tmp.reserve(s.size());
-  for (char c : s) {
+  for (char const c : s) {
     switch (c) {
       case '\b':
         tmp += "\\b";
@@ -121,13 +121,13 @@ bool JSONReporter::ReportContext(const Context& context) {
   std::ostream& out = GetOutputStream();
 
   out << "{\n";
-  std::string inner_indent(2, ' ');
+  std::string const inner_indent(2, ' ');
 
   // Open context block and print context information.
   out << inner_indent << "\"context\": {\n";
   std::string indent(4, ' ');
 
-  std::string walltime_value = LocalDateTimeString();
+  std::string const walltime_value = LocalDateTimeString();
   out << indent << FormatKV("date", walltime_value) << ",\n";
 
   out << indent << FormatKV("host_name", context.sys_info.name) << ",\n";
@@ -160,7 +160,7 @@ bool JSONReporter::ReportContext(const Context& context) {
 
   out << indent << "\"caches\": [\n";
   indent = std::string(6, ' ');
-  std::string cache_indent(8, ' ');
+  std::string const cache_indent(8, ' ');
   for (size_t i = 0; i < info.caches.size(); ++i) {
     const auto& CI = info.caches[i];
     out << indent << "{\n";
@@ -224,7 +224,7 @@ void JSONReporter::ReportRuns(std::vector<Run> const& reports) {
   if (reports.empty()) {
     return;
   }
-  std::string indent(4, ' ');
+  std::string const indent(4, ' ');
   std::ostream& out = GetOutputStream();
   if (!first_report_) {
     out << ",\n";

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -141,7 +141,7 @@ std::string StrFormatImp(const char* msg, va_list args) {
 
   // we did not provide a long enough buffer on our first attempt.
   // add 1 to size to account for null-byte in size cast to prevent overflow
-  std::size_t size = static_cast<std::size_t>(ret) + 1;
+  std::size_t const size = static_cast<std::size_t>(ret) + 1;
   auto buff_ptr = std::unique_ptr<char[]>(new char[size]);
   // 2015-10-08: vsnprintf is used instead of snd::vsnprintf due to a limitation
   // in the android-ndk

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -785,7 +785,8 @@ double GetCPUCyclesPerSecond(CPUInfo::Scaling scaling) {
 #elif defined BENCHMARK_OS_WINDOWS_WIN32
   // In NT, read MHz from the registry. If we fail to do so or we're in win9x
   // then make a crude estimate.
-  DWORD data, data_size = sizeof(data);
+  DWORD data;
+  DWORD data_size = sizeof(data);
   if (IsWindowsXPOrGreater() &&
       SUCCEEDED(
           SHGetValueA(HKEY_LOCAL_MACHINE,

--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -258,7 +258,7 @@ int CountSetBitsInCPUMap(std::string val) {
   auto CountBits = [](std::string part) {
     using CPUMask = std::bitset<sizeof(std::uintptr_t) * CHAR_BIT>;
     part = "0x" + part;
-    CPUMask mask(benchmark::stoul(part, nullptr, 16));
+    CPUMask const mask(benchmark::stoul(part, nullptr, 16));
     return static_cast<int>(mask.count());
   };
   std::size_t pos = 0;
@@ -276,11 +276,11 @@ int CountSetBitsInCPUMap(std::string val) {
 BENCHMARK_MAYBE_UNUSED
 std::vector<CPUInfo::CacheInfo> GetCacheSizesFromKVFS() {
   std::vector<CPUInfo::CacheInfo> res;
-  std::string dir = "/sys/devices/system/cpu/cpu0/cache/";
+  std::string const dir = "/sys/devices/system/cpu/cpu0/cache/";
   int idx = 0;
   while (true) {
     CPUInfo::CacheInfo info;
-    std::string fpath = StrCat(dir, "index", idx++, "/");
+    std::string const fpath = StrCat(dir, "index", idx++, "/");
     std::ifstream f(StrCat(fpath, "size").c_str());
     if (!f.is_open()) {
       break;
@@ -354,7 +354,7 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizesWindows() {
 
   using UPtr = std::unique_ptr<PInfo, decltype(&std::free)>;
   GetLogicalProcessorInformation(nullptr, &buffer_size);
-  UPtr buff(static_cast<PInfo*>(std::malloc(buffer_size)), &std::free);
+  UPtr const buff(static_cast<PInfo*>(std::malloc(buffer_size)), &std::free);
   if (!GetLogicalProcessorInformation(buff.get(), &buffer_size)) {
     PrintErrorAndDie("Failed during call to GetLogicalProcessorInformation: ",
                      GetLastError());
@@ -368,7 +368,7 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizesWindows() {
       continue;
     }
     using BitSet = std::bitset<sizeof(ULONG_PTR) * CHAR_BIT>;
-    BitSet b(it->ProcessorMask);
+    BitSet const b(it->ProcessorMask);
     // To prevent duplicates, only consider caches where CPU 0 is specified
     if (!b.test(0)) continue;
     const CInfo& cache = it->Cache;
@@ -594,7 +594,7 @@ class ThreadAffinityGuard final {
       return;
     }
 #elif defined(BENCHMARK_OS_WINDOWS_WIN32)
-    DWORD_PTR ret = SetThreadAffinityMask(self, previous_affinity);
+    DWORD_PTR const ret = SetThreadAffinityMask(self, previous_affinity);
     if (ret != 0) {
       return;
     }
@@ -641,7 +641,8 @@ class ThreadAffinityGuard final {
     return ret == 0;
 #elif defined(BENCHMARK_OS_WINDOWS_WIN32)
     self = GetCurrentThread();
-    DWORD_PTR mask = static_cast<DWORD_PTR>(1) << GetCurrentProcessorNumber();
+    DWORD_PTR const mask = static_cast<DWORD_PTR>(1)
+                           << GetCurrentProcessorNumber();
     previous_affinity = SetThreadAffinityMask(self, mask);
     return previous_affinity != 0;
 #else
@@ -836,7 +837,7 @@ double GetCPUCyclesPerSecond(CPUInfo::Scaling scaling) {
   // Make sure to use the same cycle counter when starting and stopping the
   // cycle timer. We just pin the current thread to a cpu in the previous
   // affinity set.
-  ThreadAffinityGuard affinity_guard;
+  ThreadAffinityGuard const affinity_guard;
 
   static constexpr double estimate_time_s = 1.0;
   const double start_time = ChronoClockNow();

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -226,7 +226,7 @@ double ThreadCPUUsage() {
 std::string LocalDateTimeString() {
   // Write the local time in RFC3339 format yyyy-mm-ddTHH:MM:SS+/-HH:MM.
   typedef std::chrono::system_clock Clock;
-  std::time_t now = Clock::to_time_t(Clock::now());
+  std::time_t const now = Clock::to_time_t(Clock::now());
   const std::size_t kTzOffsetLen = 6;
   const std::size_t kTimestampLen = 19;
 


### PR DESCRIPTION
Works through a slice of the clang-tidy findings collated in #1925, scoped to `src/` and split into one commit per check for easier review:

- `misc-const-correctness`: declare immutable locals `const` (13 files, includes the `MutexLock` guards and the `State` objects constructed for Setup/Teardown callbacks)
- `readability-uppercase-literal-suffix`: `0u` -> `0U`
- `readability-simplify-boolean-expr` / `readability-isolate-declaration` / `readability-use-anyofallof`: De Morgan simplifications in `benchmark_runner.cc` and `commandlineflags.cc`, split a multi-variable declaration in `sysinfo.cc`, replace a hand-written find loop in `SameNames` with `std::all_of`
- `misc-use-anonymous-namespace`: move the file-static `IgnoreColorPrint`/`FormatTime` helpers in `console_reporter.cc` into an anonymous namespace

Not included on purpose: `readability-convert-member-functions-to-static` on `PerfCountersMeasurement::Read` (the suggestion is only valid for the non-libpfm stub, making it static would break the Linux/libpfm build), and the `cppcoreguidelines-avoid-non-const-global-variables` findings on flag definitions and registration globals, which look intentional.

The remaining findings were re-checked with clang-tidy 20 against a fresh `compile_commands.json`; the checks addressed here now report clean for `src/` in a Windows configuration (Linux-only code paths, e.g. libpfm perf counters, were not analyzed and may retain findings).

Testing: full CMake test suite passes locally in Debug and the library and tests build warning-free in Release (`-Wall -Wextra -Werror`, MinGW-w64 GCC 15.2 on Windows 11).

Refs #1925

AI disclosure (per AGENTS.md): this change was developed with AI assistance (Anthropic's Claude).
