### PR TITLE
Update Bazel tooling for Python bindings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,6 +73,7 @@ Shapr3D <google-contributors@shapr3d.com>
 Shashank Thakur <shashankt2004@gmail.com>
 Shuo Chen <chenshuo@chenshuo.com>
 Staffan Tjernstrom <staffantj@gmail.com>
+Stanley C. <stanbot8@gmail.com>
 Steinar H. Gunderson <sgunderson@bigfoot.com>
 Stripe, Inc.
 Tobias Schmidt <tobias.schmidt@in.tum.de>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -100,6 +100,7 @@ Shashank Thakur <shashankt2004@gmail.com>
 ShengYi Hung <aokblast@FreeBSD.org>
 Shuo Chen <chenshuo@chenshuo.com>
 Steven Wan <wan.yu@ibm.com>
+Stanley C. <stanbot8@gmail.com>
 Tobias Schmidt <tobias.schmidt@in.tum.de>
 Tobias Ulvgård <tobias.ulvgard@dirac.se>
 Tom Madams <tom.ej.madams@gmail.com> <tmadams@google.com>

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,11 +3,11 @@ module(
     version = "1.9.5",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.5")
 
-bazel_dep(name = "rules_python", version = "1.0.0", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "1.7.0", dev_dependency = True)
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True, repo_name = "com_google_googletest")
 
 bazel_dep(name = "libpfm", version = "4.11.0.bcr.1")
@@ -38,4 +38,4 @@ use_repo(pip, "tools_pip_deps")
 
 # -- bazel_dep definitions -- #
 
-bazel_dep(name = "nanobind_bazel", version = "2.9.2", dev_dependency = True)
+bazel_dep(name = "nanobind_bazel", version = "2.12.0", dev_dependency = True)

--- a/bindings/python/google_benchmark/BUILD
+++ b/bindings/python/google_benchmark/BUILD
@@ -18,7 +18,6 @@ nanobind_extension(
 
 nanobind_stubgen(
     name = "benchmark_stubgen",
-    marker_file = "bindings/python/google_benchmark/py.typed",
     module = ":_benchmark",
 )
 

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ class BuildBazelExtension(build_ext.build_ext):
         do again in the `build_ext` base class.
         """
 
-    def bazel_build(self, ext: BazelExtension) -> None:  # noqa: C901
+    def bazel_build(self, ext: BazelExtension) -> None:
         """Runs the bazel build to create the package."""
         temp_path = Path(self.build_temp)
 
@@ -143,17 +143,10 @@ class BuildBazelExtension(build_ext.build_ext):
 
             for f in files:
                 fp = Path(f)
-                should_copy = False
                 # we do not want the bare .so file included
                 # when building for ABI3, so we require a
                 # full and exact match on the file extension.
                 if "".join(fp.suffixes) == suffix or fp.suffix == ".pyi":
-                    should_copy = True
-                elif Path(root) == srcdir and f == "py.typed":
-                    # copy py.typed, but only at the package root.
-                    should_copy = True
-
-                if should_copy:
                     shutil.copyfile(root / fp, libdir / fp)
 
 


### PR DESCRIPTION
Update the Python binding's Bazel modules, toolchain, and packaging.
- The Python binding build pinned `bazel_skylib`, `platforms`, `rules_cc`, `rules_python`, and `nanobind_bazel` to releases that predated its supported Bazel and Python toolchain. Update all five modules to releases compatible with that toolchain. `MODULE.bazel`: `6-8, 10, 41`
- The binding build routed `py.typed` through Bazel stub generation, carried a dedicated copy branch for it, and suppressed the resulting `bazel_build` complexity warning. Keep `py.typed` in the source package, remove it from stub generation, copy only the extension and generated stub, and remove the obsolete `C901` suppression. `bindings/python/google_benchmark/BUILD`: `21`, `setup.py`: `91, 146, 151-156`

#### AI Disclosure
Codex (OpenAI) separated these changes from my monolith and reviewed the draft before I submitted it.