### PR TITLE
Fix typos, add codespell configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ Documentation = "https://github.com/google/benchmark/tree/main/docs"
 Repository = "https://github.com/google/benchmark.git"
 Discord = "https://discord.gg/cz7UX7wKC2"
 
+[tool.codespell]
+ignore-words-list = ["bion", "globa", "wron"]
+
 [tool.setuptools]
 package-dir = { "" = "bindings/python" }
 zip-safe = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,6 @@ Documentation = "https://github.com/google/benchmark/tree/main/docs"
 Repository = "https://github.com/google/benchmark.git"
 Discord = "https://discord.gg/cz7UX7wKC2"
 
-[tool.codespell]
-ignore-words-list = ["bion", "globa", "wron"]
-
 [tool.setuptools]
 package-dir = { "" = "bindings/python" }
 zip-safe = false

--- a/src/cycleclock.h
+++ b/src/cycleclock.h
@@ -230,7 +230,7 @@ inline BENCHMARK_ALWAYS_INLINE int64_t Now() {
   // Alpha has a cycle counter, the PCC register, but it is an unsigned 32-bit
   // integer and thus wraps every ~4s, making using it for tick counts
   // unreliable beyond this time range.  The real-time clock is low-precision,
-  // roughtly ~1ms, but it is the only option that can reasonable count
+  // roughly ~1ms, but it is the only option that can reasonable count
   // indefinitely.
   struct timeval tv;
   gettimeofday(&tv, nullptr);
@@ -238,7 +238,7 @@ inline BENCHMARK_ALWAYS_INLINE int64_t Now() {
 #elif defined(__hppa__) || defined(__linux__) || defined(BENCHMARK_OS_WASI)
   // Fallback for all other architectures with a recent Linux kernel, e.g.:
   // HP PA-RISC provides a user-readable clock counter (cr16), but
-  // it's not syncronized across CPUs and only 32-bit wide when programs
+  // it's not synchronized across CPUs and only 32-bit wide when programs
   // are built as 32-bit binaries.
   // Same for SH-4 and possibly others.
   // Use clock_gettime(CLOCK_MONOTONIC, ...) instead of gettimeofday

--- a/test/output_test_helper.cc
+++ b/test/output_test_helper.cc
@@ -30,7 +30,7 @@ using TestCaseList = std::vector<TestCase>;
 using SubMap = std::vector<std::pair<std::string, std::string>>;
 
 TestCaseList& GetTestCaseList(TestCaseID ID) {
-  // Uses function-local statics to ensure initialization occurs
+  // Uses function-local statistics to ensure initialization occurs
   // before first use.
   static TestCaseList lists[TC_NumID];
   return lists[ID];

--- a/test/output_test_helper.cc
+++ b/test/output_test_helper.cc
@@ -30,7 +30,7 @@ using TestCaseList = std::vector<TestCase>;
 using SubMap = std::vector<std::pair<std::string, std::string>>;
 
 TestCaseList& GetTestCaseList(TestCaseID ID) {
-  // Uses function-local statistics to ensure initialization occurs
+  // Uses function-local static to ensure initialization occurs
   // before first use.
   static TestCaseList lists[TC_NumID];
   return lists[ID];

--- a/tools/gbench/util.py
+++ b/tools/gbench/util.py
@@ -143,7 +143,7 @@ def load_benchmark_results(fname, benchmark_filter):
             json_schema_version = results["context"]["json_schema_version"]
             if json_schema_version != 1:
                 print(
-                    f"In {fname}, got unnsupported JSON schema version:"
+                    f"In {fname}, got unsupported JSON schema version:"
                     f" {json_schema_version}, expected 1"
                 )
                 sys.exit(1)


### PR DESCRIPTION
This fixes a few typos identified and corrected using codespell. A configuration is also added, in case this tool is used again in the future. This check can be added to CI and/or pre-commit, but this is not done in this PR.

Note that codespell has previously been used with fe65457e80ef8ab6bbd6da418ab7cb6f6102afda