### PR TITLE
Pass benchmark State to ProfilerManager hooks via GetState() accessor

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1604,6 +1604,11 @@ If set, the `ProfilerManager::AfterSetupStart` and
 end of a separate benchmark run to allow user code to collect and report
 user-provided profile metrics.
 
+From within either hook, `ProfilerManager::GetState()` returns the
+`benchmark::State` of the run being profiled, which gives access to run
+information such as the benchmark name (e.g. for registering named profiling
+regions).
+
 Output collected from this profiling run must be reported separately.
 
 <a name="using-register-benchmark" />

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1604,10 +1604,10 @@ If set, the `ProfilerManager::AfterSetupStart` and
 end of a separate benchmark run to allow user code to collect and report
 user-provided profile metrics.
 
-From within either hook, `ProfilerManager::GetState()` returns the
-`benchmark::State` of the run being profiled, which gives access to run
+From within either hook, `ProfilerManager::GetState()` returns a pointer to
+the `benchmark::State` of the run being profiled, which gives access to run
 information such as the benchmark name (e.g. for registering named profiling
-regions).
+regions). Outside of the two hooks it returns `nullptr`.
 
 Output collected from this profiling run must be reported separately.
 

--- a/include/benchmark/managers.h
+++ b/include/benchmark/managers.h
@@ -61,9 +61,10 @@ class ProfilerManager {
 
  protected:
   // The State of the benchmark run being profiled, giving access to e.g. the
-  // benchmark name (for a named profiling region). Only valid to call from
-  // within AfterSetupStart() and BeforeTeardownStop().
-  const State& GetState() const { return *state_; }
+  // benchmark name (for a named profiling region). Non-null only while
+  // AfterSetupStart() or BeforeTeardownStop() is executing; any other caller
+  // observes nullptr.
+  const State* GetState() const { return state_; }
 
  private:
   friend class State;

--- a/include/benchmark/managers.h
+++ b/include/benchmark/managers.h
@@ -24,6 +24,8 @@
 
 namespace benchmark {
 
+class State;
+
 class MemoryManager {
  public:
   static constexpr int64_t TombstoneValue = std::numeric_limits<int64_t>::max();
@@ -56,6 +58,16 @@ class ProfilerManager {
   virtual ~ProfilerManager() {}
   virtual void AfterSetupStart() = 0;
   virtual void BeforeTeardownStop() = 0;
+
+ protected:
+  // The State of the benchmark run being profiled, giving access to e.g. the
+  // benchmark name (for a named profiling region). Only valid to call from
+  // within AfterSetupStart() and BeforeTeardownStop().
+  const State& GetState() const { return *state_; }
+
+ private:
+  friend class State;
+  const State* state_ = nullptr;
 };
 
 BENCHMARK_EXPORT

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -331,6 +331,7 @@ void State::StartKeepRunning() {
   started_ = true;
   total_iterations_ = skipped() ? 0 : max_iterations;
   if (BENCHMARK_BUILTIN_EXPECT(profiler_manager_ != nullptr, false)) {
+    profiler_manager_->state_ = this;
     profiler_manager_->AfterSetupStart();
   }
   manager_->StartStopBarrier();
@@ -349,6 +350,7 @@ void State::FinishKeepRunning() {
   finished_ = true;
   manager_->StartStopBarrier();
   if (BENCHMARK_BUILTIN_EXPECT(profiler_manager_ != nullptr, false)) {
+    profiler_manager_->state_ = this;
     profiler_manager_->BeforeTeardownStop();
   }
 }

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -333,6 +333,7 @@ void State::StartKeepRunning() {
   if (BENCHMARK_BUILTIN_EXPECT(profiler_manager_ != nullptr, false)) {
     profiler_manager_->state_ = this;
     profiler_manager_->AfterSetupStart();
+    profiler_manager_->state_ = nullptr;
   }
   manager_->StartStopBarrier();
   if (!skipped()) {
@@ -352,6 +353,7 @@ void State::FinishKeepRunning() {
   if (BENCHMARK_BUILTIN_EXPECT(profiler_manager_ != nullptr, false)) {
     profiler_manager_->state_ = this;
     profiler_manager_->BeforeTeardownStop();
+    profiler_manager_->state_ = nullptr;
   }
 }
 

--- a/test/profiler_manager_test.cc
+++ b/test/profiler_manager_test.cc
@@ -16,9 +16,15 @@ class TestProfilerManager : public benchmark::ProfilerManager {
  public:
   void AfterSetupStart() override {
     ++start_called;
-    benchmark_name = GetState().name();
+    if (GetState() != nullptr) {
+      benchmark_name = GetState()->name();
+    }
   }
   void BeforeTeardownStop() override { ++stop_called; }
+
+  // Expose the protected accessor so the harness can verify it yields
+  // nullptr outside the hooks.
+  const benchmark::State* StateOutsideHooks() const { return GetState(); }
 
   int start_called = 0;
   int stop_called = 0;
@@ -61,4 +67,6 @@ int main(int argc, char* argv[]) {
   assert(pm->start_called == 1);
   assert(pm->stop_called == 1);
   assert(pm->benchmark_name == "BM_empty");
+  // Outside the hooks the state must not be observable.
+  assert(pm->StateOutsideHooks() == nullptr);
 }

--- a/test/profiler_manager_test.cc
+++ b/test/profiler_manager_test.cc
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <memory>
+#include <string>
 
 #include "benchmark/benchmark_api.h"
 #include "benchmark/managers.h"
@@ -13,11 +14,15 @@
 namespace {
 class TestProfilerManager : public benchmark::ProfilerManager {
  public:
-  void AfterSetupStart() override { ++start_called; }
+  void AfterSetupStart() override {
+    ++start_called;
+    benchmark_name = GetState().name();
+  }
   void BeforeTeardownStop() override { ++stop_called; }
 
   int start_called = 0;
   int stop_called = 0;
+  std::string benchmark_name;
 };
 
 void BM_empty(benchmark::State& state) {
@@ -55,4 +60,5 @@ int main(int argc, char* argv[]) {
 
   assert(pm->start_called == 1);
   assert(pm->stop_called == 1);
+  assert(pm->benchmark_name == "BM_empty");
 }


### PR DESCRIPTION
Supersedes #2249, which could not be reopened after its branch was force-pushed to address review feedback.

Profilers that do regional profiling need information about the benchmark being profiled, e.g. its name to register a named profiling region. This exposes the running benchmark's `State` to the `ProfilerManager` hooks.

Instead of overloading `AfterSetupStart()`/`BeforeTeardownStop()` with `State`-taking variants (which hide the base methods and force existing subclasses to add `using` declarations under `-Woverloaded-virtual`), the existing pure-virtual hooks are left unchanged and a protected `ProfilerManager::GetState()` accessor is added. The library sets the active `State` immediately before invoking each hook; the profiling run is single-threaded, so no synchronization is needed. Existing `ProfilerManager` implementations compile unchanged.

Fixes google/benchmark#2234

Testing:
- Added coverage in profiler_manager_test that reads the benchmark name through GetState() from within AfterSetupStart().
- Release build/tests and Debug build/tests pass (profiler_manager tests plus the full suite).
- Builds remain -Werror clean.

AI disclosure (per AGENTS.md): this change was developed with AI assistance (Anthropic's Claude).
