### PR TITLE
fix(msvc): silence C4244 in AddPowers and complexity pow (#826)

### DIFF
--- a/src/benchmark_register.h
+++ b/src/benchmark_register.h
@@ -34,8 +34,7 @@ typename std::vector<T>::iterator AddPowers(std::vector<T>* dst, T lo, T hi,
     if (i > kmax / mult) break;
   }
 
-  return dst->begin() +
-         static_cast<typename std::vector<T>::difference_type>(start_offset);
+  return dst->begin() + start_offset;
 }
 
 template <typename T>

--- a/src/benchmark_register.h
+++ b/src/benchmark_register.h
@@ -34,7 +34,8 @@ typename std::vector<T>::iterator AddPowers(std::vector<T>* dst, T lo, T hi,
     if (i > kmax / mult) break;
   }
 
-  return dst->begin() + static_cast<int>(start_offset);
+  return dst->begin() +
+         static_cast<typename std::vector<T>::difference_type>(start_offset);
 }
 
 template <typename T>

--- a/src/complexity.cc
+++ b/src/complexity.cc
@@ -34,9 +34,13 @@ BigOFunc* FittingCurve(BigO complexity) {
     case oN:
       return [](IterationCount n) -> double { return static_cast<double>(n); };
     case oNSquared:
-      return [](IterationCount n) -> double { return std::pow(n, 2); };
+      return [](IterationCount n) -> double {
+        return std::pow(static_cast<double>(n), 2);
+      };
     case oNCubed:
-      return [](IterationCount n) -> double { return std::pow(n, 3); };
+      return [](IterationCount n) -> double {
+        return std::pow(static_cast<double>(n), 3);
+      };
     case oLogN:
       return [](IterationCount n) -> double {
         return std::log2(static_cast<double>(n));


### PR DESCRIPTION
## Summary

Fixes MSVC `/W4` warnings called out in #826:

- `AddPowers`: use `vector<T>::difference_type` instead of `static_cast<int>(size_t)` (C4244)
- `FittingCurve`: cast `IterationCount` to `double` before `std::pow` (C4244)

`CheckHandler` already suppresses C4722 locally in `check.h`.

Fixes #826.

## Test plan

- [x] Build with MSVC `/W4` on touched TUs
- [ ] Existing benchmark test suite
