### PR TITLE
Fix use-after-free in CreateDefaultDisplayReporter (#2240)

### DIFF
--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -54,7 +54,8 @@ BENCHMARK_EXPORT void SetBenchmarkFilter(std::string value);
 
 BENCHMARK_EXPORT int32_t GetBenchmarkVerbosity();
 
-BENCHMARK_EXPORT BenchmarkReporter* CreateDefaultDisplayReporter();
+BENCHMARK_EXPORT std::unique_ptr<BenchmarkReporter>
+CreateDefaultDisplayReporter();
 
 BENCHMARK_EXPORT size_t RunSpecifiedBenchmarks();
 BENCHMARK_EXPORT size_t RunSpecifiedBenchmarks(std::string spec);

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -585,12 +585,9 @@ ConsoleReporter::OutputOptions GetOutputOptions(bool force_no_color) {
 
 }  // end namespace internal
 
-BenchmarkReporter* CreateDefaultDisplayReporter() {
-  static auto* default_display_reporter =
-      internal::CreateReporter(FLAGS_benchmark_format,
-                               internal::GetOutputOptions())
-          .release();
-  return default_display_reporter;
+std::unique_ptr<BenchmarkReporter> CreateDefaultDisplayReporter() {
+  return internal::CreateReporter(FLAGS_benchmark_format,
+                                  internal::GetOutputOptions());
 }
 
 size_t RunSpecifiedBenchmarks() {
@@ -629,7 +626,7 @@ size_t RunSpecifiedBenchmarks(BenchmarkReporter* display_reporter,
   std::unique_ptr<BenchmarkReporter> default_display_reporter;
   std::unique_ptr<BenchmarkReporter> default_file_reporter;
   if (display_reporter == nullptr) {
-    default_display_reporter.reset(CreateDefaultDisplayReporter());
+    default_display_reporter = CreateDefaultDisplayReporter();
     display_reporter = default_display_reporter.get();
   }
   auto& Out = display_reporter->GetOutputStream();


### PR DESCRIPTION
Fixes #2240.

`CreateDefaultDisplayReporter()` transfers ownership of the returned reporter to
the caller, but cached that owning pointer in a function-local `static`. After
the first `RunSpecifiedBenchmarks()` call destroyed the reporter, a subsequent
call handed back the same, now-dangling pointer, causing a heap-use-after-free
in `BenchmarkReporter::GetOutputStream()`.

Per @dmah42's review, the ownership transfer is now expressed in the type: the
function returns `std::unique_ptr<BenchmarkReporter>` instead of a raw pointer,
and the `static` is gone, so every call returns a fresh reporter. With that
signature the old bug is unrepresentable, so no regression test is included.

### API change

This changes the signature of an exported function:

```diff
-BENCHMARK_EXPORT BenchmarkReporter* CreateDefaultDisplayReporter();
+BENCHMARK_EXPORT std::unique_ptr<BenchmarkReporter>
+CreateDefaultDisplayReporter();
```

Callers that stored the result in a raw pointer need `.get()`, and callers that
already wrapped it in a `unique_ptr` (which is what the old contract required)
simplify. The only in-tree caller is `RunSpecifiedBenchmarks()`. This is a
source-level break for external users, so it may be worth calling out in the
next release notes.

Release and Debug builds pass; test suite unchanged from `main`.

---

Per AGENTS.md: **AI-assisted** — the patch was drafted with AI assistance
(Claude) and then reviewed, tested, and understood by me. I take full
responsibility for it.
