### PR TITLE
Fix DoNotOptimize compile failure on types with const members

### DIFF
--- a/include/benchmark/utils.h
+++ b/include/benchmark/utils.h
@@ -26,7 +26,26 @@ namespace benchmark {
 
 namespace internal {
 BENCHMARK_EXPORT void UseCharPointer(char const volatile*);
-}
+
+// GCC and Clang reject objects of class types with const data members
+// (recursively) as asm *output* operands, since such objects cannot be
+// stored to (see issue #1997). There is no portable trait for "contains a
+// const member", so approximate it as "not assignable": this additionally
+// routes reference-member types (which would be valid outputs) through the
+// input-only fallback, which is harmless — the fallback keeps the memory
+// clobber, and such objects cannot be legally written through anyway.
+// Arrays are not assignable but are valid memory outputs, so they are
+// accepted unconditionally.
+template <class Tp>
+struct IsAsmOutputOperand
+    : std::integral_constant<
+          bool,
+          std::is_array<typename std::remove_reference<Tp>::type>::value ||
+              std::is_copy_assignable<
+                  typename std::remove_reference<Tp>::type>::value ||
+              std::is_move_assignable<
+                  typename std::remove_reference<Tp>::type>::value> {};
+}  // namespace internal
 
 #if (!defined(__GNUC__) && !defined(__clang__)) || defined(__pnacl__) || \
     defined(__EMSCRIPTEN__)
@@ -51,7 +70,31 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp const& value) {
 }
 
 template <class Tp>
-inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
+inline BENCHMARK_ALWAYS_INLINE
+    typename std::enable_if<internal::IsAsmOutputOperand<Tp>::value>::type
+    DoNotOptimize(Tp& value) {
+#if defined(__clang__)
+  asm volatile("" : "+r,m"(value) : : "memory");
+#else
+  asm volatile("" : "+m,r"(value) : : "memory");
+#endif
+}
+
+// Non-assignable types (e.g. with const or reference data members) cannot be
+// used as an asm output operand. Fall back to an input operand with a memory
+// clobber; such objects cannot be written through anyway, so no optimization
+// barrier is lost.
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE
+    typename std::enable_if<!internal::IsAsmOutputOperand<Tp>::value>::type
+    DoNotOptimize(Tp& value) {
+  asm volatile("" : : "r,m"(value) : "memory");
+}
+
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE
+    typename std::enable_if<internal::IsAsmOutputOperand<Tp>::value>::type
+    DoNotOptimize(Tp&& value) {
 #if defined(__clang__)
   asm volatile("" : "+r,m"(value) : : "memory");
 #else
@@ -60,12 +103,10 @@ inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp& value) {
 }
 
 template <class Tp>
