### PR TITLE
Diagnose a non-growing RangeMultiplier in release builds (#1504)

### DIFF
--- a/src/benchmark_register.cc
+++ b/src/benchmark_register.cc
@@ -370,7 +370,9 @@ Benchmark* Benchmark::Teardown(const callback_function& teardown) {
 }
 
 Benchmark* Benchmark::RangeMultiplier(int multiplier) {
-  BM_CHECK(multiplier > 1);
+  // Checked in every build configuration: a multiplier of 1 or less makes the
+  // range generation in AddRange() unable to terminate.
+  BM_CHECK_RUNTIME(multiplier > 1);
   range_multiplier_ = multiplier;
   return this;
 }

--- a/src/benchmark_register.h
+++ b/src/benchmark_register.h
@@ -18,7 +18,9 @@ typename std::vector<T>::iterator AddPowers(std::vector<T>* dst, T lo, T hi,
                                             int mult) {
   BM_CHECK_GE(lo, 0);
   BM_CHECK_GE(hi, lo);
-  BM_CHECK_GE(mult, 2);
+  // Checked in every build configuration: a multiplier that does not grow the
+  // value never reaches `hi`, so the loop below would never terminate.
+  BM_CHECK_RUNTIME_GE(mult, 2);
 
   const size_t start_offset = dst->size();
 
@@ -63,7 +65,7 @@ void AddRange(std::vector<T>* dst, T lo, T hi, int mult) {
                 "Args type must be a signed integer");
 
   BM_CHECK_GE(hi, lo);
-  BM_CHECK_GE(mult, 2);
+  BM_CHECK_RUNTIME_GE(mult, 2);
 
   // Add "lo"
   dst->push_back(lo);

--- a/src/check.h
+++ b/src/check.h
@@ -79,21 +79,29 @@ class CheckHandler {
 }  // end namespace internal
 }  // end namespace benchmark
 
-// The BM_CHECK macro returns a std::ostream object that can have extra
-// information written to it.
-#ifndef NDEBUG
-#define BM_CHECK(b)                                          \
+// Checks the condition in every build configuration, NDEBUG included, and
+// aborts if it does not hold. Reserved for preconditions whose violation the
+// library cannot recover from or report later -- and only away from the
+// measured loop, since the check is never compiled out.
+#define BM_CHECK_RUNTIME(b)                                  \
   (b ? ::benchmark::internal::GetNullLogInstance()           \
      : ::benchmark::internal::CheckHandler(                  \
            std::string_view(#b), std::string_view(__FILE__), \
            std::string_view(__func__), __LINE__)             \
            .GetLog())
+
+// The BM_CHECK macro returns a std::ostream object that can have extra
+// information written to it.
+#ifndef NDEBUG
+#define BM_CHECK(b) BM_CHECK_RUNTIME(b)
 #else
 #define BM_CHECK(b) ::benchmark::internal::GetNullLogInstance()
 #endif
 
 // clang-format off
 // preserve whitespacing between operators for alignment
+#define BM_CHECK_RUNTIME_GE(a, b) BM_CHECK_RUNTIME((a) >= (b))
+
 #define BM_CHECK_EQ(a, b) BM_CHECK((a) == (b))
 #define BM_CHECK_NE(a, b) BM_CHECK((a) != (b))
 #define BM_CHECK_GE(a, b) BM_CHECK((a) >= (b))

--- a/test/benchmark_gtest.cc
+++ b/test/benchmark_gtest.cc
@@ -1,11 +1,18 @@
 #include <map>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 #include "../src/benchmark_register.h"
+#include "../src/check.h"
 #include "benchmark/benchmark_api.h"
+#include "benchmark/registration.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+#if defined(__GNUC__) && !defined(__EXCEPTIONS)
+#define TEST_HAS_NO_EXCEPTIONS
+#endif
 
 namespace benchmark {
 namespace internal {
@@ -149,6 +156,40 @@ TEST(AddCustomContext, Simple) {
   delete global_context;
   global_context = nullptr;
 }
+
+#ifndef TEST_HAS_NO_EXCEPTIONS
+// A range multiplier that does not grow the value used to spin forever in
+// release builds, where the BM_CHECK guarding it was compiled out.
+// See https://github.com/google/benchmark/issues/1504.
+class AbortsAsThrows : public ::testing::Test {
+ public:
+  void SetUp() override {
+    previous_handler_ = GetAbortHandler();
+    GetAbortHandler() = &ThrowingHandler;
+  }
+  void TearDown() override { GetAbortHandler() = previous_handler_; }
+
+ private:
+  [[noreturn]] static void ThrowingHandler() { throw std::logic_error(""); }
+
+  AbortHandlerT* previous_handler_ = nullptr;
+};
+
+TEST_F(AbortsAsThrows, AddRangeRejectsNonGrowingMultiplier) {
+  std::vector<int> dst;
+  EXPECT_THROW(AddRange(&dst, 1, 2, 1), std::logic_error);
+  EXPECT_THROW(AddRange(&dst, 1, 8, 0), std::logic_error);
+  EXPECT_THROW(AddRange(&dst, 1, 8, -2), std::logic_error);
+}
+
+TEST_F(AbortsAsThrows, RangeMultiplierRejectsNonGrowingMultiplier) {
+  Benchmark* b = RegisterBenchmarkInternal(std::unique_ptr<Benchmark>(
+      new FunctionBenchmark("BM_check", [](State&) {})));
+  EXPECT_THROW(b->RangeMultiplier(1), std::logic_error);
+  EXPECT_THROW(b->RangeMultiplier(0), std::logic_error);
+  ClearRegisteredBenchmarks();
+}
+#endif  // TEST_HAS_NO_EXCEPTIONS
 
 TEST(AddCustomContext, DuplicateKey) {
   std::map<std::string, std::string>*& global_context = GetGlobalContext();


### PR DESCRIPTION
RangeMultiplier(1) hangs the binary. The guards that reject it -- the `multiplier > 1` check in RangeMultiplier() and `mult >= 2` in AddRange() -- are BM_CHECKs, which compile away under NDEBUG, so in a release build the multiplier is accepted and AddPowers() then multiplies by one forever looking for a value that reaches `hi`. Debug builds abort with a clear message; release builds spin with no output at all.

Add BM_CHECK_RUNTIME (the name suggested in #1754), which is the existing BM_CHECK without the NDEBUG opt-out, and define BM_CHECK to it in debug builds so there is only one implementation. Use it for the two range multiplier preconditions.

These run once per BENCHMARK() registration, never inside the measured loop, so the concern about paying for checks in the critical path does not apply here. Nothing changes for debug builds, and release builds now abort with

  RangeMultiplier: Check `multiplier > 1' failed.

instead of hanging.

Covered by two new cases in benchmark_gtest that swap in an abort handler and assert both preconditions fire; the RangeMultiplier() one exercises the library as built, i.e. with NDEBUG.