-inline BENCHMARK_ALWAYS_INLINE void DoNotOptimize(Tp&& value) {
-#if defined(__clang__)
-  asm volatile("" : "+r,m"(value) : : "memory");
-#else
-  asm volatile("" : "+m,r"(value) : : "memory");
-#endif
+inline BENCHMARK_ALWAYS_INLINE
+    typename std::enable_if<!internal::IsAsmOutputOperand<Tp>::value>::type
+    DoNotOptimize(Tp&& value) {
+  asm volatile("" : : "r,m"(value) : "memory");
 }
 #elif (__GNUC__ >= 5)
 template <class Tp>
@@ -88,7 +129,8 @@ inline BENCHMARK_ALWAYS_INLINE
 
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE
-    typename std::enable_if<std::is_trivially_copyable<Tp>::value &&
+    typename std::enable_if<internal::IsAsmOutputOperand<Tp>::value &&
+                            std::is_trivially_copyable<Tp>::value &&
                             (sizeof(Tp) <= sizeof(Tp*))>::type
     DoNotOptimize(Tp& value) {
   asm volatile("" : "+m,r"(value) : : "memory");
@@ -96,15 +138,39 @@ inline BENCHMARK_ALWAYS_INLINE
 
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE
-    typename std::enable_if<!std::is_trivially_copyable<Tp>::value ||
-                            (sizeof(Tp) > sizeof(Tp*))>::type
+    typename std::enable_if<internal::IsAsmOutputOperand<Tp>::value &&
+                            (!std::is_trivially_copyable<Tp>::value ||
+                             (sizeof(Tp) > sizeof(Tp*)))>::type
     DoNotOptimize(Tp& value) {
   asm volatile("" : "+m"(value) : : "memory");
 }
 
+// Non-assignable types (e.g. with const or reference data members) cannot be
+// used as an asm output operand. Fall back to an input operand with a memory
+// clobber; such objects cannot be written through anyway, so no optimization
+// barrier is lost.
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE
-    typename std::enable_if<std::is_trivially_copyable<Tp>::value &&
+    typename std::enable_if<!internal::IsAsmOutputOperand<Tp>::value &&
+                            std::is_trivially_copyable<Tp>::value &&
+                            (sizeof(Tp) <= sizeof(Tp*))>::type
+    DoNotOptimize(Tp& value) {
+  asm volatile("" : : "r,m"(value) : "memory");
+}
+
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE
+    typename std::enable_if<!internal::IsAsmOutputOperand<Tp>::value &&
+                            (!std::is_trivially_copyable<Tp>::value ||
+                             (sizeof(Tp) > sizeof(Tp*)))>::type
+    DoNotOptimize(Tp& value) {
+  asm volatile("" : : "m"(value) : "memory");
+}
+
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE
+    typename std::enable_if<internal::IsAsmOutputOperand<Tp>::value &&
+                            std::is_trivially_copyable<Tp>::value &&
                             (sizeof(Tp) <= sizeof(Tp*))>::type
     DoNotOptimize(Tp&& value) {
   asm volatile("" : "+m,r"(value) : : "memory");
@@ -112,10 +178,29 @@ inline BENCHMARK_ALWAYS_INLINE
 
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE
-    typename std::enable_if<!std::is_trivially_copyable<Tp>::value ||
-                            (sizeof(Tp) > sizeof(Tp*))>::type
+    typename std::enable_if<internal::IsAsmOutputOperand<Tp>::value &&
+                            (!std::is_trivially_copyable<Tp>::value ||
+                             (sizeof(Tp) > sizeof(Tp*)))>::type
     DoNotOptimize(Tp&& value) {
   asm volatile("" : "+m"(value) : : "memory");
+}
+
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE
+    typename std::enable_if<!internal::IsAsmOutputOperand<Tp>::value &&
+                            std::is_trivially_copyable<Tp>::value &&
+                            (sizeof(Tp) <= sizeof(Tp*))>::type
+    DoNotOptimize(Tp&& value) {
+  asm volatile("" : : "r,m"(value) : "memory");
+}
+
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE
+    typename std::enable_if<!internal::IsAsmOutputOperand<Tp>::value &&
+                            (!std::is_trivially_copyable<Tp>::value ||
+                             (sizeof(Tp) > sizeof(Tp*)))>::type
+    DoNotOptimize(Tp&& value) {
+  asm volatile("" : : "m"(value) : "memory");
 }
 #endif
 

--- a/test/donotoptimize_test.cc
+++ b/test/donotoptimize_test.cc
@@ -27,6 +27,21 @@ struct BitRef {
   BitRef(int i, unsigned char& b) : index(i), byte(b) {}
 };
 
+// Types with const data members cannot be used as an asm output operand, so
+// DoNotOptimize must degrade to an input-only constraint for them.
+// See https://github.com/google/benchmark/issues/1997.
+struct ConstMember {
+  ConstMember() : value{} {}
+  const int value;
+};
+
+// Same, for a type too large to be register-sized.
+struct BigConstMember {
+  BigConstMember() : value{} {}
+  const int value;
+  int padding[16] = {};
+};
+
 int main(int argc, char* argv[]) {
   benchmark::MaybeReenterWithoutASLR(argc, argv);
 
@@ -67,4 +82,14 @@ int main(int argc, char* argv[]) {
 
   // Check that accept rvalue.
   benchmark::DoNotOptimize(BitRef::Make());
+
+  // Non-assignable types (const data members) must compile as lvalues and
+  // rvalues, including through deduced (non-const) references (#1997).
+  ConstMember cm;
+  benchmark::DoNotOptimize(cm);
+  benchmark::DoNotOptimize(ConstMember{});
+  BigConstMember bcm;
+  benchmark::DoNotOptimize(bcm);
+  benchmark::DoNotOptimize(BigConstMember{});
+  [](auto& v) { benchmark::DoNotOptimize(v); }(cm);
 }


### PR DESCRIPTION
Fixes #1997

## Problem

GCC and Clang both reject objects of class types with `const` data members as asm **output** operands — such objects cannot be stored to:

```
gcc:   error: read-only reference 'value' used as 'asm' output
clang: error: invalid lvalue in asm output
```

Since the `const&` overload of `DoNotOptimize` is deprecated, there was no usable spelling at all for these types when reached through a deduced non-const reference (`[](auto& v) { DoNotOptimize(v); }`), as reported in #1997.

## Fix

Add an `internal::IsAsmOutputOperand` trait and route non-output-capable types to an **input-only constraint with a memory clobber**. Such objects cannot be legally written through anyway, so no optimization barrier is lost relative to the read-write constraint.

There is no portable trait for "contains a const member", so the trait approximates it as "not assignable" (`is_array || is_copy_assignable || is_move_assignable`):

- types with const members → correctly take the fallback (they'd fail to compile as outputs)
- reference-member types (e.g. the existing `BitRef` test type) are actually valid asm outputs but are indistinguishable by trait — they conservatively take the same fallback, which still compiles and keeps the clobber
- arrays are not assignable but are valid memory outputs, so they're accepted unconditionally

Both the clang/ICC branch and the GCC ≥ 5 branch get the dispatch; the GCC branch keeps its existing register-size/trivially-copyable split in the fallbacks (`"r,m"` vs `"m"`, mirroring the deprecated const-ref overloads). MSVC needs no change (no inline asm).

## Testing

- The reproducer from #1997 now compiles with GCC 15 and Clang 21 (it fails with both on current main)
- `donotoptimize_test.cc` extended with const-member types: register-sized and larger, as lvalues, rvalues, and through a deduced non-const reference; builds and runs clean with `-Wall -Wextra` on GCC and Clang, `-O1` and `-O3`

## Disclosure

Per [AGENTS.md](https://github.com/google/benchmark/blob/main/AGENTS.md): this PR was developed with AI assistance (Claude Code). The change and analysis have been reviewed and are owned by me.